### PR TITLE
Optional extent element on indentificationInfo

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -335,20 +335,21 @@ class MD_DataIdentification(object):
         extent = md.find(util.nspath_eval('gmd:extent', namespaces))
         if extent is None:
             extent = md.find(util.nspath_eval('srv:extent', namespaces))
+        
+        if extent is not None:
+            for e in extent.findall(util.nspath_eval('gmd:EX_Extent/gmd:geographicElement', namespaces)):
+                if e.find(util.nspath_eval('gmd:EX_GeographicBoundingBox', namespaces)) is not None or e.find(util.nspath_eval('gmd:EX_BoundingPolygon', namespaces)) is not None:
+                    val = e
+                    break
+            self.extent = EX_Extent(val)
+            self.bbox = self.extent.boundingBox  # for backwards compatibility
 
-        for e in extent.findall(util.nspath_eval('gmd:EX_Extent/gmd:geographicElement', namespaces)):
-            if e.find(util.nspath_eval('gmd:EX_GeographicBoundingBox', namespaces)) is not None or e.find(util.nspath_eval('gmd:EX_BoundingPolygon', namespaces)) is not None:
-                val = e
-                break
-        self.extent = EX_Extent(val)
-        self.bbox = self.extent.boundingBox  # for backwards compatibility
-        
-        val = md.find(util.nspath_eval('gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition', namespaces))
-        self.temporalextent_start = util.testXMLValue(val)
-        
-        self.temporalextent_end = []
-        val = md.find(util.nspath_eval('gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition', namespaces))
-        self.temporalextent_end = util.testXMLValue(val)
+            val = extent.find(util.nspath_eval('gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition', namespaces))
+            self.temporalextent_start = util.testXMLValue(val)
+
+            self.temporalextent_end = []
+            val = extent.find(util.nspath_eval('gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition', namespaces))
+            self.temporalextent_end = util.testXMLValue(val)
 
 class MD_Distributor(object):        
     """ process MD_Distributor """


### PR DESCRIPTION
NB: My understanding of ISO subtleties is limited, so feel free to ignore this if not correct

Parsing this particular document I found the following exception.

<pre><code>
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/owslib/owslib/iso.py", line 111, in __init__
    self.identificationinfo.append(MD_DataIdentification(val, 'dataset'))
  File "[...]/owslib/owslib/iso.py", line 339, in __init__
    if extent == None:
AttributeError: 'NoneType' object has no attribute 'findall'
</code></pre>


The file parsed is this document. Note that there are two md:identificationInfo elements, one of which does not have an extent:

http://web.apps.state.nd.us/hubdataportal/srv/en/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetRecordById&ID=f9c45457-e63f-4499-888c-05fd960d4378&outputSchema=http://www.isotc211.org/2005/gmd

If understand correctly the ISO spec document (6.3.2.2), the extent elements are optional, so my patch if there is any extent before trying to do more stuff with it. 

Also since 077054 'srv:extent' is also used to get the extent element, but the paths used for the getting temporal extent were not taking this into account.

I'm not sure if self.extent, self.temporalextent_start, etc. should still be set to None if the extent is missing.

Hope all makes sense.
