### PR TITLE
fix error on val.text.strip() with empty Element

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -144,8 +144,10 @@ def testXMLValue(val, attrib=False):
     if val is not None:
         if attrib == True:
             return val.strip()
-        else:
+        elif val.text:  
             return val.text.strip()
+        else:
+            return None	
     else:
         return None
 


### PR DESCRIPTION
proposal of fix for https://github.com/geopython/OWSLib/issues/44
