### PR TITLE
Very minor typo in MD_Metadata

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -45,7 +45,7 @@ class MD_Metadata(object):
         val = md.find(util.nspath_eval('gmd:language/gco:CharacterString', namespaces))
         self.language = util.testXMLValue(val)
         
-        val = md.find(util.nspath_eval('gmd:datasetURI/gco:CharacterString', namespaces))
+        val = md.find(util.nspath_eval('gmd:dataSetURI/gco:CharacterString', namespaces))
         self.dataseturi = util.testXMLValue(val)
 
         val = md.find(util.nspath_eval('gmd:language/gmd:LanguageCode', namespaces))


### PR DESCRIPTION
According to http://schemas.opengis.net/iso/19139/20060504/gmd/metadataEntity.xsd it should be "dataSetURI" instead of "datasetURI".

Maybe it isn't even case-sensitive. Just noticed....
