### PR TITLE
Removed pytz from requirements.txt and added pytz>=2013b to setup.py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python-dateutil==1.5
-pytz
 pytest
 pytest-cov
 PIL

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ class PyTest(TestCommand):
 
 readme = open('README.txt').read()
 reqs = [line.strip() for line in open('requirements.txt')]
+reqs.append('pytz>=2013d')
 
 setup(name              = 'OWSLib',
       version           = owslib.__version__,


### PR DESCRIPTION
This will enable OWSLib to be installed with pip 1.4+ without resorting
to the '--pre' flag
