### PR TITLE
Fixed bug with 'Content-Type' in openURL.

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -159,7 +159,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         else:
             raise e
     # check for service exceptions without the http header set
-    if if ((u.info().has_key('Content-Type')) and (u.info()['Content-Type'] in ['text/xml', 'application/xml'])):          
+    if ((u.info().has_key('Content-Type')) and (u.info()['Content-Type'] in ['text/xml', 'application/xml'])):          
         #just in case 400 headers were not set, going to have to read the xml to see if it's an exception report.
         #wrap the url stram in a extended StringIO object so it's re-readable
         u=RereadableURL(u)      


### PR DESCRIPTION
This condition was generating an exception when the 'Content-Type' key was not present.
