### PR TITLE
Fix error detection when GetCapabilities is an ExceptionReport

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -53,9 +53,8 @@ class SensorObservationService_1_0_0(object):
             self._capabilities = reader.read(self.url)
 
         # Avoid building metadata if the response is an Exception
-        se = self._capabilities.find(nspath_eval('ows:ExceptionReport', namespaces))
-        if se is not None: 
-            raise ows.ExceptionReport(se) 
+        if self._capabilities.tag == nspath_eval("ows:ExceptionReport", namespaces):
+            raise ows.ExceptionReport(self._capabilities)
 
         # build metadata objects
         self._build_metadata()


### PR DESCRIPTION
This syncs the behavior with that of DescribeSensor requests (see https://github.com/asascience-open/OWSLib/blob/dd2b6c643c9f17e869623079740e3a0f098e38fe/owslib/swe/observation/sos100.py#L119-L120)

When a GetCapabilities request returned an ExceptionReport, it wasn't properly being detected and would result in an AttributeError down the line.
