### PR TITLE
Add timeout to urlopen calls

### DIFF
--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -114,7 +114,7 @@ class WCSCapabilitiesReader(object):
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs
 
-    def read(self, service_url):
+    def read(self, service_url, timeout=30):
         """Get and parse a WCS capabilities document, returning an
         elementtree tree
 
@@ -128,7 +128,7 @@ class WCSCapabilitiesReader(object):
         req = Request(request)
         if self.cookies is not None:
             req.add_header('Cookie', self.cookies)   
-        u = urlopen(req)
+        u = urlopen(req, timeout=timeout)
         return etree.fromstring(u.read())
     
     def readString(self, st):
@@ -187,7 +187,7 @@ class DescribeCoverageReader(object):
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs
 
-    def read(self, service_url):
+    def read(self, service_url, timeout=30):
         """Get and parse a Describe Coverage document, returning an
         elementtree tree
 
@@ -201,7 +201,7 @@ class DescribeCoverageReader(object):
         req = Request(request)
         if self.cookies is not None:
             req.add_header('Cookie', self.cookies)   
-        u = urlopen(req)
+        u = urlopen(req, timeout=timeout)
         return etree.fromstring(u.read())
     
        

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -120,12 +120,12 @@ class WebFeatureService_1_0_0(object):
         self.exceptions = [f.text for f \
                 in self._capabilities.findall('Capability/Exception/Format')]
       
-    def getcapabilities(self):
+    def getcapabilities(self, timeout=30):
         """Request and return capabilities document from the WFS as a 
         file-like object.
         NOTE: this is effectively redundant now"""
         reader = WFSCapabilitiesReader(self.version)
-        return urlopen(reader.capabilities_url(self.url))
+        return urlopen(reader.capabilities_url(self.url), timeout=timeout)
     
     def items(self):
         '''supports dict-like items() access'''
@@ -251,7 +251,7 @@ class ContentMetadata:
     Implements IMetadata.
     """
 
-    def __init__(self, elem, parent, parse_remote_metadata=False):
+    def __init__(self, elem, parent, parse_remote_metadata=False, timeout=30):
         """."""
         self.id = testXMLValue(elem.find(nspath('Name')))
         self.title = testXMLValue(elem.find(nspath('Title')))
@@ -298,7 +298,7 @@ class ContentMetadata:
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urlopen(metadataUrl['url'])
+                    content = urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     if metadataUrl['type'] is not None:
                         if metadataUrl['type'] == 'FGDC':
@@ -355,7 +355,7 @@ class WFSCapabilitiesReader(object):
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs
 
-    def read(self, url):
+    def read(self, url, timeout=30):
         """Get and parse a WFS capabilities document, returning an
         instance of WFSCapabilitiesInfoset
 
@@ -363,9 +363,11 @@ class WFSCapabilitiesReader(object):
         ----------
         url : string
             The URL to the WFS capabilities document.
+        timeout : number
+            A timeout value (in seconds) for the request.
         """
         request = self.capabilities_url(url)
-        u = urlopen(request)
+        u = urlopen(request, timeout=timeout)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -102,12 +102,12 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         self.exceptions = [f.text for f \
                 in self._capabilities.findall('Capability/Exception/Format')]
       
-    def getcapabilities(self):
+    def getcapabilities(self, timeout=30):
         """Request and return capabilities document from the WFS as a 
         file-like object.
         NOTE: this is effectively redundant now"""
         reader = WFSCapabilitiesReader(self.version)
-        return urlopen(reader.capabilities_url(self.url))
+        return urlopen(reader.capabilities_url(self.url), timeout=timeout)
     
     def items(self):
         '''supports dict-like items() access'''
@@ -238,7 +238,7 @@ class ContentMetadata:
     Implements IMetadata.
     """
 
-    def __init__(self, elem, parse_remote_metadata=False):
+    def __init__(self, elem, parse_remote_metadata=False, timeout=30):
         """."""
         self.id = testXMLValue(elem.find(nspath_eval('wfs:Name', namespaces)))
         self.title = testXMLValue(elem.find(nspath_eval('wfs:Title', namespaces)))
@@ -276,7 +276,7 @@ class ContentMetadata:
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urlopen(metadataUrl['url'])
+                    content = urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     if metadataUrl['type'] is not None:
                         if metadataUrl['type'] == 'FGDC':
@@ -321,7 +321,7 @@ class WFSCapabilitiesReader(object):
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs
 
-    def read(self, url):
+    def read(self, url, timeout=30):
         """Get and parse a WFS capabilities document, returning an
         instance of WFSCapabilitiesInfoset
 
@@ -329,9 +329,11 @@ class WFSCapabilitiesReader(object):
         ----------
         url : string
             The URL to the WFS capabilities document.
+        timeout : number
+            A timeout value (in seconds) for the request.
         """
         request = self.capabilities_url(url)
-        u = urlopen(request)
+        u = urlopen(request, timeout=timeout)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -133,12 +133,12 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         self.exceptions = [f.text for f \
                 in self._capabilities.findall('Capability/Exception/Format')]
       
-    def getcapabilities(self):
+    def getcapabilities(self, timeout=30):
         """Request and return capabilities document from the WFS as a 
         file-like object.
         NOTE: this is effectively redundant now"""
         reader = WFSCapabilitiesReader(self.version)
-        return urlopen(reader.capabilities_url(self.url))
+        return urlopen(reader.capabilities_url(self.url), timeout=timeout)
     
     def items(self):
         '''supports dict-like items() access'''
@@ -149,7 +149,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
     
     def getfeature(self, typename=None, filter=None, bbox=None, featureid=None,
                    featureversion=None, propertyname=None, maxfeatures=None,storedQueryID=None, storedQueryParams={},
-                   method='Get'):
+                   method='Get', timeout=30):
         """Request and return feature data as a file-like object.
         #TODO: NOTE: have changed property name from ['*'] to None - check the use of this in WFS 2.0
         Parameters
@@ -170,6 +170,8 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             Maximum number of features to be returned.
         method : string
             Qualified name of the HTTP DCP method to use.
+        timeout : number
+            A timeout value (in seconds) for the request.
 
         There are 3 different modes of use
 
@@ -189,11 +191,8 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             (url,data) = self.getPOSTGetFeatureRequest()
 
 
-
-        if method == 'Post':
-            u = urlopen(base_url, data=data)
-        else:
-            u = urlopen(url)
+        # If method is 'Post', data will be None here
+        u = urlopen(url, data, timeout)
         
         # check for service exceptions, rewrap, and return
         # We're going to assume that anything with a content-length > 32k
@@ -236,12 +235,12 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         if kwargs:
             for kw in kwargs.keys():
                 request[kw]=str(kwargs[kw])
-        data=urlencode(request)
-        u = urlopen(base_url + data)
+        encoded_request=urlencode(request)
+        u = urlopen(base_url + encoded_request)
         return u.read()
         
         
-    def _getStoredQueries(self):
+    def _getStoredQueries(self, timeout=30):
         ''' gets descriptions of the stored queries available on the server '''
         sqs=[]
         #This method makes two calls to the WFS - one ListStoredQueries, and one DescribeStoredQueries. The information is then
@@ -251,8 +250,8 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         #first make the ListStoredQueries response and save the results in a dictionary if form {storedqueryid:(title, returnfeaturetype)}
         base_url = self.getOperationByName('ListStoredQueries').methods[method]['url']
         request = {'service': 'WFS', 'version': self.version, 'request': 'ListStoredQueries'}
-        data = urlencode(request)
-        u = urlopen(base_url + data)
+        encoded_request = urlencode(request)
+        u = urlopen(base_url + encoded_request, timeout=timeout)
         tree=etree.fromstring(u.read())
         base_url = self.getOperationByName('ListStoredQueries').methods[method]['url']
         tempdict={}       
@@ -269,8 +268,8 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         #then make the DescribeStoredQueries request and get the rest of the information about the stored queries 
         base_url = self.getOperationByName('DescribeStoredQueries').methods[method]['url']
         request = {'service': 'WFS', 'version': self.version, 'request': 'DescribeStoredQueries'}
-        data = urlencode(request)
-        u = urlopen(base_url + data)
+        encoded_request = urlencode(request)
+        u = urlopen(base_url + encoded_request, timeout=timeout)
         tree=etree.fromstring(u.read())
         tempdict2={} 
         for sqelem in tree[:]:
@@ -320,7 +319,7 @@ class ContentMetadata:
     Implements IMetadata.
     """
 
-    def __init__(self, elem, parent, parse_remote_metadata=False):
+    def __init__(self, elem, parent, parse_remote_metadata=False, timeout=30):
         """."""
         self.id = elem.find(nspath('Name',ns=WFS_NAMESPACE)).text
         self.title = elem.find(nspath('Title',ns=WFS_NAMESPACE)).text
@@ -378,7 +377,7 @@ class ContentMetadata:
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urllib2.urlopen(metadataUrl['url'])
+                    content = urllib2.urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     try:  # FGDC
                         metadataUrl['metadata'] = Metadata(doc)
@@ -418,7 +417,7 @@ class WFSCapabilitiesReader(object):
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs
 
-    def read(self, url):
+    def read(self, url, timeout=30):
         """Get and parse a WFS capabilities document, returning an
         instance of WFSCapabilitiesInfoset
 
@@ -426,9 +425,11 @@ class WFSCapabilitiesReader(object):
         ----------
         url : string
             The URL to the WFS capabilities document.
+        timeout : number
+            A timeout value (in seconds) for the request.
         """
         request = self.capabilities_url(url)
-        u = urlopen(request)
+        u = urlopen(request, timeout=timeout)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -18,7 +18,7 @@ import urllib2
 import etree
 from coverage import wcs100, wcs110, wcsBase
 
-def WebCoverageService(url, version=None, xml=None, cookies=None):
+def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
     ''' wcs factory function, returns a version specific WebCoverageService object '''
     
     if version is None:
@@ -26,11 +26,11 @@ def WebCoverageService(url, version=None, xml=None, cookies=None):
             reader = wcsBase.WCSCapabilitiesReader()
             request = reader.capabilities_url(url)
             if cookies is None:
-                xml = urllib2.urlopen(request).read()
+                xml = urllib2.urlopen(request, timeout=timeout).read()
             else:
                 req = urllib2.Request(request)
                 req.add_header('Cookie', cookies)   
-                xml=urllib2.urlopen(req)
+                xml=urllib2.urlopen(req, timeout=timeout)
         capabilities = etree.etree.fromstring(xml)
         version = capabilities.get('version')
         del capabilities

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -312,7 +312,7 @@ class ContentMetadata:
 
     Implements IContentMetadata.
     """
-    def __init__(self, elem, parent=None, index=0, parse_remote_metadata=False):
+    def __init__(self, elem, parent=None, index=0, parse_remote_metadata=False, timeout=30):
         if elem.tag != 'Layer':
             raise ValueError('%s should be a Layer' % (elem,))
         
@@ -474,7 +474,7 @@ class ContentMetadata:
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urllib2.urlopen(metadataUrl['url'])
+                    content = urllib2.urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     if metadataUrl['type'] is not None:
                         if metadataUrl['type'] == 'FGDC':


### PR DESCRIPTION
Occasionally, a WxS server will be unresponsive, and can cause urlopen to hang.  For example, wms.jpl.nasa.gov/wms.cgi?service=WFS&request=GetCapabilities&version=1.0.0 never returns (at least not this week!)  The urlopen function can take a timeout parameter, so in almost every place where this is called, I added a timeout, which can be passed into the calling function, and defaults to 30 seconds.

The one place I did not make this change was in wfs200.py :: getpropertyvalue() because I could see no good way to pass a timeout to that function without breaking the signature for existing functions.

I am not positive this is the best solution, but it totally fixed the hanging issues I was experiencing.
