### PR TITLE
Don't install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name              = 'OWSLib',
       url               = 'https://geopython.github.io/OWSLib',
       install_requires  = reqs,
       cmdclass          = {'test': PyTest},
-      packages          = find_packages(),
+      packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
       classifiers       = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The OWSLib package, when installed from pypi installs a directory tests. This is due to the find_packages in setup.py, which also find the tests directory. Because the tests directory includes an **init**.py, find_packages thinks tests is also a package and installs it. By excluding the tests directory from the find_packages, it is no longer installed. 
I also added the other directories that are probably not meant to be packages.
