### PR TITLE
Code style with autopep8 and initial steps for python 3 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.append(os.path.abspath('.'))
+# sys.path.append(os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -174,8 +175,8 @@ htmlhelp_basename = 'OWSLibdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'OWSLib.tex', u'OWSLib Documentation',
-   u'Tom Kralidis', 'manual'),
+    ('index', 'OWSLib.tex', u'OWSLib Documentation',
+     u'Tom Kralidis', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'OWSLib'
-copyright = u'2010, Tom Kralidis'
+project = 'OWSLib'
+copyright = '2010, Tom Kralidis'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -175,8 +175,8 @@ htmlhelp_basename = 'OWSLibdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'OWSLib.tex', u'OWSLib Documentation',
-     u'Tom Kralidis', 'manual'),
+    ('index', 'OWSLib.tex', 'OWSLib Documentation',
+     'Tom Kralidis', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -284,7 +284,7 @@ Transaction: insert
 
 .. code-block:: python
 
-  >>> csw.transaction(ttype='insert', typename='gmd:MD_Metadata', record=open(file.xml).read())
+  >>> csw.transaction(ttype='insert', typename='gmd:MD_Metadata', record=open(file.xml, 'rb').read())
 
 Transaction: update
 
@@ -491,7 +491,7 @@ You can also submit a pre-made request encoded as WPS XML:
 
 .. code-block:: python
 
-	>>> request = open('/Users/cinquini/Documents/workspace-cog/wps/tests/resources/wps_USGSExecuteRequest1.xml','r').read()
+	>>> request = open('/Users/cinquini/Documents/workspace-cog/wps/tests/resources/wps_USGSExecuteRequest1.xml', 'rb').read()
 	>>> execution = wps.execute(None, [], request=request)
 	Executing WPS request...
 	Execution status=ProcessStarted

--- a/examples/csw-client.py
+++ b/examples/csw-client.py
@@ -16,7 +16,7 @@ from owslib.util import xmlvalid
 
 
 def usage():
-    print("""
+    print('''
     %s [options]
 
 Required Parameters
@@ -54,7 +54,7 @@ GetRecords
 GetRecordById
     --id=[ID] the ID of the record
 
-""" % sys.argv[0])
+''' % sys.argv[0])
 
 # check args
 if len(sys.argv) == 1:

--- a/examples/csw-client.py
+++ b/examples/csw-client.py
@@ -64,7 +64,7 @@ if len(sys.argv) == 1:
 try:
     opts, args = getopt.getopt(sys.argv[1:], '', ['typename=', 'request=', 'lang=', 'version', 'keyword=', 'bbox=', 'schema=', 'qtype=', 'esn=', 'url=', 'print-request', 'sortby=', 'id=', 'dtype=', 'dname=', 'validate'])
 except getopt.GetoptError as err:
-    print(str(err))
+    print(err)
     usage()
     sys.exit(2)
 

--- a/examples/csw-client.py
+++ b/examples/csw-client.py
@@ -15,7 +15,7 @@ from owslib.csw import CatalogueServiceWeb
 
 
 def usage():
-    print """
+    print("""
     %s [options]
 
 Required Parameters
@@ -53,7 +53,7 @@ GetRecords
 GetRecordById
     --id=[ID] the ID of the record
 
-""" % sys.argv[0]
+""" % sys.argv[0])
 
 # check args
 if len(sys.argv) == 1:
@@ -62,8 +62,8 @@ if len(sys.argv) == 1:
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], '', ['typename=', 'request=', 'lang=', 'version', 'keyword=', 'bbox=', 'schema=', 'qtype=', 'esn=', 'url=', 'print-request', 'sortby=', 'id=', 'dtype=', 'dname=', 'validate'])
-except getopt.GetoptError, err:
-    print str(err)
+except getopt.GetoptError as err:
+    print(str(err))
     usage()
     sys.exit(2)
 
@@ -143,14 +143,14 @@ elif request == 'GetRecords':
     c.getrecords(qtype, [keyword], bbox, esn, sortby, schema)
 
 if print_request is True:  # print the request
-    print c.request
+    print(c.request)
 
 if validate is True:  # do XML validation
-    print 'Validating request XML'
+    print('Validating request XML')
     if util.xmlvalid(c.request, csw.schema_location.split()[1]) is True:
-        print 'request is valid XML'
+        print('request is valid XML')
     else:
-        print 'request is NOT valid XML'
+        print('request is NOT valid XML')
 
 # print response
-print c.response
+print(c.response)

--- a/examples/csw-client.py
+++ b/examples/csw-client.py
@@ -13,6 +13,7 @@ import getopt
 
 from owslib.csw import CatalogueServiceWeb
 
+
 def usage():
     print """
     %s [options]
@@ -35,7 +36,7 @@ Request Specific Parameters
 ---------------------------
 
 DescribeRecord
-    --typename=[TypeName] the typename to describe 
+    --typename=[TypeName] the typename to describe
 
 GetDomain
     --dname=[NAME] the domain to query
@@ -108,7 +109,7 @@ for o, a in opts:
     elif o in '--dname':
         dname = a
     elif o in '--dtype':
-        dtype= a
+        dtype = a
     elif o in '--version':
         version = a
     elif o in '--lang':
@@ -125,7 +126,7 @@ if request is None or url is None:
     sys.exit(3)
 
 if schema == 'iso':
-  outputschema = 'http://www.isotc211.org/2005/gmd'
+    outputschema = 'http://www.isotc211.org/2005/gmd'
 
 # init
 c = CatalogueServiceWeb(url, lang, version)
@@ -141,10 +142,10 @@ elif request == 'GetDomain':
 elif request == 'GetRecords':
     c.getrecords(qtype, [keyword], bbox, esn, sortby, schema)
 
-if print_request is True: # print the request
+if print_request is True:  # print the request
     print c.request
 
-if validate is True: # do XML validation
+if validate is True:  # do XML validation
     print 'Validating request XML'
     if util.xmlvalid(c.request, csw.schema_location.split()[1]) is True:
         print 'request is valid XML'
@@ -153,4 +154,3 @@ if validate is True: # do XML validation
 
 # print response
 print c.response
-

--- a/examples/csw-client.py
+++ b/examples/csw-client.py
@@ -11,7 +11,8 @@
 import sys
 import getopt
 
-from owslib.csw import CatalogueServiceWeb
+from owslib.csw import CatalogueServiceWeb, schema_location
+from owslib.util import xmlvalid
 
 
 def usage():
@@ -147,7 +148,7 @@ if print_request is True:  # print the request
 
 if validate is True:  # do XML validation
     print('Validating request XML')
-    if util.xmlvalid(c.request, csw.schema_location.split()[1]) is True:
+    if xmlvalid(c.request, schema_location.split()[1]) is True:
         print('request is valid XML')
     else:
         print('request is NOT valid XML')

--- a/examples/csw-harvest.py
+++ b/examples/csw-harvest.py
@@ -11,7 +11,9 @@
 # simple process to harvest CSW catalogues via Harvest operations
 
 import sys
+
 from owslib.csw import CatalogueServiceWeb
+
 
 stop = 0
 flag = 0

--- a/examples/csw-harvest.py
+++ b/examples/csw-harvest.py
@@ -39,8 +39,8 @@ while stop == 0:
     print src.results
 
     if src.results['nextrecord'] == 0 \
-        or src.results['returned'] == 0 \
-        or src.results['nextrecord'] > src.results['matches']:  # end the loop, exhausted all records
+            or src.results['returned'] == 0 \
+            or src.results['nextrecord'] > src.results['matches']:  # end the loop, exhausted all records
         stop = 1
         break
 
@@ -48,9 +48,9 @@ while stop == 0:
     for i in list(src.records):
         source = '%s?service=CSW&version=2.0.2&request=GetRecordById&id=%s' % \
             (sys.argv[1], i)
-        dest.harvest(source=source, \
-            resourcetype='http://www.isotc211.org/2005/gmd')
-        #print dest.request
-        #print dest.response
+        dest.harvest(source=source,
+                     resourcetype='http://www.isotc211.org/2005/gmd')
+        # print dest.request
+        # print dest.response
 
     flag = 1

--- a/examples/csw-harvest.py
+++ b/examples/csw-harvest.py
@@ -18,8 +18,8 @@ flag = 0
 maxrecords = 10
 
 if len(sys.argv) < 3:
-    print 'Usage: %s <source_catalogue_url> <destination_catalogue_url> [maxrecords]' \
-        % sys.argv[0]
+    print('Usage: %s <source_catalogue_url> <destination_catalogue_url> [maxrecords]'
+          % sys.argv[0])
     sys.exit(1)
 
 src = CatalogueServiceWeb(sys.argv[1])
@@ -36,7 +36,7 @@ while stop == 0:
 
     src.getrecords(esn='brief', startposition=startposition, maxrecords=maxrecords)
 
-    print src.results
+    print(src.results)
 
     if src.results['nextrecord'] == 0 \
             or src.results['returned'] == 0 \

--- a/examples/iso-getcodelist.py
+++ b/examples/iso-getcodelist.py
@@ -11,10 +11,10 @@
 # get a list of entries for a given code list dictionary
 
 import sys
-import urllib2
 
 from owslib.etree import etree
 from owslib.iso import CodelistCatalogue
+
 
 if len(sys.argv) < 3:
     print('Usage: %s <path/to/gmxCodelists.xml> <CodeListDictionary>' % sys.argv[0])

--- a/examples/iso-getcodelist.py
+++ b/examples/iso-getcodelist.py
@@ -20,13 +20,14 @@ if len(sys.argv) < 3:
     print 'Usage: %s <path/to/gmxCodelists.xml> <CodeListDictionary>' % sys.argv[0]
     sys.exit(1)
 
-e=etree.parse(sys.argv[1])
-c=CodelistCatalogue(e)
+e = etree.parse(sys.argv[1])
+c = CodelistCatalogue(e)
 
 clds = c.getcodelistdictionaries()
 
+
 def valid_clds():
-    return  '''
+    return '''
 Valid code list dictionaries are:
 
 %s
@@ -46,7 +47,7 @@ if cld is None:
     print '''
 Invalid code list dictionary: %s
 %s
-''' % (sys.argv[2],valid_clds())
+''' % (sys.argv[2], valid_clds())
     sys.exit(2)
 
 print '''
@@ -57,4 +58,4 @@ codeEntry's:
 
  %s
 
-''' % (sys.argv[2],'\n '.join(cld))
+''' % (sys.argv[2], '\n '.join(cld))

--- a/examples/iso-getcodelist.py
+++ b/examples/iso-getcodelist.py
@@ -17,7 +17,7 @@ from owslib.etree import etree
 from owslib.iso import CodelistCatalogue
 
 if len(sys.argv) < 3:
-    print 'Usage: %s <path/to/gmxCodelists.xml> <CodeListDictionary>' % sys.argv[0]
+    print('Usage: %s <path/to/gmxCodelists.xml> <CodeListDictionary>' % sys.argv[0])
     sys.exit(1)
 
 e = etree.parse(sys.argv[1])
@@ -35,22 +35,22 @@ Valid code list dictionaries are:
 
 
 if len(sys.argv) < 2:
-    print '''
+    print('''
 Usage: %s <codelistdictionary>
 %s
-''' % (sys.argv[0], valid_clds())
+''' % (sys.argv[0], valid_clds()))
     sys.exit(1)
 
 cld = c.getcodedefinitionidentifiers(sys.argv[2])
 
 if cld is None:
-    print '''
+    print('''
 Invalid code list dictionary: %s
 %s
-''' % (sys.argv[2], valid_clds())
+''' % (sys.argv[2], valid_clds()))
     sys.exit(2)
 
-print '''
+print('''
 
 CodeListDictionary: %s
 
@@ -58,4 +58,4 @@ codeEntry's:
 
  %s
 
-''' % (sys.argv[2], '\n '.join(cld))
+''' % (sys.argv[2], '\n '.join(cld)))

--- a/examples/wcs-thredds-prism.py
+++ b/examples/wcs-thredds-prism.py
@@ -1,29 +1,29 @@
 # Very simple script demonstrating how to interact with a THREDDS based WCS.
 # ---
 #
-# The GetCapabilities and DescribeCoverage requests for this dataset are: 
+# The GetCapabilities and DescribeCoverage requests for this dataset are:
 # http://cida.usgs.gov/thredds/wcs/prism?service=WCS&version=1.0.0&request=GetCapabilities
 # http://cida.usgs.gov/thredds/wcs/prism?service=WCS&version=1.0.0&request=DescribeCoverage
 #
 # The equivalent GetCoverage request that is equivalent ot hte example is:
 # http://cida.usgs.gov/thredds/wcs/prism?request=GetCoverage&version=1.0.0&service=WCS&format=GeoTIFF&coverage=tmx&time=1895-01-01T00:00:00Z&bbox=-90,40,-89,41
 # ---
-# 
+#
 # Example to find the equivalent information using OWSLib:
-# 
+#
 from owslib.wcs import WebCoverageService
-wcs=WebCoverageService('http://cida.usgs.gov/thredds/wcs/prism',version='1.0.0')
+wcs = WebCoverageService('http://cida.usgs.gov/thredds/wcs/prism', version='1.0.0')
 # Take a look at the contents (coverages) of the wcs.
 print wcs.contents
-tmax=wcs['tmx']
+tmax = wcs['tmx']
 # Take a look at the attributes of the coverage
 dir(tmax)
 print tmax.boundingBoxWGS84
 print tmax.timepositions
 print tmax.supportedFormats
 # mock up a simple GetCoverage request.
-output=wcs.getCoverage(identifier='tmx',time=['1895-01-01T00:00:00Z'],bbox=(-90,40,-89,41),format='GeoTIFF')
+output = wcs.getCoverage(identifier='tmx', time=['1895-01-01T00:00:00Z'], bbox=(-90, 40, -89, 41), format='GeoTIFF')
 # Write the file out to disk.
-f=open('foo.tif','wb')
+f = open('foo.tif', 'wb')
 f.write(output.read())
 f.close()

--- a/examples/wcs-thredds-prism.py
+++ b/examples/wcs-thredds-prism.py
@@ -14,13 +14,13 @@
 from owslib.wcs import WebCoverageService
 wcs = WebCoverageService('http://cida.usgs.gov/thredds/wcs/prism', version='1.0.0')
 # Take a look at the contents (coverages) of the wcs.
-print wcs.contents
+print(wcs.contents)
 tmax = wcs['tmx']
 # Take a look at the attributes of the coverage
 dir(tmax)
-print tmax.boundingBoxWGS84
-print tmax.timepositions
-print tmax.supportedFormats
+print(tmax.boundingBoxWGS84)
+print(tmax.timepositions)
+print(tmax.supportedFormats)
 # mock up a simple GetCoverage request.
 output = wcs.getCoverage(identifier='tmx', time=['1895-01-01T00:00:00Z'], bbox=(-90, 40, -89, 41), format='GeoTIFF')
 # Write the file out to disk.

--- a/examples/wcs-thredds-prism.py
+++ b/examples/wcs-thredds-prism.py
@@ -11,7 +11,10 @@
 #
 # Example to find the equivalent information using OWSLib:
 #
+
 from owslib.wcs import WebCoverageService
+
+
 wcs = WebCoverageService('http://cida.usgs.gov/thredds/wcs/prism', version='1.0.0')
 # Take a look at the contents (coverages) of the wcs.
 print(wcs.contents)

--- a/examples/wps-ceda-script.py
+++ b/examples/wps-ceda-script.py
@@ -17,7 +17,7 @@ for operation in wps.operations:
     print 'WPS Operation: %s' % operation.name
 for process in wps.processes:
     print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
-    
+
 # 2) DescribeProcess
 # GET request: http://ceda-wps2.badc.rl.ac.uk/wps?identifier=DoubleIt&version=1.0.0&request=DescribeProcess&service=WPS
 process = wps.describeprocess('DoubleIt')
@@ -39,4 +39,4 @@ for output in process.processOutputs:
 #output = "OutputXML"
 #execution = wps.execute(processid, inputs, output)
 
-#monitorExecution(execution)
+# monitorExecution(execution)

--- a/examples/wps-ceda-script.py
+++ b/examples/wps-ceda-script.py
@@ -10,25 +10,25 @@ wps = WebProcessingService('http://ceda-wps2.badc.rl.ac.uk/wps', verbose=verbose
 # GET request: http://ceda-wps2.badc.rl.ac.uk/wps?Service=WPS&Request=GetCapabilities&Format=text/xml
 wps.getcapabilities()
 
-print 'WPS Identification type: %s' % wps.identification.type
-print 'WPS Identification title: %s' % wps.identification.title
-print 'WPS Identification abstract: %s' % wps.identification.abstract
+print('WPS Identification type: %s' % wps.identification.type)
+print('WPS Identification title: %s' % wps.identification.title)
+print('WPS Identification abstract: %s' % wps.identification.abstract)
 for operation in wps.operations:
-    print 'WPS Operation: %s' % operation.name
+    print('WPS Operation: %s' % operation.name)
 for process in wps.processes:
-    print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
+    print('WPS Process: identifier=%s title=%s' % (process.identifier, process.title))
 
 # 2) DescribeProcess
 # GET request: http://ceda-wps2.badc.rl.ac.uk/wps?identifier=DoubleIt&version=1.0.0&request=DescribeProcess&service=WPS
 process = wps.describeprocess('DoubleIt')
-print 'WPS Process: identifier=%s' % process.identifier
-print 'WPS Process: title=%s' % process.title
-print 'WPS Process: abstract=%s' % process.abstract
+print('WPS Process: identifier=%s' % process.identifier)
+print('WPS Process: title=%s' % process.title)
+print('WPS Process: abstract=%s' % process.abstract)
 for input in process.dataInputs:
-    print 'Process input:'
+    print('Process input:')
     printInputOutput(input, indent='\t')
 for output in process.processOutputs:
-    print 'Process output:'
+    print('Process output:')
     printInputOutput(output, indent='\t')
 
 # 3) Execute

--- a/examples/wps-ceda-script.py
+++ b/examples/wps-ceda-script.py
@@ -34,9 +34,9 @@ for output in process.processOutputs:
 # 3) Execute
 # POST request:
 # Note: not working, requires openid login ?
-#processid = "DoubleIt"
-#inputs = [ ("NumberToDouble","1") ]
-#output = "OutputXML"
+#processid = 'DoubleIt'
+#inputs = [('NumberToDouble', '1')]
+#output = 'OutputXML'
 #execution = wps.execute(processid, inputs, output)
 
-# monitorExecution(execution)
+#monitorExecution(execution)

--- a/examples/wps-ceda-script.py
+++ b/examples/wps-ceda-script.py
@@ -1,7 +1,7 @@
 # Example script that performs a set of (small) live requests versus the live CEDA WPS service
 
-from owslib.wps import WebProcessingService, WPSExecution, WFSFeatureCollection, WFSQuery, GMLMultiPolygonFeatureCollection, monitorExecution, ComplexData, printInputOutput
-from owslib.util import dump
+from owslib.wps import WebProcessingService, printInputOutput
+
 
 verbose = True
 wps = WebProcessingService('http://ceda-wps2.badc.rl.ac.uk/wps', verbose=verbose)

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -13,7 +13,7 @@ from owslib.wps import WebProcessingService, monitorExecution
 
 
 def usage():
-    print """
+    print("""
 
 Usage: %s [parameters]
 
@@ -52,23 +52,23 @@ python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../te
 python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest5.xml
 python wps-client.py -u http://rsg.pml.ac.uk/wps/vector.cgi -r Execute -x ../tests/wps_PMLExecuteRequest6.xml
 
-""" % sys.argv[0]
+""" % sys.argv[0])
 
 # check args
 if len(sys.argv) == 1:
     usage()
     sys.exit(1)
 
-print 'ARGV      :', sys.argv[1:]
+print('ARGV      : %s' % sys.argv[1:])
 
 try:
     options, remainder = getopt.getopt(sys.argv[1:], 'u:r:x:i:v', ['url=', 'request=', 'xml=', 'identifier=', 'verbose'])
-except getopt.GetoptError, err:
-    print str(err)
+except getopt.GetoptError as err:
+    print(str(err))
     usage()
     sys.exit(2)
 
-print 'OPTIONS   :', options
+print('OPTIONS   : %s' % options)
 
 url = None
 request = None
@@ -100,37 +100,37 @@ wps = WebProcessingService(url, verbose=verbose, skip_caps=True)
 
 if request == 'GetCapabilities':
     wps.getcapabilities()
-    print 'WPS Identification type: %s' % wps.identification.type
-    print 'WPS Identification title: %s' % wps.identification.title
-    print 'WPS Identification abstract: %s' % wps.identification.abstract
+    print('WPS Identification type: %s' % wps.identification.type)
+    print('WPS Identification title: %s' % wps.identification.title)
+    print('WPS Identification abstract: %s' % wps.identification.abstract)
     for operation in wps.operations:
-        print 'WPS Operation: %s' % operation.name
+        print('WPS Operation: %s' % operation.name)
     for process in wps.processes:
-        print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
+        print('WPS Process: identifier=%s title=%s' % (process.identifier, process.title))
 
 elif request == 'DescribeProcess':
     if identifier is None:
-        print '\nERROR: missing mandatory "-i (or --identifier)" argument'
+        print('\nERROR: missing mandatory "-i (or --identifier)" argument')
         usage()
         sys.exit(4)
     process = wps.describeprocess(identifier)
-    print 'WPS Process: identifier=%s' % process.identifier
-    print 'WPS Process: title=%s' % process.title
-    print 'WPS Process: abstract=%s' % process.abstract
+    print('WPS Process: identifier=%s' % process.identifier)
+    print('WPS Process: title=%s' % process.title)
+    print('WPS Process: abstract=%s' % process.abstract)
     for input in process.dataInputs:
-        print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
+        print('Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs))
     for output in process.processOutputs:
-        print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
+        print('Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType))
 
 elif request == 'Execute':
     if xml is None:
-        print '\nERROR: missing mandatory "-x (or --xml)" argument'
+        print('\nERROR: missing mandatory "-x (or --xml)" argument')
         usage()
         sys.exit(5)
     execution = wps.execute(None, [], request=xml)
     monitorExecution(execution)
 
 else:
-    print '\nERROR: Unknown request type'
+    print('\nERROR: Unknown request type')
     usage()
     sys.exit(6)

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -64,7 +64,7 @@ print('ARGV      : %s' % sys.argv[1:])
 try:
     options, remainder = getopt.getopt(sys.argv[1:], 'u:r:x:i:v', ['url=', 'request=', 'xml=', 'identifier=', 'verbose'])
 except getopt.GetoptError as err:
-    print(str(err))
+    print(err)
     usage()
     sys.exit(2)
 
@@ -82,7 +82,7 @@ for opt, arg in options:
     elif opt in ('-r', '--request'):
         request = arg
     elif opt in ('-x', '--xml'):
-        xml = open(arg, 'r').read()
+        xml = open(arg, 'rb').read()
     elif opt in ('-i', '--identifier'):
         identifier = arg
     elif opt in ('-v', '--verbose'):

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -8,7 +8,7 @@
 
 import sys
 import getopt
-import os
+
 from owslib.wps import WebProcessingService, monitorExecution
 
 

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -13,7 +13,7 @@ from owslib.wps import WebProcessingService, monitorExecution
 
 
 def usage():
-    print("""
+    print('''
 
 Usage: %s [parameters]
 
@@ -52,7 +52,7 @@ python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../te
 python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest5.xml
 python wps-client.py -u http://rsg.pml.ac.uk/wps/vector.cgi -r Execute -x ../tests/wps_PMLExecuteRequest6.xml
 
-""" % sys.argv[0])
+''' % sys.argv[0])
 
 # check args
 if len(sys.argv) == 1:

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -11,17 +11,18 @@ import getopt
 import os
 from owslib.wps import WebProcessingService, monitorExecution
 
+
 def usage():
-    print  """
-    
+    print """
+
 Usage: %s [parameters]
 
 Common Parameters for all request types
 -------------------
 
     -u, --url=[URL] the base URL of the WPS - required
-    -r, --request=[REQUEST] the request type (GetCapabilities, DescribeProcess, Execute) - required 
-    -v, --verbose set flag for verbose output - optional (defaults to False)    
+    -r, --request=[REQUEST] the request type (GetCapabilities, DescribeProcess, Execute) - required
+    -v, --verbose set flag for verbose output - optional (defaults to False)
 
 Request Specific Parameters
 ---------------------------
@@ -47,26 +48,26 @@ python wps-client.py -u http://rsg.pml.ac.uk/wps/vector.cgi -r DescribeProcess -
 
 python wps-client.py -u http://cida.usgs.gov/climate/gdp/process/WebProcessingService -r Execute -x ../tests/wps_USGSExecuteRequest1.xml
 python wps-client.py --verbose --url http://cida.usgs.gov/climate/gdp/process/WebProcessingService --request Execute --xml ../tests/wps_USGSExecuteRequest1.xml
-python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest4.xml 
-python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest5.xml 
-python wps-client.py -u http://rsg.pml.ac.uk/wps/vector.cgi -r Execute -x ../tests/wps_PMLExecuteRequest6.xml 
+python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest4.xml
+python wps-client.py -u http://rsg.pml.ac.uk/wps/generic.cgi -r Execute -x ../tests/wps_PMLExecuteRequest5.xml
+python wps-client.py -u http://rsg.pml.ac.uk/wps/vector.cgi -r Execute -x ../tests/wps_PMLExecuteRequest6.xml
 
 """ % sys.argv[0]
-    
+
 # check args
 if len(sys.argv) == 1:
     usage()
     sys.exit(1)
-    
+
 print 'ARGV      :', sys.argv[1:]
-    
+
 try:
     options, remainder = getopt.getopt(sys.argv[1:], 'u:r:x:i:v', ['url=', 'request=', 'xml=', 'identifier=', 'verbose'])
 except getopt.GetoptError, err:
     print str(err)
     usage()
     sys.exit(2)
-    
+
 print 'OPTIONS   :', options
 
 url = None
@@ -88,12 +89,12 @@ for opt, arg in options:
         verbose = True
     else:
         assert False, 'Unhandled option'
-   
-# required arguments for all requests     
+
+# required arguments for all requests
 if request is None or url is None:
     usage()
     sys.exit(3)
-        
+
 # instantiate client
 wps = WebProcessingService(url, verbose=verbose, skip_caps=True)
 
@@ -106,7 +107,7 @@ if request == 'GetCapabilities':
         print 'WPS Operation: %s' % operation.name
     for process in wps.processes:
         print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
-    
+
 elif request == 'DescribeProcess':
     if identifier is None:
         print '\nERROR: missing mandatory "-i (or --identifier)" argument'
@@ -120,7 +121,7 @@ elif request == 'DescribeProcess':
         print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
     for output in process.processOutputs:
         print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
-        
+
 elif request == 'Execute':
     if xml is None:
         print '\nERROR: missing mandatory "-x (or --xml)" argument'
@@ -128,7 +129,7 @@ elif request == 'Execute':
         sys.exit(5)
     execution = wps.execute(None, [], request=xml)
     monitorExecution(execution)
-    
+
 else:
     print '\nERROR: Unknown request type'
     usage()

--- a/examples/wps-climdaps.py
+++ b/examples/wps-climdaps.py
@@ -8,7 +8,7 @@ wps = WebProcessingService('http://rsg.pml.ac.uk/wps/generic.cgi', verbose=verbo
 processid = 'dummyprocess'
 inputs = [("input1", '1'), ("input2", '2')]
 # list of tuple (output identifier, asReference attribute)
-outputs = [("output1",True), ("output2",False)]
+outputs = [("output1", True), ("output2", False)]
 
 execution = wps.execute(processid, inputs, output=outputs)
 print execution.status
@@ -19,7 +19,7 @@ print 'status message', execution.statusMessage
 monitorExecution(execution)
 
 for output in execution.processOutputs:
-        print 'identifier=%s, dataType=%s, data=%s, reference=%s' % (output.identifier, output.dataType, output.data, output.reference) 
+    print 'identifier=%s, dataType=%s, data=%s, reference=%s' % (output.identifier, output.dataType, output.data, output.reference)
 
 # get errors
 inputs = [("input1", '1'), ("input2", '3')]
@@ -27,8 +27,4 @@ execution = wps.execute(processid, inputs, output=outputs)
 monitorExecution(execution)
 print execution.status
 for error in execution.errors:
-        print error.code, error.locator, error.text
-
-
-
-
+    print error.code, error.locator, error.text

--- a/examples/wps-climdaps.py
+++ b/examples/wps-climdaps.py
@@ -1,5 +1,6 @@
 from owslib.wps import WebProcessingService, monitorExecution
 
+
 verbose = True
 
 # get multiple outputs

--- a/examples/wps-climdaps.py
+++ b/examples/wps-climdaps.py
@@ -7,9 +7,9 @@ verbose = True
 wps = WebProcessingService('http://rsg.pml.ac.uk/wps/generic.cgi', verbose=verbose)
 
 processid = 'dummyprocess'
-inputs = [("input1", '1'), ("input2", '2')]
+inputs = [('input1', '1'), ('input2', '2')]
 # list of tuple (output identifier, asReference attribute)
-outputs = [("output1", True), ("output2", False)]
+outputs = [('output1', True), ('output2', False)]
 
 execution = wps.execute(processid, inputs, output=outputs)
 print(execution.status)
@@ -23,7 +23,7 @@ for output in execution.processOutputs:
     print('identifier=%s, dataType=%s, data=%s, reference=%s' % (output.identifier, output.dataType, output.data, output.reference))
 
 # get errors
-inputs = [("input1", '1'), ("input2", '3')]
+inputs = [('input1', '1'), ('input2', '3')]
 execution = wps.execute(processid, inputs, output=outputs)
 monitorExecution(execution)
 print(execution.status)

--- a/examples/wps-climdaps.py
+++ b/examples/wps-climdaps.py
@@ -11,20 +11,20 @@ inputs = [("input1", '1'), ("input2", '2')]
 outputs = [("output1", True), ("output2", False)]
 
 execution = wps.execute(processid, inputs, output=outputs)
-print execution.status
+print(execution.status)
 # show status
-print 'percent complete', execution.percentCompleted
-print 'status message', execution.statusMessage
+print('percent complete %s' % execution.percentCompleted)
+print('status message %s' % execution.statusMessage)
 
 monitorExecution(execution)
 
 for output in execution.processOutputs:
-    print 'identifier=%s, dataType=%s, data=%s, reference=%s' % (output.identifier, output.dataType, output.data, output.reference)
+    print('identifier=%s, dataType=%s, data=%s, reference=%s' % (output.identifier, output.dataType, output.data, output.reference))
 
 # get errors
 inputs = [("input1", '1'), ("input2", '3')]
 execution = wps.execute(processid, inputs, output=outputs)
 monitorExecution(execution)
-print execution.status
+print(execution.status)
 for error in execution.errors:
-    print error.code, error.locator, error.text
+    print('%s %s %s' % (error.code, error.locator, error.text))

--- a/examples/wps-pml-script-1.py
+++ b/examples/wps-pml-script-1.py
@@ -8,23 +8,23 @@ wps = WebProcessingService('http://rsg.pml.ac.uk/wps/generic.cgi', verbose=verbo
 
 # 1) GetCapabilities
 wps.getcapabilities()
-print 'WPS Identification type: %s' % wps.identification.type
-print 'WPS Identification title: %s' % wps.identification.title
-print 'WPS Identification abstract: %s' % wps.identification.abstract
+print('WPS Identification type: %s' % wps.identification.type)
+print('WPS Identification title: %s' % wps.identification.title)
+print('WPS Identification abstract: %s' % wps.identification.abstract)
 for operation in wps.operations:
-    print 'WPS Operation: %s' % operation.name
+    print('WPS Operation: %s' % operation.name)
 for process in wps.processes:
-    print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
+    print('WPS Process: identifier=%s title=%s' % (process.identifier, process.title))
 
 # 2) DescribeProcess
 process = wps.describeprocess('reprojectImage')
-print 'WPS Process: identifier=%s' % process.identifier
-print 'WPS Process: title=%s' % process.title
-print 'WPS Process: abstract=%s' % process.abstract
+print('WPS Process: identifier=%s' % process.identifier)
+print('WPS Process: title=%s' % process.title)
+print('WPS Process: abstract=%s' % process.abstract)
 for input in process.dataInputs:
-    print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
+    print('Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs))
 for output in process.processOutputs:
-    print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
+    print('Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType))
 
 # 3a) Execute
 # GET request: http://rsg.pml.ac.uk/wps/generic.cgi?request=Execute&service=wps&version=1.0.0&identifier=reprojectImage&datainputs=[inputImage=http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img;outputSRS=EPSG:4326]&responsedocument=outputImage=@asreference=true

--- a/examples/wps-pml-script-1.py
+++ b/examples/wps-pml-script-1.py
@@ -15,7 +15,7 @@ for operation in wps.operations:
     print 'WPS Operation: %s' % operation.name
 for process in wps.processes:
     print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
-    
+
 # 2) DescribeProcess
 process = wps.describeprocess('reprojectImage')
 print 'WPS Process: identifier=%s' % process.identifier
@@ -25,23 +25,23 @@ for input in process.dataInputs:
     print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
 for output in process.processOutputs:
     print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
-    
+
 # 3a) Execute
 # GET request: http://rsg.pml.ac.uk/wps/generic.cgi?request=Execute&service=wps&version=1.0.0&identifier=reprojectImage&datainputs=[inputImage=http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img;outputSRS=EPSG:4326]&responsedocument=outputImage=@asreference=true
 processid = "reprojectImage"
-inputs = [ ("inputImage","http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img"),
-           ("outputSRS", "EPSG:4326") ]
+inputs = [("inputImage", "http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img"),
+          ("outputSRS", "EPSG:4326")]
 output = "outputImage"
 execution = wps.execute(processid, inputs, output)
 
 monitorExecution(execution)
-        
+
 # 3b) Execute
 # GET request: http://rsg.pml.ac.uk/wps/generic.cgi?request=Execute&service=WPS&version=1.0.0&identifier=reprojectCoords&datainputs=[coords=http://rsg.pml.ac.uk/wps/testdata/coords.txt;outputSRS=EPSG:32630;inputSRS=EPSG:4326]
 processid = "reprojectCoords"
-inputs = [ ("coords","http://rsg.pml.ac.uk/wps/testdata/coords.txt"),
-           ("outputSRS", "EPSG:32630"),
-           ("inputSRS","EPSG:4326") ]
+inputs = [("coords", "http://rsg.pml.ac.uk/wps/testdata/coords.txt"),
+          ("outputSRS", "EPSG:32630"),
+          ("inputSRS", "EPSG:4326")]
 execution = wps.execute(processid, inputs)
 
 monitorExecution(execution)

--- a/examples/wps-pml-script-1.py
+++ b/examples/wps-pml-script-1.py
@@ -28,20 +28,20 @@ for output in process.processOutputs:
 
 # 3a) Execute
 # GET request: http://rsg.pml.ac.uk/wps/generic.cgi?request=Execute&service=wps&version=1.0.0&identifier=reprojectImage&datainputs=[inputImage=http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img;outputSRS=EPSG:4326]&responsedocument=outputImage=@asreference=true
-processid = "reprojectImage"
-inputs = [("inputImage", "http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img"),
-          ("outputSRS", "EPSG:4326")]
-output = "outputImage"
+processid = 'reprojectImage'
+inputs = [('inputImage', 'http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img'),
+          ('outputSRS', 'EPSG:4326')]
+output = 'outputImage'
 execution = wps.execute(processid, inputs, output)
 
 monitorExecution(execution)
 
 # 3b) Execute
 # GET request: http://rsg.pml.ac.uk/wps/generic.cgi?request=Execute&service=WPS&version=1.0.0&identifier=reprojectCoords&datainputs=[coords=http://rsg.pml.ac.uk/wps/testdata/coords.txt;outputSRS=EPSG:32630;inputSRS=EPSG:4326]
-processid = "reprojectCoords"
-inputs = [("coords", "http://rsg.pml.ac.uk/wps/testdata/coords.txt"),
-          ("outputSRS", "EPSG:32630"),
-          ("inputSRS", "EPSG:4326")]
+processid = 'reprojectCoords'
+inputs = [('coords', 'http://rsg.pml.ac.uk/wps/testdata/coords.txt'),
+          ('outputSRS', 'EPSG:32630'),
+          ('inputSRS', 'EPSG:4326')]
 execution = wps.execute(processid, inputs)
 
 monitorExecution(execution)

--- a/examples/wps-pml-script-2.py
+++ b/examples/wps-pml-script-2.py
@@ -15,7 +15,7 @@ for operation in wps.operations:
     print 'WPS Operation: %s' % operation.name
 for process in wps.processes:
     print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
-    
+
 # 2) DescribeProcess
 process = wps.describeprocess('v.net.path')
 # alternatively, read process description from XML file (no live request to WPS server)
@@ -28,11 +28,11 @@ for input in process.dataInputs:
     print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
 for output in process.processOutputs:
     print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
-    
+
 # 3) Execute
 # GET request: http://rsg.pml.ac.uk/wps/vector.cgi?request=execute&service=WPS&version=1.0.0&identifier=v.net.path&datainputs=[input=http://rsg.pml.ac.uk/wps/example/graph.gml;file=1%20-960123.1421801624%204665723.56559387%20-101288.65106088226%205108200.011823481]
 processid = "v.net.path"
-inputs = [ ("input","http://rsg.pml.ac.uk/wps/example/graph.gml"),
-           ("file","1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481")]
+inputs = [("input", "http://rsg.pml.ac.uk/wps/example/graph.gml"),
+          ("file", "1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481")]
 execution = wps.execute(processid, inputs)
 monitorExecution(execution)

--- a/examples/wps-pml-script-2.py
+++ b/examples/wps-pml-script-2.py
@@ -31,8 +31,8 @@ for output in process.processOutputs:
 
 # 3) Execute
 # GET request: http://rsg.pml.ac.uk/wps/vector.cgi?request=execute&service=WPS&version=1.0.0&identifier=v.net.path&datainputs=[input=http://rsg.pml.ac.uk/wps/example/graph.gml;file=1%20-960123.1421801624%204665723.56559387%20-101288.65106088226%205108200.011823481]
-processid = "v.net.path"
-inputs = [("input", "http://rsg.pml.ac.uk/wps/example/graph.gml"),
-          ("file", "1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481")]
+processid = 'v.net.path'
+inputs = [('input', 'http://rsg.pml.ac.uk/wps/example/graph.gml'),
+          ('file', '1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481')]
 execution = wps.execute(processid, inputs)
 monitorExecution(execution)

--- a/examples/wps-pml-script-2.py
+++ b/examples/wps-pml-script-2.py
@@ -8,26 +8,26 @@ wps = WebProcessingService('http://rsg.pml.ac.uk/wps/vector.cgi', verbose=verbos
 
 # 1) GetCapabilities
 wps.getcapabilities()
-print 'WPS Identification type: %s' % wps.identification.type
-print 'WPS Identification title: %s' % wps.identification.title
-print 'WPS Identification abstract: %s' % wps.identification.abstract
+print('WPS Identification type: %s' % wps.identification.type)
+print('WPS Identification title: %s' % wps.identification.title)
+print('WPS Identification abstract: %s' % wps.identification.abstract)
 for operation in wps.operations:
-    print 'WPS Operation: %s' % operation.name
+    print('WPS Operation: %s' % operation.name)
 for process in wps.processes:
-    print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
+    print('WPS Process: identifier=%s title=%s' % (process.identifier, process.title))
 
 # 2) DescribeProcess
 process = wps.describeprocess('v.net.path')
 # alternatively, read process description from XML file (no live request to WPS server)
 #xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
-print 'WPS Process: identifier=%s' % process.identifier
-print 'WPS Process: title=%s' % process.title
-print 'WPS Process: abstract=%s' % process.abstract
+print('WPS Process: identifier=%s' % process.identifier)
+print('WPS Process: title=%s' % process.title)
+print('WPS Process: abstract=%s' % process.abstract)
 for input in process.dataInputs:
-    print 'Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs)
+    print('Process input: identifier=%s, data type=%s, minOccurs=%d, maxOccurs=%d' % (input.identifier, input.dataType, input.minOccurs, input.maxOccurs))
 for output in process.processOutputs:
-    print 'Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType)
+    print('Process output: identifier=%s, data type=%s' % (output.identifier, output.dataType))
 
 # 3) Execute
 # GET request: http://rsg.pml.ac.uk/wps/vector.cgi?request=execute&service=WPS&version=1.0.0&identifier=v.net.path&datainputs=[input=http://rsg.pml.ac.uk/wps/example/graph.gml;file=1%20-960123.1421801624%204665723.56559387%20-101288.65106088226%205108200.011823481]

--- a/examples/wps-pml-script-2.py
+++ b/examples/wps-pml-script-2.py
@@ -19,7 +19,7 @@ for process in wps.processes:
 # 2) DescribeProcess
 process = wps.describeprocess('v.net.path')
 # alternatively, read process description from XML file (no live request to WPS server)
-#xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
+#xml = open('../tests/USGSDescribeProcess.xml', 'rb').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 print('WPS Process: identifier=%s' % process.identifier)
 print('WPS Process: title=%s' % process.title)

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -15,13 +15,13 @@ wps.getcapabilities()
 # alternatively, read capabilities from XML file (no live request to WPS server)
 #xml = open('../tests/USGSCapabilities.xml', 'r').read()
 # wps.getcapabilities(xml=xml)
-print 'WPS Identification type: %s' % wps.identification.type
-print 'WPS Identification title: %s' % wps.identification.title
-print 'WPS Identification abstract: %s' % wps.identification.abstract
+print('WPS Identification type: %s' % wps.identification.type)
+print('WPS Identification title: %s' % wps.identification.title)
+print('WPS Identification abstract: %s' % wps.identification.abstract)
 for operation in wps.operations:
-    print 'WPS Operation: %s' % operation.name
+    print('WPS Operation: %s' % operation.name)
 for process in wps.processes:
-    print 'WPS Process: identifier=%s title=%s' % (process.identifier, process.title)
+    print('WPS Process: identifier=%s title=%s' % (process.identifier, process.title))
 
 # 2) DescribeProcess
 # Submits an HTTP GET "DescribeProcess" request to the WPS service and parses the HTTP response
@@ -30,14 +30,14 @@ process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGr
 # alternatively, read process description from XML file (no live request to WPS server)
 #xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
-print 'WPS Process: identifier=%s' % process.identifier
-print 'WPS Process: title=%s' % process.title
-print 'WPS Process: abstract=%s' % process.abstract
+print('WPS Process: identifier=%s' % process.identifier)
+print('WPS Process: title=%s' % process.title)
+print('WPS Process: abstract=%s' % process.abstract)
 for input in process.dataInputs:
-    print 'Process input:'
+    print('Process input:')
     printInputOutput(input, indent='\t')
 for output in process.processOutputs:
-    print 'Process output:'
+    print('Process output:')
     printInputOutput(output, indent='\t')
 
 # 3a) Execute

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -12,7 +12,7 @@ wps = WebProcessingService('http://cida.usgs.gov/climate/gdp/process/WebProcessi
 
 wps.getcapabilities()
 # alternatively, read capabilities from XML file (no live request to WPS server)
-#xml = open('../tests/USGSCapabilities.xml', 'r').read()
+#xml = open('../tests/USGSCapabilities.xml', 'rb').read()
 #wps.getcapabilities(xml=xml)
 print('WPS Identification type: %s' % wps.identification.type)
 print('WPS Identification title: %s' % wps.identification.title)
@@ -27,7 +27,7 @@ for process in wps.processes:
 
 process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm')
 # alternatively, read process description from XML file (no live request to WPS server)
-#xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
+#xml = open('../tests/USGSDescribeProcess.xml', 'rb').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 print('WPS Process: identifier=%s' % process.identifier)
 print('WPS Process: title=%s' % process.title)
@@ -64,7 +64,7 @@ inputs = [('FEATURE_ATTRIBUTE_NAME', 'the_geom'),
 output = 'OUTPUT'
 execution = wps.execute(processid, inputs, output='OUTPUT')
 # alternatively, submit a pre-made request specified in an XML file
-#request = open('../tests/wps_USGSExecuteRequest1.xml','r').read()
+#request = open('../tests/wps_USGSExecuteRequest1.xml','rb').read()
 #execution = wps.execute(None, [], request=request)
 
 # The monitorExecution() function can be conveniently used to wait for the process termination
@@ -101,7 +101,7 @@ inputs =  [ ('FEATURE_ATTRIBUTE_NAME', 'the_geom'),
 output = 'OUTPUT'
 execution = wps.execute(processid, inputs, output = 'OUTPUT')
 # alternatively, submit a pre-made request specified in an XML file
-#request = open('../tests/wps_USGSExecuteRequest3.xml','r').read()
+#request = open('../tests/wps_USGSExecuteRequest3.xml','rb').read()
 #execution = wps.execute(None, [], request=request)
 monitorExecution(execution)
 '''

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -13,8 +13,8 @@ wps = WebProcessingService('http://cida.usgs.gov/climate/gdp/process/WebProcessi
 
 wps.getcapabilities()
 # alternatively, read capabilities from XML file (no live request to WPS server)
-#xml = open('../tests/USGSCapabilities.xml', 'r').read() 
-#wps.getcapabilities(xml=xml)
+#xml = open('../tests/USGSCapabilities.xml', 'r').read()
+# wps.getcapabilities(xml=xml)
 print 'WPS Identification type: %s' % wps.identification.type
 print 'WPS Identification title: %s' % wps.identification.title
 print 'WPS Identification abstract: %s' % wps.identification.abstract
@@ -48,31 +48,31 @@ for output in process.processOutputs:
 #query = WFSQuery("sample:CONUS_States", propertyNames=['the_geom',"STATE"], filters=["CONUS_States.508","CONUS_States.469"])
 #featureCollection = WFSFeatureCollection(wfsUrl, query)
 polygon = [(-102.8184, 39.5273), (-102.8184, 37.418), (-101.2363, 37.418), (-101.2363, 39.5273), (-102.8184, 39.5273)]
-featureCollection = GMLMultiPolygonFeatureCollection( [polygon] )
+featureCollection = GMLMultiPolygonFeatureCollection([polygon])
 processid = 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm'
-inputs = [ ("FEATURE_ATTRIBUTE_NAME","the_geom"),
-           ("DATASET_URI", "dods://cida.usgs.gov/qa/thredds/dodsC/derivatives/derivative-days_above_threshold.pr.ncml"),
-           ("DATASET_ID", "ensemble_b1_pr-days_above_threshold"),
-           ("TIME_START","2010-01-01T00:00:00.000Z"),
-           ("TIME_END","2011-01-01T00:00:00.000Z"),
-           ("REQUIRE_FULL_COVERAGE","false"),
-           ("DELIMITER","COMMA"),
-           ("STATISTICS","MEAN"),
-           ("GROUP_BY","STATISTIC"),
-           ("SUMMARIZE_TIMESTEP","false"),
-           ("SUMMARIZE_FEATURE_ATTRIBUTE","false"),
-           ("FEATURE_COLLECTION", featureCollection)
+inputs = [("FEATURE_ATTRIBUTE_NAME", "the_geom"),
+          ("DATASET_URI", "dods://cida.usgs.gov/qa/thredds/dodsC/derivatives/derivative-days_above_threshold.pr.ncml"),
+          ("DATASET_ID", "ensemble_b1_pr-days_above_threshold"),
+          ("TIME_START", "2010-01-01T00:00:00.000Z"),
+          ("TIME_END", "2011-01-01T00:00:00.000Z"),
+          ("REQUIRE_FULL_COVERAGE", "false"),
+          ("DELIMITER", "COMMA"),
+          ("STATISTICS", "MEAN"),
+          ("GROUP_BY", "STATISTIC"),
+          ("SUMMARIZE_TIMESTEP", "false"),
+          ("SUMMARIZE_FEATURE_ATTRIBUTE", "false"),
+          ("FEATURE_COLLECTION", featureCollection)
           ]
 output = "OUTPUT"
-execution = wps.execute(processid, inputs, output = "OUTPUT")
+execution = wps.execute(processid, inputs, output="OUTPUT")
 # alternatively, submit a pre-made request specified in an XML file
 #request = open('../tests/wps_USGSExecuteRequest1.xml','r').read()
 #execution = wps.execute(None, [], request=request)
 
 # The monitorExecution() function can be conveniently used to wait for the process termination
 # It will eventually write the process output to the specified file, or to the file specified by the server.
-monitorExecution(execution)    
-'''    
+monitorExecution(execution)
+'''
 # 3b) Execute
 # Submits an HTTP POST "Execute" process request to the WPS service, keeps checking the status of the request,
 # and retrieves the output once the request terminates successfully (displaying any errors if found).
@@ -105,5 +105,5 @@ execution = wps.execute(processid, inputs, output = "OUTPUT")
 # alternatively, submit a pre-made request specified in an XML file
 #request = open('../tests/wps_USGSExecuteRequest3.xml','r').read()
 #execution = wps.execute(None, [], request=request)
-monitorExecution(execution)    
+monitorExecution(execution)
 '''

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -1,7 +1,6 @@
 # Example script that performs a set of (small) live requests versus the live USGS WPS service
 
-from owslib.wps import WebProcessingService, WPSExecution, WFSFeatureCollection, WFSQuery, GMLMultiPolygonFeatureCollection, monitorExecution, printInputOutput
-from owslib.util import dump
+from owslib.wps import WebProcessingService, GMLMultiPolygonFeatureCollection, monitorExecution, printInputOutput
 
 # instantiate WPS client
 # setting verbose=True will print out all HTTP request and responses to standard output
@@ -61,8 +60,7 @@ inputs = [("FEATURE_ATTRIBUTE_NAME", "the_geom"),
           ("GROUP_BY", "STATISTIC"),
           ("SUMMARIZE_TIMESTEP", "false"),
           ("SUMMARIZE_FEATURE_ATTRIBUTE", "false"),
-          ("FEATURE_COLLECTION", featureCollection)
-          ]
+          ("FEATURE_COLLECTION", featureCollection)]
 output = "OUTPUT"
 execution = wps.execute(processid, inputs, output="OUTPUT")
 # alternatively, submit a pre-made request specified in an XML file

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -13,7 +13,7 @@ wps = WebProcessingService('http://cida.usgs.gov/climate/gdp/process/WebProcessi
 wps.getcapabilities()
 # alternatively, read capabilities from XML file (no live request to WPS server)
 #xml = open('../tests/USGSCapabilities.xml', 'r').read()
-# wps.getcapabilities(xml=xml)
+#wps.getcapabilities(xml=xml)
 print('WPS Identification type: %s' % wps.identification.type)
 print('WPS Identification title: %s' % wps.identification.title)
 print('WPS Identification abstract: %s' % wps.identification.abstract)
@@ -43,26 +43,26 @@ for output in process.processOutputs:
 # Submits an HTTP POST "Execute" process request to the WPS service, keeps checking the status of the request,
 # and retrieves the output once the request terminates successfully (displaying any errors if found).
 # This request uses a FEATURE_COLLECTION input obtained from a live WFS service.
-#wfsUrl = "http://cida.usgs.gov/climate/gdp/proxy/http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs"
-#query = WFSQuery("sample:CONUS_States", propertyNames=['the_geom',"STATE"], filters=["CONUS_States.508","CONUS_States.469"])
+#wfsUrl = 'http://cida.usgs.gov/climate/gdp/proxy/http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs'
+#query = WFSQuery('sample:CONUS_States', propertyNames=['the_geom', 'STATE'], filters=['CONUS_States.508','CONUS_States.469'])
 #featureCollection = WFSFeatureCollection(wfsUrl, query)
 polygon = [(-102.8184, 39.5273), (-102.8184, 37.418), (-101.2363, 37.418), (-101.2363, 39.5273), (-102.8184, 39.5273)]
 featureCollection = GMLMultiPolygonFeatureCollection([polygon])
 processid = 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm'
-inputs = [("FEATURE_ATTRIBUTE_NAME", "the_geom"),
-          ("DATASET_URI", "dods://cida.usgs.gov/qa/thredds/dodsC/derivatives/derivative-days_above_threshold.pr.ncml"),
-          ("DATASET_ID", "ensemble_b1_pr-days_above_threshold"),
-          ("TIME_START", "2010-01-01T00:00:00.000Z"),
-          ("TIME_END", "2011-01-01T00:00:00.000Z"),
-          ("REQUIRE_FULL_COVERAGE", "false"),
-          ("DELIMITER", "COMMA"),
-          ("STATISTICS", "MEAN"),
-          ("GROUP_BY", "STATISTIC"),
-          ("SUMMARIZE_TIMESTEP", "false"),
-          ("SUMMARIZE_FEATURE_ATTRIBUTE", "false"),
-          ("FEATURE_COLLECTION", featureCollection)]
-output = "OUTPUT"
-execution = wps.execute(processid, inputs, output="OUTPUT")
+inputs = [('FEATURE_ATTRIBUTE_NAME', 'the_geom'),
+          ('DATASET_URI', 'dods://cida.usgs.gov/qa/thredds/dodsC/derivatives/derivative-days_above_threshold.pr.ncml'),
+          ('DATASET_ID', 'ensemble_b1_pr-days_above_threshold'),
+          ('TIME_START', '2010-01-01T00:00:00.000Z'),
+          ('TIME_END', '2011-01-01T00:00:00.000Z'),
+          ('REQUIRE_FULL_COVERAGE', 'false'),
+          ('DELIMITER', 'COMMA'),
+          ('STATISTICS', 'MEAN'),
+          ('GROUP_BY', 'STATISTIC'),
+          ('SUMMARIZE_TIMESTEP', 'false'),
+          ('SUMMARIZE_FEATURE_ATTRIBUTE', 'false'),
+          ('FEATURE_COLLECTION', featureCollection)]
+output = 'OUTPUT'
+execution = wps.execute(processid, inputs, output='OUTPUT')
 # alternatively, submit a pre-made request specified in an XML file
 #request = open('../tests/wps_USGSExecuteRequest1.xml','r').read()
 #execution = wps.execute(None, [], request=request)
@@ -79,27 +79,27 @@ monitorExecution(execution)
 polygon = [(-102.8184, 39.5273), (-102.8184, 37.418), (-101.2363, 37.418), (-101.2363, 39.5273), (-102.8184, 39.5273)]
 featureCollection = GMLMultiPolygonFeatureCollection( [polygon] )
 processid = 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm'
-inputs =  [ ("FEATURE_ATTRIBUTE_NAME","the_geom"),
-            ("DATASET_URI", "dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml"),
-            ("DATASET_ID", "ccsm3_a1b_tmax"),
-            ("TIME_START","1960-01-01T00:00:00.000Z"),
-            ("TIME_END","1960-12-31T00:00:00.000Z"),
-            ("REQUIRE_FULL_COVERAGE","true"),
-            ("DELIMITER","COMMA"),
-            ("STATISTICS","MEAN"),
-            ("STATISTICS","MINIMUM"),
-            ("STATISTICS","MAXIMUM"),
-            ("STATISTICS","WEIGHT_SUM"),
-            ("STATISTICS","VARIANCE"),
-            ("STATISTICS","STD_DEV"),
-            ("STATISTICS","COUNT"),
-            ("GROUP_BY","STATISTIC"),
-            ("SUMMARIZE_TIMESTEP","false"),
-            ("SUMMARIZE_FEATURE_ATTRIBUTE","false"),
-            ("FEATURE_COLLECTION", featureCollection)
+inputs =  [ ('FEATURE_ATTRIBUTE_NAME', 'the_geom'),
+            ('DATASET_URI', 'dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml'),
+            ('DATASET_ID', 'ccsm3_a1b_tmax'),
+            ('TIME_START', '1960-01-01T00:00:00.000Z'),
+            ('TIME_END', '1960-12-31T00:00:00.000Z'),
+            ('REQUIRE_FULL_COVERAGE', 'true'),
+            ('DELIMITER', 'COMMA'),
+            ('STATISTICS', 'MEAN'),
+            ('STATISTICS', 'MINIMUM'),
+            ('STATISTICS', 'MAXIMUM'),
+            ('STATISTICS', 'WEIGHT_SUM'),
+            ('STATISTICS', 'VARIANCE'),
+            ('STATISTICS', 'STD_DEV'),
+            ('STATISTICS', 'COUNT'),
+            ('GROUP_BY', 'STATISTIC'),
+            ('SUMMARIZE_TIMESTEP', 'false'),
+            ('SUMMARIZE_FEATURE_ATTRIBUTE', 'false'),
+            ('FEATURE_COLLECTION', featureCollection)
            ]
-output = "OUTPUT"
-execution = wps.execute(processid, inputs, output = "OUTPUT")
+output = 'OUTPUT'
+execution = wps.execute(processid, inputs, output = 'OUTPUT')
 # alternatively, submit a pre-made request specified in an XML file
 #request = open('../tests/wps_USGSExecuteRequest3.xml','r').read()
 #execution = wps.execute(None, [], request=request)

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -93,7 +93,7 @@ class WebCoverageService_1_0_0(WCSBase):
 
     def __makeString(self, value):
         # using repr unconditionally breaks things in some circumstances if a value is already a string
-        if type(value) is not str:
+        if not isinstance(value, str):
             sval = repr(value)
         else:
             sval = value

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -38,7 +38,7 @@ class WebCoverageService_1_0_0(WCSBase):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, xml, cookies):
         self.version = '1.0.0'
@@ -165,7 +165,7 @@ class WebCoverageService_1_0_0(WCSBase):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class OperationMetadata(object):

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -32,7 +32,7 @@ class WebCoverageService_1_0_0(WCSBase):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -9,16 +9,11 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
-from urllib import urlencode
-from owslib.util import openURL, testXMLValue
-from owslib.etree import etree
-from owslib.crs import Crs
-import os
-import errno
-
 import logging
-from owslib.util import log
+
+from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
+from owslib.util import openURL, testXMLValue, urlencode, log
+from owslib.crs import Crs
 
 #  function to save writing out WCS namespace in full each time
 

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -11,6 +11,7 @@
 
 import logging
 
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode
 
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
@@ -52,7 +53,7 @@ class WebCoverageService_1_0_0(WCSBase):
         se = self._capabilities.find('ServiceException')
 
         if se is not None:
-            err_message = str(se.text).strip()
+            err_message = text_type(se.text).strip()
             raise ServiceException(err_message, xml)
 
         # serviceIdentification metadata
@@ -93,7 +94,7 @@ class WebCoverageService_1_0_0(WCSBase):
 
     def __makeString(self, value):
         # using repr unconditionally breaks things in some circumstances if a value is already a string
-        if not isinstance(value, str):
+        if not isinstance(value, (text_type, binary_type)):
             sval = repr(value)
         else:
             sval = value
@@ -111,7 +112,7 @@ class WebCoverageService_1_0_0(WCSBase):
 
         """
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, crs, width, height, resx, resy, resz, parameter, method, str(kwargs)))
+            log.debug('WCS 1.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, crs, width, height, resx, resy, resz, parameter, method, text_type(kwargs)))
 
         base_url = self.getOperationByName('GetCoverage').methods[method]['url']
 

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -11,8 +11,10 @@
 
 import logging
 
+from six.moves.urllib.parse import urlencode
+
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
-from owslib.util import openURL, testXMLValue, urlencode, log
+from owslib.util import openURL, testXMLValue, log
 from owslib.crs import Crs
 
 #  function to save writing out WCS namespace in full each time

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <d.lowe@rl.ac.uk>
 #
 # Contact email: d.lowe@rl.ac.uk
@@ -14,30 +14,36 @@ from urllib import urlencode
 from owslib.util import openURL, testXMLValue
 from owslib.etree import etree
 from owslib.crs import Crs
-import os, errno
+import os
+import errno
 
 import logging
 from owslib.util import log
 
 #  function to save writing out WCS namespace in full each time
+
+
 def ns(tag):
-    return '{http://www.opengis.net/wcs}'+tag
+    return '{http://www.opengis.net/wcs}' + tag
+
 
 class WebCoverageService_1_0_0(WCSBase):
+
     """Abstraction for OGC Web Coverage Service (WCS), version 1.0.0
     Implements IWebCoverageService.
     """
-    def __getitem__(self,name):
+
+    def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
-    
-    def __init__(self,url,xml, cookies):
-        self.version='1.0.0'
-        self.url = url   
-        self.cookies=cookies
+
+    def __init__(self, url, xml, cookies):
+        self.version = '1.0.0'
+        self.url = url
+        self.cookies = cookies
         # initialize from saved capability document or access the server
         reader = WCSCapabilitiesReader(self.version, self.cookies)
         if xml:
@@ -49,55 +55,54 @@ class WebCoverageService_1_0_0(WCSBase):
         se = self._capabilities.find('ServiceException')
 
         if se is not None:
-            err_message = str(se.text).strip()  
-            raise ServiceException(err_message, xml) 
+            err_message = str(se.text).strip()
+            raise ServiceException(err_message, xml)
 
-        #serviceIdentification metadata
-        subelem=self._capabilities.find(ns('Service'))
-        self.identification=ServiceIdentification(subelem)                               
-                   
-        #serviceProvider metadata
-        subelem=self._capabilities.find(ns('Service/')+ns('responsibleParty'))
-        self.provider=ServiceProvider(subelem)   
-        
-        #serviceOperations metadata
-        self.operations=[]
-        for elem in self._capabilities.find(ns('Capability/')+ns('Request'))[:]:
+        # serviceIdentification metadata
+        subelem = self._capabilities.find(ns('Service'))
+        self.identification = ServiceIdentification(subelem)
+
+        # serviceProvider metadata
+        subelem = self._capabilities.find(ns('Service/') + ns('responsibleParty'))
+        self.provider = ServiceProvider(subelem)
+
+        # serviceOperations metadata
+        self.operations = []
+        for elem in self._capabilities.find(ns('Capability/') + ns('Request'))[:]:
             self.operations.append(OperationMetadata(elem))
-          
-        #serviceContents metadata
-        self.contents={}
-        for elem in self._capabilities.findall(ns('ContentMetadata/')+ns('CoverageOfferingBrief')): 
-            cm=ContentMetadata(elem, self)
-            self.contents[cm.id]=cm
-        
-        #Some WCS servers (wrongly) advertise 'Content' OfferingBrief instead.
-        if self.contents=={}:
-            for elem in self._capabilities.findall(ns('ContentMetadata/')+ns('ContentOfferingBrief')): 
-                cm=ContentMetadata(elem, self)
-                self.contents[cm.id]=cm
-        
-        #exceptions
-        self.exceptions = [f.text for f \
-                in self._capabilities.findall('Capability/Exception/Format')]
-    
-    
+
+        # serviceContents metadata
+        self.contents = {}
+        for elem in self._capabilities.findall(ns('ContentMetadata/') + ns('CoverageOfferingBrief')):
+            cm = ContentMetadata(elem, self)
+            self.contents[cm.id] = cm
+
+        # Some WCS servers (wrongly) advertise 'Content' OfferingBrief instead.
+        if self.contents == {}:
+            for elem in self._capabilities.findall(ns('ContentMetadata/') + ns('ContentOfferingBrief')):
+                cm = ContentMetadata(elem, self)
+                self.contents[cm.id] = cm
+
+        # exceptions
+        self.exceptions = [f.text for f
+                           in self._capabilities.findall('Capability/Exception/Format')]
+
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
-    
-    def __makeString(self,value):
-        #using repr unconditionally breaks things in some circumstances if a value is already a string
+
+    def __makeString(self, value):
+        # using repr unconditionally breaks things in some circumstances if a value is already a string
         if type(value) is not str:
-            sval=repr(value)
+            sval = repr(value)
         else:
             sval = value
         return sval
-  
-    def getCoverage(self, identifier=None, bbox=None, time=None, format = None,  crs=None, width=None, height=None, resx=None, resy=None, resz=None,parameter=None,method='Get',**kwargs):
+
+    def getCoverage(self, identifier=None, bbox=None, time=None, format=None, crs=None, width=None, height=None, resx=None, resy=None, resz=None, parameter=None, method='Get', **kwargs):
         """Request and return a coverage from the WCS as a file-like object
         note: additional **kwargs helps with multi-version implementation
         core keyword arguments should be supported cross version
@@ -106,311 +111,327 @@ class WebCoverageService_1_0_0(WCSBase):
 
         is equivalent to:
         http://myhost/mywcs?SERVICE=WCS&REQUEST=GetCoverage&IDENTIFIER=TuMYrRQ4&VERSION=1.1.0&BOUNDINGBOX=-180,-90,180,90&TIME=2792-06-01T00:00:00.0&FORMAT=cf-netcdf
-           
+
         """
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s'%(identifier, bbox, time, format, crs, width, height, resx, resy, resz, parameter, method, str(kwargs)))
-                
+            log.debug('WCS 1.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, crs, width, height, resx, resy, resz, parameter, method, str(kwargs)))
+
         base_url = self.getOperationByName('GetCoverage').methods[method]['url']
-        
+
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: base url of server: %s'%base_url)
-        
-        #process kwargs
-        request = {'version': self.version, 'request': 'GetCoverage', 'service':'WCS'}
+            log.debug('WCS 1.0.0 DEBUG: base url of server: %s' % base_url)
+
+        # process kwargs
+        request = {'version': self.version, 'request': 'GetCoverage', 'service': 'WCS'}
         assert len(identifier) > 0
-        request['Coverage']=identifier
+        request['Coverage'] = identifier
         #request['identifier'] = ','.join(identifier)
         if bbox:
-            request['BBox']=','.join([self.__makeString(x) for x in bbox])
+            request['BBox'] = ','.join([self.__makeString(x) for x in bbox])
         else:
-            request['BBox']=None
+            request['BBox'] = None
         if time:
-            request['time']=','.join(time)
+            request['time'] = ','.join(time)
         if crs:
-            request['crs']=crs
-        request['format']=format
+            request['crs'] = crs
+        request['format'] = format
         if width:
-            request['width']=width
+            request['width'] = width
         if height:
-            request['height']=height
+            request['height'] = height
         if resx:
-            request['resx']=resx
+            request['resx'] = resx
         if resy:
-            request['resy']=resy
+            request['resy'] = resy
         if resz:
-            request['resz']=resz
-        
-        #anything else e.g. vendor specific parameters must go through kwargs
+            request['resz'] = resz
+
+        # anything else e.g. vendor specific parameters must go through kwargs
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
-        
+                request[kw] = kwargs[kw]
+
         #encode and request
         data = urlencode(request)
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s'%data)
-        
-        
-        u=openURL(base_url, data, method, self.cookies)
+            log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s' % data)
+
+        u = openURL(base_url, data, method, self.cookies)
 
         return u
-    
 
-               
     def getOperationByName(self, name):
         """Return a named operation item."""
         for item in self.operations:
             if item.name == name:
                 return item
         raise KeyError, "No operation named %s" % name
-    
+
+
 class OperationMetadata(object):
-    """Abstraction for WCS metadata.   
+
+    """Abstraction for WCS metadata.
     Implements IMetadata.
     """
+
     def __init__(self, elem):
         """."""
-        self.name = elem.tag.split('}')[1]          
-        
+        self.name = elem.tag.split('}')[1]
+
         #self.formatOptions = [f.text for f in elem.findall('{http://www.opengis.net/wcs/1.1/ows}Parameter/{http://www.opengis.net/wcs/1.1/ows}AllowedValues/{http://www.opengis.net/wcs/1.1/ows}Value')]
         methods = []
-        for resource in elem.findall(ns('DCPType/')+ns('HTTP/')+ns('Get/')+ns('OnlineResource')):
+        for resource in elem.findall(ns('DCPType/') + ns('HTTP/') + ns('Get/') + ns('OnlineResource')):
             url = resource.attrib['{http://www.w3.org/1999/xlink}href']
-            methods.append(('Get', {'url': url}))        
-        for resource in elem.findall(ns('DCPType/')+ns('HTTP/')+ns('Post/')+ns('OnlineResource')):
+            methods.append(('Get', {'url': url}))
+        for resource in elem.findall(ns('DCPType/') + ns('HTTP/') + ns('Post/') + ns('OnlineResource')):
             url = resource.attrib['{http://www.w3.org/1999/xlink}href']
-            methods.append(('Post', {'url': url}))        
+            methods.append(('Post', {'url': url}))
         self.methods = dict(methods)
-            
+
+
 class ServiceIdentification(object):
+
     """ Abstraction for ServiceIdentification metadata """
-    def __init__(self,elem):
-        # properties              
-        self.type='OGC:WCS'
-        self.version='1.0.0'
+
+    def __init__(self, elem):
+        # properties
+        self.type = 'OGC:WCS'
+        self.version = '1.0.0'
         self.service = testXMLValue(elem.find(ns('name')))
         self.abstract = testXMLValue(elem.find(ns('description')))
-        self.title = testXMLValue(elem.find(ns('label')))     
-        self.keywords = [f.text for f in elem.findall(ns('keywords')+'/'+ns('keyword'))]
-        #note: differs from 'rights' in interface
-        self.fees=elem.find(ns('fees')).text
-        self.accessConstraints=elem.find(ns('accessConstraints')).text
-       
+        self.title = testXMLValue(elem.find(ns('label')))
+        self.keywords = [f.text for f in elem.findall(ns('keywords') + '/' + ns('keyword'))]
+        # note: differs from 'rights' in interface
+        self.fees = elem.find(ns('fees')).text
+        self.accessConstraints = elem.find(ns('accessConstraints')).text
+
+
 class ServiceProvider(object):
-    """ Abstraction for WCS ResponsibleParty 
+
+    """ Abstraction for WCS ResponsibleParty
     Implements IServiceProvider"""
-    def __init__(self,elem):
-        #it's not uncommon for the service provider info to be missing
-        #so handle case where None is passed in
+
+    def __init__(self, elem):
+        # it's not uncommon for the service provider info to be missing
+        # so handle case where None is passed in
         if elem is None:
-            self.name=None
-            self.url=None
+            self.name = None
+            self.url = None
             self.contact = None
         else:
-            self.name=testXMLValue(elem.find(ns('organisationName')))
-            self.url=self.name #there is no definitive place for url  WCS, repeat organisationName
-            self.contact=ContactMetadata(elem)
+            self.name = testXMLValue(elem.find(ns('organisationName')))
+            self.url = self.name  # there is no definitive place for url  WCS, repeat organisationName
+            self.contact = ContactMetadata(elem)
+
 
 class ContactMetadata(object):
+
     ''' implements IContactMetadata'''
+
     def __init__(self, elem):
         try:
             self.name = elem.find(ns('individualName')).text
         except AttributeError:
             self.name = None
         try:
-            self.organization=elem.find(ns('organisationName')).text 
+            self.organization = elem.find(ns('organisationName')).text
         except AttributeError:
             self.organization = None
         try:
-            self.address = elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('deliveryPoint')).text
+            self.address = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('deliveryPoint')).text
         except AttributeError:
             self.address = None
         try:
-            self.city= elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('city')).text
+            self.city = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('city')).text
         except AttributeError:
             self.city = None
         try:
-            self.region=elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('administrativeArea')).text
+            self.region = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('administrativeArea')).text
         except AttributeError:
             self.region = None
         try:
-            self.postcode=elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('postalCode')).text
+            self.postcode = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('postalCode')).text
         except AttributeError:
-            self.postcode=None
+            self.postcode = None
         try:
-            self.country=elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('country')).text
+            self.country = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('country')).text
         except AttributeError:
             self.country = None
         try:
-            self.email=elem.find(ns('contactInfo')+'/'+ns('address')+'/'+ns('electronicMailAddress')).text
+            self.email = elem.find(ns('contactInfo') + '/' + ns('address') + '/' + ns('electronicMailAddress')).text
         except AttributeError:
             self.email = None
 
+
 class ContentMetadata(object):
+
     """
     Implements IContentMetadata
     """
+
     def __init__(self, elem, service):
         """Initialize. service is required so that describeCoverage requests may be made"""
-        #TODO - examine the parent for bounding box info.
-        
-        #self._parent=parent
-        self._elem=elem
-        self._service=service
-        self.id=elem.find(ns('name')).text
-        self.title = testXMLValue(elem.find(ns('label')))
-        self.abstract= testXMLValue(elem.find(ns('description')))
-        self.keywords = [f.text for f in elem.findall(ns('keywords')+'/'+ns('keyword'))]        
-        self.boundingBox=None #needed for iContentMetadata harmonisation
-        self.boundingBoxWGS84 = None        
-        b = elem.find(ns('lonLatEnvelope')) 
-        if b is not None:
-            gmlpositions=b.findall('{http://www.opengis.net/gml}pos')
-            lc=gmlpositions[0].text
-            uc=gmlpositions[1].text
-            self.boundingBoxWGS84 = (
-                    float(lc.split()[0]),float(lc.split()[1]),
-                    float(uc.split()[0]), float(uc.split()[1]),
-                    )
-        #others not used but needed for iContentMetadata harmonisation
-        self.styles=None
-        self.crsOptions=None
-        self.defaulttimeposition=None
+        # TODO - examine the parent for bounding box info.
 
-    #grid is either a gml:Grid or a gml:RectifiedGrid if supplied as part of the DescribeCoverage response.
+        # self._parent=parent
+        self._elem = elem
+        self._service = service
+        self.id = elem.find(ns('name')).text
+        self.title = testXMLValue(elem.find(ns('label')))
+        self.abstract = testXMLValue(elem.find(ns('description')))
+        self.keywords = [f.text for f in elem.findall(ns('keywords') + '/' + ns('keyword'))]
+        self.boundingBox = None  # needed for iContentMetadata harmonisation
+        self.boundingBoxWGS84 = None
+        b = elem.find(ns('lonLatEnvelope'))
+        if b is not None:
+            gmlpositions = b.findall('{http://www.opengis.net/gml}pos')
+            lc = gmlpositions[0].text
+            uc = gmlpositions[1].text
+            self.boundingBoxWGS84 = (
+                float(lc.split()[0]), float(lc.split()[1]),
+                float(uc.split()[0]), float(uc.split()[1]),
+            )
+        # others not used but needed for iContentMetadata harmonisation
+        self.styles = None
+        self.crsOptions = None
+        self.defaulttimeposition = None
+
+    # grid is either a gml:Grid or a gml:RectifiedGrid if supplied as part of the DescribeCoverage response.
     def _getGrid(self):
         if not hasattr(self, 'descCov'):
-                self.descCov=self._service.getDescribeCoverage(self.id)
-        gridelem= self.descCov.find(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}RectifiedGrid')
+            self.descCov = self._service.getDescribeCoverage(self.id)
+        gridelem = self.descCov.find(ns('CoverageOffering/') + ns('domainSet/') + ns('spatialDomain/') + '{http://www.opengis.net/gml}RectifiedGrid')
         if gridelem is not None:
-            grid=RectifiedGrid(gridelem)
+            grid = RectifiedGrid(gridelem)
         else:
-            gridelem=self.descCov.find(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}Grid')
-            grid=Grid(gridelem)
+            gridelem = self.descCov.find(ns('CoverageOffering/') + ns('domainSet/') + ns('spatialDomain/') + '{http://www.opengis.net/gml}Grid')
+            grid = Grid(gridelem)
         return grid
-    grid=property(_getGrid, None)
-        
-     #timelimits are the start/end times, timepositions are all timepoints. WCS servers can declare one or both or neither of these.
+    grid = property(_getGrid, None)
+
+    # timelimits are the start/end times, timepositions are all timepoints. WCS servers can declare one or both or neither of these.
     def _getTimeLimits(self):
-        timepoints, timelimits=[],[]
-        b=self._elem.find(ns('lonLatEnvelope'))
+        timepoints, timelimits = [], []
+        b = self._elem.find(ns('lonLatEnvelope'))
         if b is not None:
-            timepoints=b.findall('{http://www.opengis.net/gml}timePosition')
+            timepoints = b.findall('{http://www.opengis.net/gml}timePosition')
         else:
-            #have to make a describeCoverage request...
+            # have to make a describeCoverage request...
             if not hasattr(self, 'descCov'):
-                self.descCov=self._service.getDescribeCoverage(self.id)
-            for pos in self.descCov.findall(ns('CoverageOffering/')+ns('domainSet/')+ns('temporalDomain/')+'{http://www.opengis.net/gml}timePosition'):
+                self.descCov = self._service.getDescribeCoverage(self.id)
+            for pos in self.descCov.findall(ns('CoverageOffering/') + ns('domainSet/') + ns('temporalDomain/') + '{http://www.opengis.net/gml}timePosition'):
                 timepoints.append(pos)
         if timepoints:
-                timelimits=[timepoints[0].text,timepoints[1].text]
+            timelimits = [timepoints[0].text, timepoints[1].text]
         return timelimits
-    timelimits=property(_getTimeLimits, None)   
-    
+    timelimits = property(_getTimeLimits, None)
+
     def _getTimePositions(self):
-        timepositions=[]
+        timepositions = []
         if not hasattr(self, 'descCov'):
-            self.descCov=self._service.getDescribeCoverage(self.id)
-        for pos in self.descCov.findall(ns('CoverageOffering/')+ns('domainSet/')+ns('temporalDomain/')+'{http://www.opengis.net/gml}timePosition'):
-                timepositions.append(pos.text)
+            self.descCov = self._service.getDescribeCoverage(self.id)
+        for pos in self.descCov.findall(ns('CoverageOffering/') + ns('domainSet/') + ns('temporalDomain/') + '{http://www.opengis.net/gml}timePosition'):
+            timepositions.append(pos.text)
         return timepositions
-    timepositions=property(_getTimePositions, None)
-           
-            
+    timepositions = property(_getTimePositions, None)
+
     def _getOtherBoundingBoxes(self):
         ''' incomplete, should return other bounding boxes not in WGS84
             #TODO: find any other bounding boxes. Need to check for gml:EnvelopeWithTimePeriod.'''
 
-        bboxes=[]
+        bboxes = []
 
         if not hasattr(self, 'descCov'):
-            self.descCov=self._service.getDescribeCoverage(self.id)
+            self.descCov = self._service.getDescribeCoverage(self.id)
 
-        for envelope in self.descCov.findall(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}Envelope'):
+        for envelope in self.descCov.findall(ns('CoverageOffering/') + ns('domainSet/') + ns('spatialDomain/') + '{http://www.opengis.net/gml}Envelope'):
             bbox = {}
             bbox['nativeSrs'] = envelope.attrib['srsName']
             gmlpositions = envelope.findall('{http://www.opengis.net/gml}pos')
-            lc=gmlpositions[0].text.split()
-            uc=gmlpositions[1].text.split()
+            lc = gmlpositions[0].text.split()
+            uc = gmlpositions[1].text.split()
             bbox['bbox'] = (
-                float(lc[0]),float(lc[1]),
+                float(lc[0]), float(lc[1]),
                 float(uc[0]), float(uc[1])
             )
             bboxes.append(bbox)
 
-        return bboxes        
-    boundingboxes=property(_getOtherBoundingBoxes,None)
-    
+        return bboxes
+    boundingboxes = property(_getOtherBoundingBoxes, None)
+
     def _getSupportedCRSProperty(self):
         # gets supported crs info
-        crss=[]
-        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/')+ns('supportedCRSs/')+ns('responseCRSs')):
+        crss = []
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/') + ns('supportedCRSs/') + ns('responseCRSs')):
             for crs in elem.text.split(' '):
                 crss.append(Crs(crs))
-        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/')+ns('supportedCRSs/')+ns('requestResponseCRSs')):
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/') + ns('supportedCRSs/') + ns('requestResponseCRSs')):
             for crs in elem.text.split(' '):
                 crss.append(Crs(crs))
-        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/')+ns('supportedCRSs/')+ns('nativeCRSs')):
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/') + ns('supportedCRSs/') + ns('nativeCRSs')):
             for crs in elem.text.split(' '):
                 crss.append(Crs(crs))
         return crss
-    supportedCRS=property(_getSupportedCRSProperty, None)
-       
-       
+    supportedCRS = property(_getSupportedCRSProperty, None)
+
     def _getSupportedFormatsProperty(self):
         # gets supported formats info
-        frmts =[]
-        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/')+ns('supportedFormats/')+ns('formats')):
+        frmts = []
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/') + ns('supportedFormats/') + ns('formats')):
             frmts.append(elem.text)
         return frmts
-    supportedFormats=property(_getSupportedFormatsProperty, None)
-    
+    supportedFormats = property(_getSupportedFormatsProperty, None)
+
     def _getAxisDescriptionsProperty(self):
-        #gets any axis descriptions contained in the rangeset (requires a DescribeCoverage call to server).
-        axisDescs =[]
-        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/')+ns('rangeSet/')+ns('RangeSet/')+ns('axisDescription/')+ns('AxisDescription')):
-            axisDescs.append(AxisDescription(elem)) #create a 'AxisDescription' object.
+        # gets any axis descriptions contained in the rangeset (requires a DescribeCoverage call to server).
+        axisDescs = []
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageOffering/') + ns('rangeSet/') + ns('RangeSet/') + ns('axisDescription/') + ns('AxisDescription')):
+            axisDescs.append(AxisDescription(elem))  # create a 'AxisDescription' object.
         return axisDescs
-    axisDescriptions=property(_getAxisDescriptionsProperty, None)
-        
-        
-          
-#Adding classes to represent gml:grid and gml:rectifiedgrid. One of these is used for the cvg.grid property
-#(where cvg is a member of the contents dictionary)     
-#There is no simple way to convert the offset values in a rectifiedgrid grid to real values without CRS understanding, therefore this is beyond the current scope of owslib, so the representation here is purely to provide access to the information in the GML.
-   
+    axisDescriptions = property(_getAxisDescriptionsProperty, None)
+
+
+# Adding classes to represent gml:grid and gml:rectifiedgrid. One of these is used for the cvg.grid property
+#(where cvg is a member of the contents dictionary)
+# There is no simple way to convert the offset values in a rectifiedgrid grid to real values without CRS understanding, therefore this is beyond the current scope of owslib, so the representation here is purely to provide access to the information in the GML.
+
 class Grid(object):
+
     ''' Simple grid class to provide axis and value information for a gml grid '''
+
     def __init__(self, grid):
         self.axislabels = []
-        self.dimension=None
-        self.lowlimits=[]
-        self.highlimits=[]
+        self.dimension = None
+        self.lowlimits = []
+        self.highlimits = []
         if grid is not None:
-            self.dimension=int(grid.get('dimension'))
-            self.lowlimits= grid.find('{http://www.opengis.net/gml}limits/{http://www.opengis.net/gml}GridEnvelope/{http://www.opengis.net/gml}low').text.split(' ')
+            self.dimension = int(grid.get('dimension'))
+            self.lowlimits = grid.find('{http://www.opengis.net/gml}limits/{http://www.opengis.net/gml}GridEnvelope/{http://www.opengis.net/gml}low').text.split(' ')
             self.highlimits = grid.find('{http://www.opengis.net/gml}limits/{http://www.opengis.net/gml}GridEnvelope/{http://www.opengis.net/gml}high').text.split(' ')
             for axis in grid.findall('{http://www.opengis.net/gml}axisName'):
                 self.axislabels.append(axis.text)
-      
+
 
 class RectifiedGrid(Grid):
+
     ''' RectifiedGrid class, extends Grid with additional offset vector information '''
+
     def __init__(self, rectifiedgrid):
-        super(RectifiedGrid,self).__init__(rectifiedgrid)
-        self.origin=rectifiedgrid.find('{http://www.opengis.net/gml}origin/{http://www.opengis.net/gml}pos').text.split()
-        self.offsetvectors=[]
+        super(RectifiedGrid, self).__init__(rectifiedgrid)
+        self.origin = rectifiedgrid.find('{http://www.opengis.net/gml}origin/{http://www.opengis.net/gml}pos').text.split()
+        self.offsetvectors = []
         for offset in rectifiedgrid.findall('{http://www.opengis.net/gml}offsetVector'):
             self.offsetvectors.append(offset.text.split())
-        
+
+
 class AxisDescription(object):
-    ''' Class to represent the AxisDescription element optionally found as part of the RangeSet and used to 
+
+    ''' Class to represent the AxisDescription element optionally found as part of the RangeSet and used to
     define ordinates of additional dimensions such as wavelength bands or pressure levels'''
+
     def __init__(self, axisdescElem):
-        self.name=self.label=None
-        self.values=[]
+        self.name = self.label = None
+        self.values = []
         for elem in axisdescElem.getchildren():
             if elem.tag == ns('name'):
                 self.name = elem.text
@@ -418,4 +439,4 @@ class AxisDescription(object):
                 self.label = elem.text
             elif elem.tag == ns('values'):
                 for child in elem.getchildren():
-                    self.values.append(child.text)     
+                    self.values.append(child.text)

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -113,11 +113,11 @@ class WebCoverageService_1_1_0(WCSBase):
         ##Could be multipart mime or XML Coverages document, need to use the decoder...
         # decoder=wcsdecoder.WCSDecoder(u)
         # x=decoder.getCoverages()
-        # if type(x) is wcsdecoder.MpartMime:
-        #     filenames=x.unpackToDir(directory)
-        #     print 'Files from 1.1.0 service written to %s directory'%(directory)
+        # if isinstance(x, wcsdecoder.MpartMime):
+        #     filenames = x.unpackToDir(directory)
+        #     print('Files from 1.1.0 service written to %s directory' % (directory))
         # else:
-        #     filenames=x
+        #     filenames = x
         # return filenames
 
     # TO DO: Handle rest of the  WCS 1.1.0 keyword parameters e.g. GridCRS etc.

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -32,7 +32,7 @@ class WebCoverageService_1_1_0(WCSBase):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -13,6 +13,7 @@
 
 import logging
 
+from six import text_type
 from six.moves.urllib.parse import urlencode
 
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
@@ -52,7 +53,7 @@ class WebCoverageService_1_1_0(WCSBase):
         se = self._capabilities.find('{http://www.opengis.net/ows/1.1}Exception')
 
         if se is not None:
-            err_message = str(se.text).strip()
+            err_message = text_type(se.text).strip()
             raise ServiceException(err_message, xml)
 
         # build metadata objects:
@@ -135,7 +136,7 @@ class WebCoverageService_1_1_0(WCSBase):
         if store = false, returns a multipart mime
         """
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, rangesubset=%s, gridbaseCRS=%s, gridtype=%s, gridCS=%s, gridorigin=%s, gridoffsets=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS, gridorigin, gridoffsets, method, str(kwargs)))
+            log.debug('WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, rangesubset=%s, gridbaseCRS=%s, gridtype=%s, gridCS=%s, gridorigin=%s, gridoffsets=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS, gridorigin, gridoffsets, method, text_type(kwargs)))
 
         if method == 'Get':
             method = '{http://www.opengis.net/wcs/1.1/ows}Get'

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -40,7 +40,7 @@ class WebCoverageService_1_1_0(WCSBase):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, xml, cookies):
         self.version = '1.1.0'
@@ -190,7 +190,7 @@ class WebCoverageService_1_1_0(WCSBase):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class Operation(object):

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -13,8 +13,10 @@
 
 import logging
 
+from six.moves.urllib.parse import urlencode
+
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
-from owslib.util import openURL, testXMLValue, urlencode, log
+from owslib.util import openURL, testXMLValue, log
 from owslib.crs import Crs
 
 

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -11,18 +11,11 @@
 
 ##########NOTE: Does not conform to new interfaces yet #################
 
-from wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
-from owslib.util import openURL, testXMLValue
-from urllib import urlencode
-from urllib2 import urlopen
-from owslib.etree import etree
-import os
-import errno
-from owslib.coverage import wcsdecoder
-from owslib.crs import Crs
-
 import logging
-from owslib.util import log
+
+from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
+from owslib.util import openURL, testXMLValue, urlencode, log
+from owslib.crs import Crs
 
 
 def ns(tag):

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <d.lowe@rl.ac.uk>
 #
 # Contact email: d.lowe@rl.ac.uk
@@ -16,32 +16,36 @@ from owslib.util import openURL, testXMLValue
 from urllib import urlencode
 from urllib2 import urlopen
 from owslib.etree import etree
-import os, errno
+import os
+import errno
 from owslib.coverage import wcsdecoder
 from owslib.crs import Crs
 
 import logging
 from owslib.util import log
 
+
 def ns(tag):
-    return '{http://www.opengis.net/wcs/1.1}'+tag
+    return '{http://www.opengis.net/wcs/1.1}' + tag
+
 
 class WebCoverageService_1_1_0(WCSBase):
+
     """Abstraction for OGC Web Coverage Service (WCS), version 1.1.0
     Implements IWebCoverageService.
     """
-    
+
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
-    
-    def __init__(self,url,xml, cookies):
-        self.version='1.1.0'
-        self.url = url   
-        self.cookies=cookies
+
+    def __init__(self, url, xml, cookies):
+        self.version = '1.1.0'
+        self.url = url
+        self.cookies = cookies
         # initialize from saved capability document or access the server
         reader = WCSCapabilitiesReader(self.version)
         if xml:
@@ -56,73 +60,73 @@ class WebCoverageService_1_1_0(WCSBase):
             err_message = str(se.text).strip()
             raise ServiceException(err_message, xml)
 
-        #build metadata objects:
-        
-        #serviceIdentification metadata
-        elem=self._capabilities.find('{http://www.opengis.net/wcs/1.1/ows}ServiceIdentification')
+        # build metadata objects:
+
+        # serviceIdentification metadata
+        elem = self._capabilities.find('{http://www.opengis.net/wcs/1.1/ows}ServiceIdentification')
         if elem is None:
-            elem=self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceIdentification')
-        self.identification=ServiceIdentification(elem)
-        
-        #serviceProvider
-        elem=self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceProvider')
-        self.provider=ServiceProvider(elem)
-                
-        #serviceOperations
+            elem = self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceIdentification')
+        self.identification = ServiceIdentification(elem)
+
+        # serviceProvider
+        elem = self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceProvider')
+        self.provider = ServiceProvider(elem)
+
+        # serviceOperations
         self.operations = []
         for elem in self._capabilities.findall('{http://www.opengis.net/wcs/1.1/ows}OperationsMetadata/{http://www.opengis.net/wcs/1.1/ows}Operation/'):
             self.operations.append(Operation(elem))
-        
+
         # exceptions - ***********TO DO *************
-            self.exceptions = [f.text for f \
-                in self._capabilities.findall('Capability/Exception/Format')]
-              
+            self.exceptions = [f.text for f
+                               in self._capabilities.findall('Capability/Exception/Format')]
+
         # serviceContents: our assumption is that services use a top-level layer
         # as a metadata organizer, nothing more.
         self.contents = {}
         top = self._capabilities.find('{http://www.opengis.net/wcs/1.1}Contents/{http://www.opengis.net/wcs/1.1}CoverageSummary')
-        for elem in self._capabilities.findall('{http://www.opengis.net/wcs/1.1}Contents/{http://www.opengis.net/wcs/1.1}CoverageSummary/{http://www.opengis.net/wcs/1.1}CoverageSummary'):                    
-            cm=ContentMetadata(elem, top, self)
-            self.contents[cm.id]=cm
-            
-        if self.contents=={}:
-            #non-hierarchical.
-            top=None
-            for elem in self._capabilities.findall('{http://www.opengis.net/wcs/1.1}Contents/{http://www.opengis.net/wcs/1.1}CoverageSummary'):     
-                cm=ContentMetadata(elem, top, self)
-                #make the describeCoverage requests to populate the supported formats/crs attributes
-                self.contents[cm.id]=cm
+        for elem in self._capabilities.findall('{http://www.opengis.net/wcs/1.1}Contents/{http://www.opengis.net/wcs/1.1}CoverageSummary/{http://www.opengis.net/wcs/1.1}CoverageSummary'):
+            cm = ContentMetadata(elem, top, self)
+            self.contents[cm.id] = cm
+
+        if self.contents == {}:
+            # non-hierarchical.
+            top = None
+            for elem in self._capabilities.findall('{http://www.opengis.net/wcs/1.1}Contents/{http://www.opengis.net/wcs/1.1}CoverageSummary'):
+                cm = ContentMetadata(elem, top, self)
+                # make the describeCoverage requests to populate the supported formats/crs attributes
+                self.contents[cm.id] = cm
 
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
-          
-    #TO DECIDE: Offer repackaging of coverageXML/Multipart MIME output?
-    #def getData(self, directory='outputdir', outputfile='coverage.nc',  **kwargs):
-        #u=self.getCoverageRequest(**kwargs)
-        ##create the directory if it doesn't exist:
-        #try:
-            #os.mkdir(directory)
-        #except OSError, e:
-            ## Ignore directory exists error
-            #if e.errno <> errno.EEXIST:
-                #raise          
+
+    # TO DECIDE: Offer repackaging of coverageXML/Multipart MIME output?
+    # def getData(self, directory='outputdir', outputfile='coverage.nc',  **kwargs):
+        # u=self.getCoverageRequest(**kwargs)
+        # create the directory if it doesn't exist:
+        # try:
+        #     os.mkdir(directory)
+        # except OSError, e:
+        #     #Ignore directory exists error
+        #     if e.errno <> errno.EEXIST:
+        #         raise
         ##elif wcs.version=='1.1.0':
         ##Could be multipart mime or XML Coverages document, need to use the decoder...
-        #decoder=wcsdecoder.WCSDecoder(u)
-        #x=decoder.getCoverages()
-        #if type(x) is wcsdecoder.MpartMime:
-            #filenames=x.unpackToDir(directory)
-            ##print 'Files from 1.1.0 service written to %s directory'%(directory)
-        #else:
-            #filenames=x
-        #return filenames
-    
-    #TO DO: Handle rest of the  WCS 1.1.0 keyword parameters e.g. GridCRS etc. 
-    def getCoverage(self, identifier=None, bbox=None, time=None, format = None, store=False, rangesubset=None, gridbaseCRS=None, gridtype=None, gridCS=None, gridorigin=None, gridoffsets=None, method='Get',**kwargs):
+        # decoder=wcsdecoder.WCSDecoder(u)
+        # x=decoder.getCoverages()
+        # if type(x) is wcsdecoder.MpartMime:
+        #     filenames=x.unpackToDir(directory)
+        #     print 'Files from 1.1.0 service written to %s directory'%(directory)
+        # else:
+        #     filenames=x
+        # return filenames
+
+    # TO DO: Handle rest of the  WCS 1.1.0 keyword parameters e.g. GridCRS etc.
+    def getCoverage(self, identifier=None, bbox=None, time=None, format=None, store=False, rangesubset=None, gridbaseCRS=None, gridtype=None, gridCS=None, gridorigin=None, gridoffsets=None, method='Get', **kwargs):
         """Request and return a coverage from the WCS as a file-like object
         note: additional **kwargs helps with multi-version implementation
         core keyword arguments should be supported cross version
@@ -131,72 +135,72 @@ class WebCoverageService_1_1_0(WCSBase):
 
         is equivalent to:
         http://myhost/mywcs?SERVICE=WCS&REQUEST=GetCoverage&IDENTIFIER=TuMYrRQ4&VERSION=1.1.0&BOUNDINGBOX=-180,-90,180,90&TIMESEQUENCE=2792-06-01T00:00:00.0&FORMAT=application/netcdf
-        
+
         if store = true, returns a coverages XML file
         if store = false, returns a multipart mime
         """
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, rangesubset=%s, gridbaseCRS=%s, gridtype=%s, gridCS=%s, gridorigin=%s, gridoffsets=%s, method=%s, other_arguments=%s'%(identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS, gridorigin, gridoffsets, method, str(kwargs)))
-        
-        
+            log.debug('WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, rangesubset=%s, gridbaseCRS=%s, gridtype=%s, gridCS=%s, gridorigin=%s, gridoffsets=%s, method=%s, other_arguments=%s' % (identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS, gridorigin, gridoffsets, method, str(kwargs)))
+
         if method == 'Get':
-            method='{http://www.opengis.net/wcs/1.1/ows}Get'
+            method = '{http://www.opengis.net/wcs/1.1/ows}Get'
         base_url = self.getOperationByName('GetCoverage').methods[method]['url']
 
-
-        #process kwargs
-        request = {'version': self.version, 'request': 'GetCoverage', 'service':'WCS'}
+        # process kwargs
+        request = {'version': self.version, 'request': 'GetCoverage', 'service': 'WCS'}
         assert len(identifier) > 0
-        request['identifier']=identifier
+        request['identifier'] = identifier
         #request['identifier'] = ','.join(identifier)
         if bbox:
-            request['boundingbox']=','.join([repr(x) for x in bbox])
+            request['boundingbox'] = ','.join([repr(x) for x in bbox])
         if time:
-            request['timesequence']=','.join(time)
-        request['format']=format
-        request['store']=store
-        
-        #rangesubset: untested - require a server implementation
+            request['timesequence'] = ','.join(time)
+        request['format'] = format
+        request['store'] = store
+
+        # rangesubset: untested - require a server implementation
         if rangesubset:
-            request['RangeSubset']=rangesubset
-        
-        #GridCRS structure: untested - require a server implementation
+            request['RangeSubset'] = rangesubset
+
+        # GridCRS structure: untested - require a server implementation
         if gridbaseCRS:
-            request['gridbaseCRS']=gridbaseCRS
+            request['gridbaseCRS'] = gridbaseCRS
         if gridtype:
-            request['gridtype']=gridtype
+            request['gridtype'] = gridtype
         if gridCS:
-            request['gridCS']=gridCS
+            request['gridCS'] = gridCS
         if gridorigin:
-            request['gridorigin']=gridorigin
+            request['gridorigin'] = gridorigin
         if gridoffsets:
-            request['gridoffsets']=gridoffsets
-       
-       #anything else e.g. vendor specific parameters must go through kwargs
+            request['gridoffsets'] = gridoffsets
+
+        # anything else e.g. vendor specific parameters must go through kwargs
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
-        
+                request[kw] = kwargs[kw]
+
         #encode and request
         data = urlencode(request)
-        
-        u=openURL(base_url, data, method, self.cookies)
+
+        u = openURL(base_url, data, method, self.cookies)
         return u
-        
-        
+
     def getOperationByName(self, name):
         """Return a named operation item."""
         for item in self.operations:
             if item.name == name:
                 return item
         raise KeyError, "No operation named %s" % name
-        
+
+
 class Operation(object):
-    """Abstraction for operation metadata    
+
+    """Abstraction for operation metadata
     Implements IOperationMetadata.
     """
+
     def __init__(self, elem):
-        self.name = elem.get('name')       
+        self.name = elem.get('name')
         self.formatOptions = [f.text for f in elem.findall('{http://www.opengis.net/wcs/1.1/ows}Parameter/{http://www.opengis.net/wcs/1.1/ows}AllowedValues/{http://www.opengis.net/wcs/1.1/ows}Value')]
         methods = []
         for verb in elem.findall('{http://www.opengis.net/wcs/1.1/ows}DCP/{http://www.opengis.net/wcs/1.1/ows}HTTP/*'):
@@ -204,192 +208,200 @@ class Operation(object):
             methods.append((verb.tag, {'url': url}))
         self.methods = dict(methods)
 
+
 class ServiceIdentification(object):
-    """ Abstraction for ServiceIdentification Metadata 
+
+    """ Abstraction for ServiceIdentification Metadata
     implements IServiceIdentificationMetadata"""
-    def __init__(self,elem):        
-        self.service="WCS"
-        self.version="1.1.0"
-        self.title=testXMLValue(elem.find('{http://www.opengis.net/ows}Title'))
-        if self.title is None:  #may have used the wcs ows namespace:
-            self.title=testXMLValue(elem.find('{http://www.opengis.net/wcs/1.1/ows}Title'))
-        
-        self.abstract=testXMLValue(elem.find('{http://www.opengis.net/ows}Abstract'))
-        if self.abstract is None:#may have used the wcs ows namespace:
-            self.abstract=testXMLValue(elem.find('{http://www.opengis.net/wcs/1.1/ows}Abstract'))
+
+    def __init__(self, elem):
+        self.service = "WCS"
+        self.version = "1.1.0"
+        self.title = testXMLValue(elem.find('{http://www.opengis.net/ows}Title'))
+        if self.title is None:  # may have used the wcs ows namespace:
+            self.title = testXMLValue(elem.find('{http://www.opengis.net/wcs/1.1/ows}Title'))
+
+        self.abstract = testXMLValue(elem.find('{http://www.opengis.net/ows}Abstract'))
+        if self.abstract is None:  # may have used the wcs ows namespace:
+            self.abstract = testXMLValue(elem.find('{http://www.opengis.net/wcs/1.1/ows}Abstract'))
         if elem.find('{http://www.opengis.net/ows}Abstract') is not None:
-            self.abstract=elem.find('{http://www.opengis.net/ows}Abstract').text
+            self.abstract = elem.find('{http://www.opengis.net/ows}Abstract').text
         else:
             self.abstract = None
         self.keywords = [f.text for f in elem.findall('{http://www.opengis.net/ows}Keywords/{http://www.opengis.net/ows}Keyword')]
         #self.link = elem.find('{http://www.opengis.net/wcs/1.1}Service/{http://www.opengis.net/wcs/1.1}OnlineResource').attrib.get('{http://www.w3.org/1999/xlink}href', '')
-               
-        if elem.find('{http://www.opengis.net/wcs/1.1/ows}Fees') is not None:            
-            self.fees=elem.find('{http://www.opengis.net/wcs/1.1/ows}Fees').text
+
+        if elem.find('{http://www.opengis.net/wcs/1.1/ows}Fees') is not None:
+            self.fees = elem.find('{http://www.opengis.net/wcs/1.1/ows}Fees').text
         else:
-            self.fees=None
-        
-        if  elem.find('{http://www.opengis.net/wcs/1.1/ows}AccessConstraints') is not None:
-            self.accessConstraints=elem.find('{http://www.opengis.net/wcs/1.1/ows}AccessConstraints').text
+            self.fees = None
+
+        if elem.find('{http://www.opengis.net/wcs/1.1/ows}AccessConstraints') is not None:
+            self.accessConstraints = elem.find('{http://www.opengis.net/wcs/1.1/ows}AccessConstraints').text
         else:
-            self.accessConstraints=None
-       
-       
+            self.accessConstraints = None
+
+
 class ServiceProvider(object):
-    """ Abstraction for ServiceProvider metadata 
+
+    """ Abstraction for ServiceProvider metadata
     implements IServiceProviderMetadata """
-    def __init__(self,elem):
-        name=elem.find('{http://www.opengis.net/ows}ProviderName')
+
+    def __init__(self, elem):
+        name = elem.find('{http://www.opengis.net/ows}ProviderName')
         if name is not None:
-            self.name=name.text
+            self.name = name.text
         else:
-            self.name=None
-        #self.contact=ServiceContact(elem.find('{http://www.opengis.net/ows}ServiceContact'))
-        self.contact =ContactMetadata(elem)
-        self.url=self.name # no obvious definitive place for url in wcs, repeat provider name?
+            self.name = None
+        # self.contact=ServiceContact(elem.find('{http://www.opengis.net/ows}ServiceContact'))
+        self.contact = ContactMetadata(elem)
+        self.url = self.name  # no obvious definitive place for url in wcs, repeat provider name?
+
 
 class ContactMetadata(object):
+
     ''' implements IContactMetadata'''
+
     def __init__(self, elem):
         try:
             self.name = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}IndividualName').text
         except AttributeError:
             self.name = None
-        
+
         try:
-            self.organization=elem.find('{http://www.opengis.net/ows}ProviderName').text 
+            self.organization = elem.find('{http://www.opengis.net/ows}ProviderName').text
         except AttributeError:
             self.organization = None
-        
+
         try:
             self.address = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}DeliveryPoint').text
         except AttributeError:
             self.address = None
         try:
-            self.city=  elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}City').text
+            self.city = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}City').text
         except AttributeError:
             self.city = None
-        
+
         try:
-            self.region= elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}AdministrativeArea').text
+            self.region = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}AdministrativeArea').text
         except AttributeError:
             self.region = None
-        
+
         try:
-            self.postcode= elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}PostalCode').text
+            self.postcode = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}PostalCode').text
         except AttributeError:
             self.postcode = None
-        
+
         try:
-            self.country= elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}Country').text
+            self.country = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}Country').text
         except AttributeError:
             self.country = None
-        
+
         try:
-            self.email =            elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}ElectronicMailAddress').text
+            self.email = elem.find('{http://www.opengis.net/ows}ServiceContact/{http://www.opengis.net/ows}ContactInfo/{http://www.opengis.net/ows}Address/{http://www.opengis.net/ows}ElectronicMailAddress').text
         except AttributeError:
             self.email = None
 
+
 class ContentMetadata(object):
+
     """Abstraction for WCS ContentMetadata
     Implements IContentMetadata
     """
+
     def __init__(self, elem, parent, service):
         """Initialize."""
-        #TODO - examine the parent for bounding box info.
-        
-        self._service=service
-        self._elem=elem
-        self._parent=parent
-        self.id=self._checkChildAndParent('{http://www.opengis.net/wcs/1.1}Identifier')
-        self.description =self._checkChildAndParent('{http://www.opengis.net/wcs/1.1}Description')           
-        self.title =self._checkChildAndParent('{http://www.opengis.net/ows}Title')
-        self.abstract =self._checkChildAndParent('{http://www.opengis.net/ows}Abstract')
-        
-        #keywords.
-        self.keywords=[]
+        # TODO - examine the parent for bounding box info.
+
+        self._service = service
+        self._elem = elem
+        self._parent = parent
+        self.id = self._checkChildAndParent('{http://www.opengis.net/wcs/1.1}Identifier')
+        self.description = self._checkChildAndParent('{http://www.opengis.net/wcs/1.1}Description')
+        self.title = self._checkChildAndParent('{http://www.opengis.net/ows}Title')
+        self.abstract = self._checkChildAndParent('{http://www.opengis.net/ows}Abstract')
+
+        # keywords.
+        self.keywords = []
         for kw in elem.findall('{http://www.opengis.net/ows}Keywords/{http://www.opengis.net/ows}Keyword'):
             if kw is not None:
                 self.keywords.append(kw.text)
-        
-        #also inherit any keywords from parent coverage summary (if there is one)
+
+        # also inherit any keywords from parent coverage summary (if there is one)
         if parent is not None:
             for kw in parent.findall('{http://www.opengis.net/ows}Keywords/{http://www.opengis.net/ows}Keyword'):
                 if kw is not None:
                     self.keywords.append(kw.text)
-            
-        self.boundingBox=None #needed for iContentMetadata harmonisation
+
+        self.boundingBox = None  # needed for iContentMetadata harmonisation
         self.boundingBoxWGS84 = None
         b = elem.find('{http://www.opengis.net/ows}WGS84BoundingBox')
         if b is not None:
-            lc=b.find('{http://www.opengis.net/ows}LowerCorner').text
-            uc=b.find('{http://www.opengis.net/ows}UpperCorner').text
+            lc = b.find('{http://www.opengis.net/ows}LowerCorner').text
+            uc = b.find('{http://www.opengis.net/ows}UpperCorner').text
             self.boundingBoxWGS84 = (
-                    float(lc.split()[0]),float(lc.split()[1]),
-                    float(uc.split()[0]), float(uc.split()[1]),
-                    )
-                
-        # bboxes - other CRS 
+                float(lc.split()[0]), float(lc.split()[1]),
+                float(uc.split()[0]), float(uc.split()[1]),
+            )
+
+        # bboxes - other CRS
         self.boundingboxes = []
         for bbox in elem.findall('{http://www.opengis.net/ows}BoundingBox'):
             if bbox is not None:
                 try:
-                    lc=b.find('{http://www.opengis.net/ows}LowerCorner').text
-                    uc=b.find('{http://www.opengis.net/ows}UpperCorner').text
-                    boundingBox =  (
-                            float(lc.split()[0]),float(lc.split()[1]),
-                            float(uc.split()[0]), float(uc.split()[1]),
-                            b.attrib['crs'])
+                    lc = b.find('{http://www.opengis.net/ows}LowerCorner').text
+                    uc = b.find('{http://www.opengis.net/ows}UpperCorner').text
+                    boundingBox = (
+                        float(lc.split()[0]), float(lc.split()[1]),
+                        float(uc.split()[0]), float(uc.split()[1]),
+                        b.attrib['crs'])
                     self.boundingboxes.append(boundingBox)
                 except:
-                     pass
+                    pass
 
-        #others not used but needed for iContentMetadata harmonisation
-        self.styles=None
-        self.crsOptions=None
-                
-        #SupportedCRS
-        self.supportedCRS=[]
+        # others not used but needed for iContentMetadata harmonisation
+        self.styles = None
+        self.crsOptions = None
+
+        # SupportedCRS
+        self.supportedCRS = []
         for crs in elem.findall('{http://www.opengis.net/wcs/1.1}SupportedCRS'):
             self.supportedCRS.append(Crs(crs.text))
-            
-            
-        #SupportedFormats         
-        self.supportedFormats=[]
+
+        # SupportedFormats
+        self.supportedFormats = []
         for format in elem.findall('{http://www.opengis.net/wcs/1.1}SupportedFormat'):
             self.supportedFormats.append(format.text)
-            
-    #grid is either a gml:Grid or a gml:RectifiedGrid if supplied as part of the DescribeCoverage response.
+
+    # grid is either a gml:Grid or a gml:RectifiedGrid if supplied as part of the DescribeCoverage response.
     def _getGrid(self):
-        grid=None
-        #TODO- convert this to 1.1 from 1.0
-        #if not hasattr(self, 'descCov'):
-                #self.descCov=self._service.getDescribeCoverage(self.id)
+        grid = None
+        # TODO- convert this to 1.1 from 1.0
+        # if not hasattr(self, 'descCov'):
+        # self.descCov=self._service.getDescribeCoverage(self.id)
         #gridelem= self.descCov.find(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}RectifiedGrid')
-        #if gridelem is not None:
-            #grid=RectifiedGrid(gridelem)
-        #else:
-            #gridelem=self.descCov.find(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}Grid')
-            #grid=Grid(gridelem)
+        # if gridelem is not None:
+        # grid=RectifiedGrid(gridelem)
+        # else:
+        # gridelem=self.descCov.find(ns('CoverageOffering/')+ns('domainSet/')+ns('spatialDomain/')+'{http://www.opengis.net/gml}Grid')
+        # grid=Grid(gridelem)
         return grid
-    grid=property(_getGrid, None)
-        
-        
-        
-    #time limits/postions require a describeCoverage request therefore only resolve when requested
+    grid = property(_getGrid, None)
+
+    # time limits/postions require a describeCoverage request therefore only resolve when requested
     def _getTimeLimits(self):
-         timelimits=[]
-         for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageDescription/')+ns('Domain/')+ns('TemporalDomain/')+ns('TimePeriod/')):
-             subelems=elem.getchildren()
-             timelimits=[subelems[0].text,subelems[1].text]
-         return timelimits
-    timelimits=property(_getTimeLimits, None)
-    
-    #TODO timepositions property
+        timelimits = []
+        for elem in self._service.getDescribeCoverage(self.id).findall(ns('CoverageDescription/') + ns('Domain/') + ns('TemporalDomain/') + ns('TimePeriod/')):
+            subelems = elem.getchildren()
+            timelimits = [subelems[0].text, subelems[1].text]
+        return timelimits
+    timelimits = property(_getTimeLimits, None)
+
+    # TODO timepositions property
     def _getTimePositions(self):
         return []
-    timepositions=property(_getTimePositions, None)
-    
+    timepositions = property(_getTimePositions, None)
+
     def _checkChildAndParent(self, path):
         ''' checks child coverage  summary, and if item not found checks higher level coverage summary'''
         try:
@@ -399,4 +411,4 @@ class ContentMetadata(object):
                 value = self._parent.find(path).text
             except:
                 value = None
-        return value  
+        return value

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <d.lowe@rl.ac.uk>
 #
 # Contact email: d.lowe@rl.ac.uk
@@ -17,6 +17,7 @@ from StringIO import StringIO
 
 
 class ServiceException(Exception):
+
     """WCS ServiceException
 
     Attributes:
@@ -31,25 +32,28 @@ class ServiceException(Exception):
     def __str__(self):
         return repr(self.message)
 
+
 class WCSBase(object):
+
     """Base class to be subclassed by version dependent WCS classes. Provides 'high-level' version independent methods"""
-    def __new__(self,url, xml, cookies):
-        """ overridden __new__ method 
-        
+
+    def __new__(self, url, xml, cookies):
+        """ overridden __new__ method
+
         @type url: string
         @param url: url of WCS capabilities document
         @type xml: string
         @param xml: elementtree object
         @return: inititalised WCSBase object
         """
-        obj=object.__new__(self)
+        obj = object.__new__(self)
         obj.__init__(url, xml, cookies)
-        self.cookies=cookies
-        self._describeCoverage = {} #cache for DescribeCoverage responses
+        self.cookies = cookies
+        self._describeCoverage = {}  # cache for DescribeCoverage responses
         return obj
-    
+
     def __init__(self):
-        pass    
+        pass
 
     def getDescribeCoverage(self, identifier):
         ''' returns a describe coverage document - checks the internal cache to see if it has been fetched before '''
@@ -57,13 +61,14 @@ class WCSBase(object):
             reader = DescribeCoverageReader(self.version, identifier, self.cookies)
             self._describeCoverage[identifier] = reader.read(self.url)
         return self._describeCoverage[identifier]
-        
-        
+
+
 class WCSCapabilitiesReader(object):
+
     """Read and parses WCS capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version=None, cookies = None):
+    def __init__(self, version=None, cookies=None):
         """Initialize
         @type version: string
         @param version: WCS Version parameter e.g '1.0.0'
@@ -108,10 +113,10 @@ class WCSCapabilitiesReader(object):
         request = self.capabilities_url(service_url)
         req = Request(request)
         if self.cookies is not None:
-            req.add_header('Cookie', self.cookies)   
+            req.add_header('Cookie', self.cookies)
         u = urlopen(req, timeout=timeout)
         return etree.fromstring(u.read())
-    
+
     def readString(self, st):
         """Parse a WCS capabilities document, returning an
         instance of WCSCapabilitiesInfoset
@@ -121,7 +126,9 @@ class WCSCapabilitiesReader(object):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
 
+
 class DescribeCoverageReader(object):
+
     """Read and parses WCS DescribeCoverage document into a lxml.etree infoset
     """
 
@@ -132,7 +139,7 @@ class DescribeCoverageReader(object):
         """
         self.version = version
         self._infoset = None
-        self.identifier=identifier
+        self.identifier = identifier
         self.cookies = cookies
 
     def descCov_url(self, service_url):
@@ -158,8 +165,8 @@ class DescribeCoverageReader(object):
             if 'coverage' not in params:
                 qs.append(('coverage', self.identifier))
         elif self.version == '1.1.0':
-            #NOTE: WCS 1.1.0 is ambigous about whether it should be identifier
-            #or identifiers (see tables 9, 10 of specification)  
+            # NOTE: WCS 1.1.0 is ambigous about whether it should be identifier
+            # or identifiers (see tables 9, 10 of specification)
             if 'identifiers' not in params:
                 qs.append(('identifiers', self.identifier))
             if 'identifier' not in params:
@@ -181,8 +188,6 @@ class DescribeCoverageReader(object):
         request = self.descCov_url(service_url)
         req = Request(request)
         if self.cookies is not None:
-            req.add_header('Cookie', self.cookies)   
+            req.add_header('Cookie', self.cookies)
         u = urlopen(req, timeout=timeout)
         return etree.fromstring(u.read())
-    
-       

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,6 +9,7 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode, parse_qsl
 from six.moves.urllib.request import urlopen, Request
 
@@ -121,8 +122,8 @@ class WCSCapabilitiesReader(object):
         instance of WCSCapabilitiesInfoset
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)
 
 

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -56,7 +56,7 @@ class WCSBase(object):
 
     def getDescribeCoverage(self, identifier):
         ''' returns a describe coverage document - checks the internal cache to see if it has been fetched before '''
-        if identifier not in self._describeCoverage.keys():
+        if identifier not in self._describeCoverage:
             reader = DescribeCoverageReader(self.version, identifier, self.cookies)
             self._describeCoverage[identifier] = reader.read(self.url)
         return self._describeCoverage[identifier]

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,9 +9,10 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
+from six.moves.urllib.parse import urlencode, parse_qsl
+from six.moves.urllib.request import urlopen, Request
 
 from owslib.etree import etree
-from owslib.util import urlencode, urlopen, Request, parse_qsl
 
 
 class ServiceException(Exception):

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,11 +9,9 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from urllib import urlencode
-from urllib2 import urlopen, Request
+
 from owslib.etree import etree
-import cgi
-from StringIO import StringIO
+from owslib.util import urlencode, urlopen, Request, parse_qsl
 
 
 class ServiceException(Exception):
@@ -86,7 +84,7 @@ class WCSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 
@@ -151,7 +149,7 @@ class DescribeCoverageReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -37,7 +37,7 @@ class WCSBase(object):
 
     """Base class to be subclassed by version dependent WCS classes. Provides 'high-level' version independent methods"""
 
-    def __new__(self, url, xml, cookies):
+    def __new__(cls, url, xml, cookies):
         """ overridden __new__ method
 
         @type url: string
@@ -46,10 +46,10 @@ class WCSBase(object):
         @param xml: elementtree object
         @return: inititalised WCSBase object
         """
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, xml, cookies)
-        self.cookies = cookies
-        self._describeCoverage = {}  # cache for DescribeCoverage responses
+        cls.cookies = cookies
+        cls._describeCoverage = {}  # cache for DescribeCoverage responses
         return obj
 
     def __init__(self):

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -23,7 +23,7 @@ from owslib.etree import etree
 class WCSDecoder(object):
 
     def __init__(self, u):
-        ''' initiate with a urllib  url object.'''
+        ''' initiate with a urllib url object.'''
         self.u = u
         self._getType()
 

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -1,83 +1,86 @@
-#WCS response decoder.
-#Decodes response from a WCS (either a Coverages XML document or a Multipart MIME) and extracts the urls of the coverage data.
-#Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
-#Author: Dominic Lowe, STFC
-#contact email: d.lowe@rl.ac.uk
+# WCS response decoder.
+# Decodes response from a WCS (either a Coverages XML document or a Multipart MIME) and extracts the urls of the coverage data.
+# Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
+# Author: Dominic Lowe, STFC
+# contact email: d.lowe@rl.ac.uk
 #
 # Multipart MIME decoding based on http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/86676
 
-#example: used in conjunction with ows lib wcs:
+# example: used in conjunction with ows lib wcs:
 
 #from owslib import wcsdecoder
 #u=wcs.getcoverage(identifier=['TuMYrRQ4'], timeSequence=['2792-06-01T00:00:00.0'], bbox=(-112,36,-106,41),format='application/netcdf', store='true')
-#decoder=wcsdecoder.WCSDecoder(u)
-#decoder.getCoverages()
+# decoder=wcsdecoder.WCSDecoder(u)
+# decoder.getCoverages()
 
 import os
 from owslib.etree import etree
 import email
 import errno
 
+
 class WCSDecoder(object):
+
     def __init__(self, u):
         ''' initiate with a urllib  url object.'''
-        self.u=u
+        self.u = u
         self._getType()
 
     def _getType(self):
         ''' determine whether it is a Multipart Mime or a Coverages XML file'''
-        
-        #what's the best way to test this? 
-        #for now read start of file
-        tempu=self.u
-        if tempu.readline()[:14] == '<?xml version=':              
-            self.urlType='XML'       
+
+        # what's the best way to test this?
+        # for now read start of file
+        tempu = self.u
+        if tempu.readline()[:14] == '<?xml version=':
+            self.urlType = 'XML'
         else:
-            self.urlType='Multipart'
-        
-      
+            self.urlType = 'Multipart'
+
     def getCoverages(self, unpackdir='./unpacked'):
-        if self.urlType=='XML': 
-            paths=[]              
+        if self.urlType == 'XML':
+            paths = []
             u_xml = self.u.read()
             u_tree = etree.fromstring(u_xml)
             for ref in u_tree.findall('{http://www.opengis.net/wcs/1.1}Coverage/{http://www.opengis.net/wcs/1.1}Reference'):
                 path = ref.attrib['{http://www.w3.org/1999/xlink}href']
-                paths.append(path)         
+                paths.append(path)
             for ref in u_tree.findall('{http://www.opengis.net/wcs/1.1.0/owcs}Coverage/{{http://www.opengis.net/wcs/1.1.0/owcs}Reference'):
                 path = ref.attrib['{http://www.w3.org/1999/xlink}href']
-                paths.append(path)         
-        elif self.urlType=='Multipart':
-            #Decode multipart mime and return fileobjects
-            u_mpart=self.u.read()
-            mpart =MpartMime(u_mpart)
-            paths= mpart.unpackToDir(unpackdir)
+                paths.append(path)
+        elif self.urlType == 'Multipart':
+            # Decode multipart mime and return fileobjects
+            u_mpart = self.u.read()
+            mpart = MpartMime(u_mpart)
+            paths = mpart.unpackToDir(unpackdir)
         return paths
 
+
 class MpartMime(object):
-    def __init__ (self,mpartmime):
+
+    def __init__(self, mpartmime):
         """ mpartmime is a multipart mime file  that has already been read in."""
-        self.mpartmime=mpartmime
-        
+        self.mpartmime = mpartmime
+
     def unpackToDir(self, unpackdir):
         """ unpacks contents of Multipart mime to a given directory"""
-        
-        names=[]
-        #create the directory if it doesn't exist:
+
+        names = []
+        # create the directory if it doesn't exist:
         try:
             os.mkdir(unpackdir)
         except OSError, e:
             # Ignore directory exists error
             if e.errno <> errno.EEXIST:
                 raise
-               
-        #now walk through the multipart mime and write out files
+
+        # now walk through the multipart mime and write out files
         msg = email.message_from_string(self.mpartmime)
-        counter =1
+        counter = 1
         for part in msg.walk():
             # multipart/* are just containers, ignore
             if part.get_content_maintype() == 'multipart':
-                continue            
+                continue
             # Applications should really check the given filename so that an
             # email message can't be used to overwrite important files
             filename = part.get_filename()
@@ -85,12 +88,12 @@ class MpartMime(object):
                 try:
                     ext = mimetypes.guess_extension(part.get_type())
                 except:
-                    ext=None
+                    ext = None
                 if not ext:
                     # Use a generic extension
                     ext = '.bin'
-                filename = 'part-%03d%s' % (counter, ext)                
-            fullpath=os.path.join(unpackdir, filename)
+                filename = 'part-%03d%s' % (counter, ext)
+            fullpath = os.path.join(unpackdir, filename)
             names.append(fullpath)
             fp = open(fullpath, 'wb')
             fp.write(part.get_payload(decode=True))

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -14,9 +14,10 @@
 # decoder.getCoverages()
 
 import os
-from owslib.etree import etree
 import email
 import errno
+
+from owslib.etree import etree
 
 
 class WCSDecoder(object):

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -69,9 +69,9 @@ class MpartMime(object):
         # create the directory if it doesn't exist:
         try:
             os.mkdir(unpackdir)
-        except OSError, e:
+        except OSError as e:
             # Ignore directory exists error
-            if e.errno <> errno.EEXIST:
+            if e.errno != errno.EEXIST:
                 raise
 
         # now walk through the multipart mime and write out files

--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -1717,7 +1717,9 @@ axisorder_yx = frozenset([
     31700
 ])
 
+
 class Crs(object):
+
     """Initialize a CRS construct
 
         :param string crs: the Coordinate reference system. Examples:
@@ -1729,6 +1731,7 @@ class Crs(object):
           * urn:ogc:def:crs:EPSG:4326
         :param string axisorder: Force / override axisorder ('xy' or 'yx')
     """
+
     def __init__(self, crs, axisorder=None):
         self.id = crs
         self.naming_authority = None
@@ -1745,7 +1748,7 @@ class Crs(object):
 
         values = self.id.split(':')
 
-        if self.id.find('/def/crs/') != -1: # URI Style 1
+        if self.id.find('/def/crs/') != -1:  # URI Style 1
             self.encoding = "uri"
             vals = self.id.split('/')
             self.authority = vals[5].upper()
@@ -1790,7 +1793,6 @@ class Crs(object):
             if self.code in axisorder_yx:
                 self.axisorder = 'yx'
 
-
     def getcode(self):
         """Create for example "EPSG:4326" string and return back
 
@@ -1808,10 +1810,10 @@ class Crs(object):
         """
 
         return 'urn:%s:def:crs:%s:%s:%s' % (
-                    (self.naming_authority and self.naming_authority or "ogc"),
-                                    (self.authority or ""),
-                                    (self.version or ""),
-                                    (self.code or ""))
+            (self.naming_authority and self.naming_authority or "ogc"),
+            (self.authority or ""),
+            (self.version or ""),
+            (self.code or ""))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -39,7 +39,7 @@ schema = 'http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd'
 schema_location = '%s %s' % (namespaces['csw'], schema)
 
 
-class CatalogueServiceWeb:
+class CatalogueServiceWeb(object):
 
     """ csw request class """
 
@@ -399,7 +399,7 @@ class CatalogueServiceWeb:
         validtransactions = ['insert', 'update', 'delete']
 
         if ttype not in validtransactions:  # invalid transaction
-            raise RuntimeError, 'Invalid transaction \'%s\'.' % ttype
+            raise RuntimeError('Invalid transaction \'%s\'.' % ttype)
 
         node1 = etree.SubElement(node0, util.nspath_eval('csw:%s' % ttype.capitalize(), namespaces))
 
@@ -408,7 +408,7 @@ class CatalogueServiceWeb:
 
         if ttype == 'insert':
             if record is None:
-                raise RuntimeError, 'Nothing to insert.'
+                raise RuntimeError('Nothing to insert.')
             node1.append(etree.fromstring(record))
 
         if ttype == 'update':
@@ -484,7 +484,7 @@ class CatalogueServiceWeb:
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
     def getService_urls(self, service_string=None):
         """
@@ -620,7 +620,7 @@ class CatalogueServiceWeb:
         ]
 
         if self._exml.getroot().tag not in valid_xpaths:
-            raise RuntimeError, 'Document is XML, but not CSW-ish'
+            raise RuntimeError('Document is XML, but not CSW-ish')
 
         # check if it's an OGC Exception
         val = self._exml.find(util.nspath_eval('ows:Exception', namespaces))

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -12,7 +12,7 @@
 import warnings
 import random
 
-from six import iteritems
+from six import iteritems, text_type, binary_type, BytesIO
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.request import urlopen
 
@@ -210,8 +210,8 @@ class CatalogueServiceWeb(object):
             node0.set('resultType', resulttype)
             node0.set('service', self.service)
             if startposition > 0:
-                node0.set('startPosition', str(startposition))
-            node0.set('maxRecords', str(maxrecords))
+                node0.set('startPosition', text_type(startposition))
+            node0.set('maxRecords', text_type(maxrecords))
             node0.set(util.nspath_eval('xsi:schemaLocation', namespaces), schema_location)
 
             node1 = etree.SubElement(node0, util.nspath_eval('csw:Query', namespaces))
@@ -267,10 +267,10 @@ class CatalogueServiceWeb(object):
             'outputFormat': format,
             'outputSchema': outputschema,
             'elementsetname': esn,
-            'id': '',
+            'id': ','.join(id),
         }
 
-        self.request = '%s%s%s' % (util.bind_url(self.url), urlencode(data), ','.join(id))
+        self.request = '%s%s' % (util.bind_url(self.url), urlencode(data))
 
         self._invoke()
 
@@ -320,8 +320,8 @@ class CatalogueServiceWeb(object):
             node0.set('service', self.service)
             node0.set('resultType', resulttype)
             if startposition > 0:
-                node0.set('startPosition', str(startposition))
-            node0.set('maxRecords', str(maxrecords))
+                node0.set('startPosition', text_type(startposition))
+            node0.set('maxRecords', text_type(maxrecords))
             node0.set(util.nspath_eval('xsi:schemaLocation', namespaces), schema_location)
 
             node1 = etree.SubElement(node0, util.nspath_eval('csw:Query', namespaces))
@@ -586,7 +586,7 @@ class CatalogueServiceWeb(object):
     def _invoke(self):
         # do HTTP request
 
-        if isinstance(self.request, basestring):  # GET KVP
+        if isinstance(self.request, (text_type, binary_type)):  # GET KVP
             self.response = urlopen(self.request, timeout=self.timeout).read()
         else:
             self.request = util.cleanup_namespaces(self.request)
@@ -604,7 +604,7 @@ class CatalogueServiceWeb(object):
             self.response = util.http_post(self.url, self.request, self.lang, self.timeout)
 
         # parse result see if it's XML
-        self._exml = etree.parse(util.StringIO(self.response))
+        self._exml = etree.parse(BytesIO(self.response))
 
         # it's XML.  Attempt to decipher whether the XML response is CSW-ish """
         valid_xpaths = [

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -30,6 +30,7 @@ from owslib.util import cleanup_namespaces, bind_url, add_namespaces
 # default variables
 outputformat = 'application/xml'
 
+
 def get_namespaces():
     n = Namespaces()
     return n.get_namespaces()
@@ -37,8 +38,11 @@ namespaces = get_namespaces()
 schema = 'http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd'
 schema_location = '%s %s' % (namespaces['csw'], schema)
 
+
 class CatalogueServiceWeb:
+
     """ csw request class """
+
     def __init__(self, url, lang='en-US', version='2.0.2', timeout=10, skip_caps=False):
         """
 
@@ -69,25 +73,25 @@ class CatalogueServiceWeb:
             data = {'service': self.service, 'version': self.version, 'request': 'GetCapabilities'}
 
             self.request = '%s%s' % (bind_url(self.url), urlencode(data))
-    
+
             self._invoke()
-    
+
             if self.exceptionreport is None:
                 # ServiceIdentification
                 val = self._exml.find(util.nspath_eval('ows:ServiceIdentification', namespaces))
-                self.identification=ows.ServiceIdentification(val,self.owscommon.namespace)
+                self.identification = ows.ServiceIdentification(val, self.owscommon.namespace)
                 # ServiceProvider
                 val = self._exml.find(util.nspath_eval('ows:ServiceProvider', namespaces))
-                self.provider=ows.ServiceProvider(val,self.owscommon.namespace)
-                # ServiceOperations metadata 
-                self.operations=[]
+                self.provider = ows.ServiceProvider(val, self.owscommon.namespace)
+                # ServiceOperations metadata
+                self.operations = []
                 for elem in self._exml.findall(util.nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
                     self.operations.append(ows.OperationsMetadata(elem, self.owscommon.namespace))
-        
+
                 # FilterCapabilities
                 val = self._exml.find(util.nspath_eval('ogc:Filter_Capabilities', namespaces))
-                self.filters=fes.FilterCapabilities(val)
- 
+                self.filters = fes.FilterCapabilities(val)
+
     def describerecord(self, typename='csw:Record', format=outputformat):
         """
 
@@ -98,7 +102,7 @@ class CatalogueServiceWeb:
 
         - typename: the typename to describe (default is 'csw:Record')
         - format: the outputFormat (default is 'application/xml')
- 
+
         """
 
         # construct request
@@ -170,7 +174,7 @@ class CatalogueServiceWeb:
         - qtype: type of resource to query (i.e. service, dataset)
         - keywords: list of keywords
         - typenames: the typeNames to query against (default is csw:Record)
-        - propertyname: the PropertyName to Filter against 
+        - propertyname: the PropertyName to Filter against
         - bbox: the bounding box of the spatial query in the form [minx,miny,maxx,maxy]
         - esn: the ElementSetName 'full', 'brief' or 'summary' (default is 'summary')
         - sortby: property to sort results on
@@ -184,7 +188,7 @@ class CatalogueServiceWeb:
 
         """
 
-        warnings.warn("""Please use the updated 'getrecords2' method instead of 'getrecords'.  
+        warnings.warn("""Please use the updated 'getrecords2' method instead of 'getrecords'.
         The 'getrecords' method will be upgraded to use the 'getrecords2' parameters
         in a future version of OWSLib.""")
 
@@ -210,24 +214,24 @@ class CatalogueServiceWeb:
                 node0.set('startPosition', str(startposition))
             node0.set('maxRecords', str(maxrecords))
             node0.set(util.nspath_eval('xsi:schemaLocation', namespaces), schema_location)
-    
+
             node1 = etree.SubElement(node0, util.nspath_eval('csw:Query', namespaces))
             node1.set('typeNames', typenames)
-        
+
             etree.SubElement(node1, util.nspath_eval('csw:ElementSetName', namespaces)).text = esn
-    
+
             self._setconstraint(node1, qtype, propertyname, keywords, bbox, cql, None)
-    
+
             if sortby is not None:
                 fes.setsortby(node1, sortby)
-    
+
             self.request = node0
 
         self._invoke()
- 
+
         if self.exceptionreport is None:
             self.results = {}
-    
+
             # process search results attributes
             val = self._exml.find(util.nspath_eval('csw:SearchResults', namespaces)).attrib.get('numberOfRecordsMatched')
             self.results['matches'] = int(util.testXMLValue(val, True))
@@ -235,7 +239,7 @@ class CatalogueServiceWeb:
             self.results['returned'] = int(util.testXMLValue(val, True))
             val = self._exml.find(util.nspath_eval('csw:SearchResults', namespaces)).attrib.get('nextRecord')
             self.results['nextrecord'] = int(util.testXMLValue(val, True))
-    
+
             # process list of matching records
             self.records = OrderedDict()
 
@@ -256,7 +260,7 @@ class CatalogueServiceWeb:
 
         """
 
-        # construct request 
+        # construct request
         data = {
             'service': self.service,
             'version': self.version,
@@ -270,7 +274,7 @@ class CatalogueServiceWeb:
         self.request = '%s%s%s' % (bind_url(self.url), urlencode(data), ','.join(id))
 
         self._invoke()
- 
+
         if self.exceptionreport is None:
             self.results = {}
             self.records = OrderedDict()
@@ -287,7 +291,7 @@ class CatalogueServiceWeb:
         - constraints: the list of constraints (OgcExpression from owslib.fes module)
         - sortby: an OGC SortBy object (SortBy from owslib.fes module)
         - typenames: the typeNames to query against (default is csw:Record)
-        - esn: the ElementSetName 'full', 'brief' or 'summary' (default is 'summary')        
+        - esn: the ElementSetName 'full', 'brief' or 'summary' (default is 'summary')
         - outputschema: the outputSchema (default is 'http://www.opengis.net/cat/csw/2.0.2')
         - format: the outputFormat (default is 'application/xml')
         - startposition: requests a slice of the result set, starting at this position (default is 0)
@@ -318,15 +322,15 @@ class CatalogueServiceWeb:
             node0.set('resultType', resulttype)
             if startposition > 0:
                 node0.set('startPosition', str(startposition))
-            node0.set('maxRecords', str(maxrecords))        
+            node0.set('maxRecords', str(maxrecords))
             node0.set(util.nspath_eval('xsi:schemaLocation', namespaces), schema_location)
 
             node1 = etree.SubElement(node0, util.nspath_eval('csw:Query', namespaces))
             node1.set('typeNames', typenames)
-        
+
             etree.SubElement(node1, util.nspath_eval('csw:ElementSetName', namespaces)).text = esn
 
-            if any([len(constraints) > 0, cql is not None]): 
+            if any([len(constraints) > 0, cql is not None]):
                 node2 = etree.SubElement(node1, util.nspath_eval('csw:Constraint', namespaces))
                 node2.set('version', '1.1.0')
                 flt = fes.FilterRequest()
@@ -335,17 +339,17 @@ class CatalogueServiceWeb:
                 # Now add a CQL filter if passed in
                 elif cql is not None:
                     etree.SubElement(node2, util.nspath_eval('csw:CqlText', namespaces)).text = cql
-                
+
             if sortby is not None and isinstance(sortby, fes.SortBy):
                 node1.append(sortby.toXML())
 
             self.request = node0
 
         self._invoke()
- 
+
         if self.exceptionreport is None:
             self.results = {}
-    
+
             # process search results attributes
             val = self._exml.find(util.nspath_eval('csw:SearchResults', namespaces)).attrib.get('numberOfRecordsMatched')
             self.results['matches'] = int(util.testXMLValue(val, True))
@@ -353,7 +357,7 @@ class CatalogueServiceWeb:
             self.results['returned'] = int(util.testXMLValue(val, True))
             val = self._exml.find(util.nspath_eval('csw:SearchResults', namespaces)).attrib.get('nextRecord')
             if val is not None:
-                 self.results['nextrecord'] = int(util.testXMLValue(val, True))
+                self.results['nextrecord'] = int(util.testXMLValue(val, True))
             else:
                 warnings.warn("""CSW Server did not supply a nextRecord value (it is optional), so the client
                 should page through the results in another way.""")
@@ -399,14 +403,14 @@ class CatalogueServiceWeb:
 
         node1 = etree.SubElement(node0, util.nspath_eval('csw:%s' % ttype.capitalize(), namespaces))
 
-        if ttype != 'update':  
+        if ttype != 'update':
             node1.set('typeName', typename)
 
         if ttype == 'insert':
             if record is None:
                 raise RuntimeError, 'Nothing to insert.'
             node1.append(etree.fromstring(record))
- 
+
         if ttype == 'update':
             if record is not None:
                 node1.append(etree.fromstring(record))
@@ -458,7 +462,7 @@ class CatalogueServiceWeb:
             etree.SubElement(node0, util.nspath_eval('csw:HarvestInterval', namespaces)).text = harvestinterval
         if responsehandler is not None:
             etree.SubElement(node0, util.nspath_eval('csw:ResponseHandler', namespaces)).text = responsehandler
-       
+
         self.request = node0
 
         self._invoke()
@@ -470,7 +474,7 @@ class CatalogueServiceWeb:
                 ts = val.attrib.get('timeStamp')
                 self.timestamp = util.testXMLValue(ts, True)
                 id = val.find(util.nspath_eval('csw:RequestId', namespaces))
-                self.id = util.testXMLValue(id) 
+                self.id = util.testXMLValue(id)
             else:
                 self._parsetransactionsummary()
                 self._parseinsertresult()
@@ -493,11 +497,11 @@ class CatalogueServiceWeb:
         - service_string: a URI to lookup
 
         """
-        
-        urls=[]
-        for key,rec in self.records.iteritems():
-            #create a generator object, and iterate through it until the match is found
-            #if not found, gets the default value (here "none")
+
+        urls = []
+        for key, rec in self.records.iteritems():
+            # create a generator object, and iterate through it until the match is found
+            # if not found, gets the default value (here "none")
             url = next((d['url'] for d in rec.references if d['scheme'] == service_string), None)
             if url is not None:
                 urls.append(url)
@@ -510,23 +514,23 @@ class CatalogueServiceWeb:
                 self.results['insertresults'].append(util.testXMLValue(j))
 
     def _parserecords(self, outputschema, esn):
-        if outputschema == namespaces['gmd']: # iso 19139
-            for i in self._exml.findall('.//'+util.nspath_eval('gmd:MD_Metadata', namespaces)):
+        if outputschema == namespaces['gmd']:  # iso 19139
+            for i in self._exml.findall('.//' + util.nspath_eval('gmd:MD_Metadata', namespaces)):
                 val = i.find(util.nspath_eval('gmd:fileIdentifier/gco:CharacterString', namespaces))
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = MD_Metadata(i)
-        elif outputschema == namespaces['fgdc']: # fgdc csdgm
+        elif outputschema == namespaces['fgdc']:  # fgdc csdgm
             for i in self._exml.findall('.//metadata'):
                 val = i.find('idinfo/datasetid')
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = Metadata(i)
-        elif outputschema == namespaces['dif']: # nasa dif
-            for i in self._exml.findall('.//'+util.nspath_eval('dif:DIF', namespaces)):
+        elif outputschema == namespaces['dif']:  # nasa dif
+            for i in self._exml.findall('.//' + util.nspath_eval('dif:DIF', namespaces)):
                 val = i.find(util.nspath_eval('dif:Entry_ID', namespaces))
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = DIF(i)
-        else: # process default
-            for i in self._exml.findall('.//'+util.nspath_eval('csw:%s' % self._setesnel(esn), namespaces)):
+        else:  # process default
+            for i in self._exml.findall('.//' + util.nspath_eval('csw:%s' % self._setesnel(esn), namespaces)):
                 val = i.find(util.nspath_eval('dc:identifier', namespaces))
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = CswRecord(i)
@@ -553,8 +557,8 @@ class CatalogueServiceWeb:
         return el
 
     def _setidentifierkey(self, el):
-        if el is None: 
-            return 'owslib_random_%i' % random.randint(1,65536)
+        if el is None:
+            return 'owslib_random_%i' % random.randint(1, 65536)
         else:
             return el
 
@@ -578,8 +582,8 @@ class CatalogueServiceWeb:
                 node1.text = cql
             else:  # construct a Filter request
                 flt = fes.FilterRequest()
-                node0.append(flt.set(qtype=qtype, keywords=keywords, propertyname=propertyname,bbox=bbox))
-    
+                node0.append(flt.set(qtype=qtype, keywords=keywords, propertyname=propertyname, bbox=bbox))
+
     def _invoke(self):
         # do HTTP request
 
@@ -625,8 +629,11 @@ class CatalogueServiceWeb:
         else:
             self.exceptionreport = None
 
+
 class CswRecord(object):
+
     """ Process csw:Record, csw:BriefRecord, csw:SummaryRecord """
+
     def __init__(self, record):
 
         if hasattr(record, 'getroot'):  # standalone document
@@ -643,7 +650,7 @@ class CswRecord(object):
             self.rdf = True
             record = rdf
 
-        # some CSWs return records with multiple identifiers based on 
+        # some CSWs return records with multiple identifiers based on
         # different schemes.  Use the first dc:identifier value to set
         # self.identifier, and set self.identifiers as a list of dicts
         val = record.find(util.nspath_eval('dc:identifier', namespaces))

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -10,12 +10,7 @@
 """ CSW request and response processor """
 
 import warnings
-import StringIO
 import random
-from urllib import urlencode
-from urllib2 import urlopen
-
-from owslib.util import OrderedDict
 
 from owslib.etree import etree
 from owslib import fes
@@ -25,7 +20,7 @@ from owslib.iso import MD_Metadata
 from owslib.fgdc import Metadata
 from owslib.dif import DIF
 from owslib.namespaces import Namespaces
-from owslib.util import cleanup_namespaces, bind_url, add_namespaces
+
 
 # default variables
 outputformat = 'application/xml'
@@ -72,7 +67,7 @@ class CatalogueServiceWeb(object):
 
             data = {'service': self.service, 'version': self.version, 'request': 'GetCapabilities'}
 
-            self.request = '%s%s' % (bind_url(self.url), urlencode(data))
+            self.request = '%s%s' % (util.bind_url(self.url), util.urlencode(data))
 
             self._invoke()
 
@@ -241,7 +236,7 @@ class CatalogueServiceWeb(object):
             self.results['nextrecord'] = int(util.testXMLValue(val, True))
 
             # process list of matching records
-            self.records = OrderedDict()
+            self.records = util.OrderedDict()
 
             self._parserecords(outputschema, esn)
 
@@ -271,13 +266,13 @@ class CatalogueServiceWeb(object):
             'id': '',
         }
 
-        self.request = '%s%s%s' % (bind_url(self.url), urlencode(data), ','.join(id))
+        self.request = '%s%s%s' % (util.bind_url(self.url), util.urlencode(data), ','.join(id))
 
         self._invoke()
 
         if self.exceptionreport is None:
             self.results = {}
-            self.records = OrderedDict()
+            self.records = util.OrderedDict()
             self._parserecords(outputschema, esn)
 
     def getrecords2(self, constraints=[], sortby=None, typenames='csw:Record', esn='summary', outputschema=namespaces['csw'], format=outputformat, startposition=0, maxrecords=10, cql=None, xml=None, resulttype='results'):
@@ -366,7 +361,7 @@ class CatalogueServiceWeb(object):
                 self.results['nextrecord'] = None
 
             # process list of matching records
-            self.records = OrderedDict()
+            self.records = util.OrderedDict()
 
             self._parserecords(outputschema, esn)
 
@@ -588,9 +583,9 @@ class CatalogueServiceWeb(object):
         # do HTTP request
 
         if isinstance(self.request, basestring):  # GET KVP
-            self.response = urlopen(self.request, timeout=self.timeout).read()
+            self.response = util.urlopen(self.request, timeout=self.timeout).read()
         else:
-            self.request = cleanup_namespaces(self.request)
+            self.request = util.cleanup_namespaces(self.request)
             # Add any namespaces used in the "typeNames" attribute of the
             # csw:Query element to the query's xml namespaces.
             for query in self.request.findall(util.nspath_eval('csw:Query', namespaces)):
@@ -598,14 +593,14 @@ class CatalogueServiceWeb(object):
                 if ns is not None:
                     # Pull out "gmd" from something like "gmd:MD_Metadata"
                     ns = ns.split(":")[0]
-                    self.request = add_namespaces(self.request, ns)
+                    self.request = util.add_namespaces(self.request, ns)
 
             self.request = util.xml2string(etree.tostring(self.request))
 
             self.response = util.http_post(self.url, self.request, self.lang, self.timeout)
 
         # parse result see if it's XML
-        self._exml = etree.parse(StringIO.StringIO(self.response))
+        self._exml = etree.parse(util.StringIO(self.response))
 
         # it's XML.  Attempt to decipher whether the XML response is CSW-ish """
         valid_xpaths = [

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -12,6 +12,7 @@
 import warnings
 import random
 
+from six import iteritems
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.request import urlopen
 
@@ -497,7 +498,7 @@ class CatalogueServiceWeb(object):
         """
 
         urls = []
-        for key, rec in self.records.iteritems():
+        for key, rec in iteritems(self.records):
             # create a generator object, and iterate through it until the match is found
             # if not found, gets the default value (here "none")
             url = next((d['url'] for d in rec.references if d['scheme'] == service_string), None)

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -12,6 +12,9 @@
 import warnings
 import random
 
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
+
 from owslib.etree import etree
 from owslib import fes
 from owslib import util
@@ -67,7 +70,7 @@ class CatalogueServiceWeb(object):
 
             data = {'service': self.service, 'version': self.version, 'request': 'GetCapabilities'}
 
-            self.request = '%s%s' % (util.bind_url(self.url), util.urlencode(data))
+            self.request = '%s%s' % (util.bind_url(self.url), urlencode(data))
 
             self._invoke()
 
@@ -266,7 +269,7 @@ class CatalogueServiceWeb(object):
             'id': '',
         }
 
-        self.request = '%s%s%s' % (util.bind_url(self.url), util.urlencode(data), ','.join(id))
+        self.request = '%s%s%s' % (util.bind_url(self.url), urlencode(data), ','.join(id))
 
         self._invoke()
 
@@ -583,7 +586,7 @@ class CatalogueServiceWeb(object):
         # do HTTP request
 
         if isinstance(self.request, basestring):  # GET KVP
-            self.response = util.urlopen(self.request, timeout=self.timeout).read()
+            self.response = urlopen(self.request, timeout=self.timeout).read()
         else:
             self.request = util.cleanup_namespaces(self.request)
             # Add any namespaces used in the "typeNames" attribute of the

--- a/owslib/dif.py
+++ b/owslib/dif.py
@@ -9,7 +9,6 @@
 
 """ DIF metadata parser """
 
-from owslib.etree import etree
 from owslib import util
 from owslib.namespaces import Namespaces
 

--- a/owslib/dif.py
+++ b/owslib/dif.py
@@ -14,6 +14,8 @@ from owslib import util
 from owslib.namespaces import Namespaces
 
 # default variables
+
+
 def get_namespaces():
     n = Namespaces()
     ns = n.get_namespaces("dif")
@@ -21,8 +23,11 @@ def get_namespaces():
     return ns
 namespaces = get_namespaces()
 
+
 class DIF(object):
+
     """ Process DIF """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Entry_ID', namespaces))
         self.identifier = util.testXMLValue(val)
@@ -42,11 +47,11 @@ class DIF(object):
         for el in md.findall(util.nspath_eval('dif:Discipline', namespaces)):
             self.discipline.append(util.testXMLValue(el))
 
-        self.parameters= []
+        self.parameters = []
         for el in md.findall(util.nspath_eval('dif:Parameters', namespaces)):
             self.parameters.append(util.testXMLValue(el))
 
-        self.iso_topic_category  = []
+        self.iso_topic_category = []
         for el in md.findall(util.nspath_eval('dif:ISO_Topic_Category', namespaces)):
             self.iso_topic_category.append(util.testXMLValue(el))
 
@@ -108,15 +113,15 @@ class DIF(object):
             self.originating_center.append(util.testXMLValue(el))
 
         self.data_center = []
-        for el in md.findall(util.nspath_eval('dif:Data_Center', namespaces)):         
+        for el in md.findall(util.nspath_eval('dif:Data_Center', namespaces)):
             self.data_center.append(Data_Center(el))
 
         self.distribution = []
-        for el in md.findall(util.nspath_eval('dif:Distribution', namespaces)):     
+        for el in md.findall(util.nspath_eval('dif:Distribution', namespaces)):
             self.distribution.append(Distribution(el))
 
         self.multimedia_sample = []
-        for el in md.findall(util.nspath_eval('dif:Multimedia_Sample', namespaces)):     
+        for el in md.findall(util.nspath_eval('dif:Multimedia_Sample', namespaces)):
             self.multimedia_sample.append(Multimedia_Sample(el))
 
         val = md.find(util.nspath_eval('dif:Reference', namespaces))
@@ -158,8 +163,11 @@ class DIF(object):
         val = md.find(util.nspath_eval('dif:Private', namespaces))
         self.private = util.testXMLValue(val)
 
+
 class Citation(object):
+
     """ Parse Data_Set_Citation """
+
     def __init__(self, el):
         val = el.find(util.nspath_eval('dif:Dataset_Creator', namespaces))
         self.creator = util.testXMLValue(val)
@@ -194,8 +202,11 @@ class Citation(object):
         val = el.find(util.nspath_eval('dif:Online_Resource', namespaces))
         self.onlineresource = util.testXMLValue(val)
 
+
 class Personnel(object):
+
     """ Process Personnel """
+
     def __init__(self, md):
         self.role = []
         for el in md.findall(util.nspath_eval('dif:Role', namespaces)):
@@ -225,8 +236,11 @@ class Personnel(object):
         val = md.find(util.nspath_eval('dif:Contact_Address', namespaces))
         self.contact_address = Contact_Address(val)
 
+
 class Contact_Address(object):
+
     """ Process Contact_Address """
+
     def __init__(self, md):
         self.address = []
         for el in md.findall(util.nspath_eval('dif:Address', namespaces)):
@@ -244,8 +258,11 @@ class Contact_Address(object):
         val = md.find(util.nspath_eval('dif:Country', namespaces))
         self.country = util.testXMLValue(val)
 
+
 class Discipline(object):
+
     """ Process Discipline """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Discipline_Name', namespaces))
         self.name = util.testXMLValue(val)
@@ -256,8 +273,11 @@ class Discipline(object):
         val = md.find(util.nspath_eval('dif:Detailed_Subdiscipline', namespaces))
         self.detailed_subdiscipline = util.testXMLValue(val)
 
+
 class Parameters(object):
+
     """ Process Parameters """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Category', namespaces))
         self.category = util.testXMLValue(val)
@@ -273,15 +293,18 @@ class Parameters(object):
 
         val = md.find(util.nspath_eval('dif:Variable_Level_2', namespaces))
         self.variable_l2 = util.testXMLValue(val)
-    
+
         val = md.find(util.nspath_eval('dif:Variable_Level_3', namespaces))
         self.variable_l3 = util.testXMLValue(val)
- 
+
         val = md.find(util.nspath_eval('dif:Detailed_Variable', namespaces))
         self.detailed_variable = util.testXMLValue(val)
 
+
 class Name(object):
+
     """ Process Sensor_Name, Source_Name, Project, IDN_Node """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Short_Name', namespaces))
         self.short_name = util.testXMLValue(val)
@@ -289,17 +312,23 @@ class Name(object):
         val = md.find(util.nspath_eval('dif:Long_Name', namespaces))
         self.long_name = util.testXMLValue(val)
 
+
 class Temporal_Coverage(object):
+
     """ Process Temporal_Coverage """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Start_Date', namespaces))
         self.start_date = util.testXMLValue(val)
-        
+
         val = md.find(util.nspath_eval('dif:End_Date', namespaces))
         self.end_date = util.testXMLValue(val)
 
+
 class Paleo_Temporal_Coverage(object):
+
     """ Process Paleo_Temporal_Coverage """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Paleo_Start_Date', namespaces))
         self.paleo_start_date = util.testXMLValue(val)
@@ -311,8 +340,11 @@ class Paleo_Temporal_Coverage(object):
         for el in md.findall(util.nspath_eval('dif:Chronostratigraphic_Unit', namespaces)):
             self.chronostratigraphic_unit.append(Chronostratigraphic_Unit(el))
 
+
 class Chronostratigraphic_Unit(object):
+
     """ Process Chronostratigraphic_Unit """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Eon', namespaces))
         self.eon = util.testXMLValue(val)
@@ -332,8 +364,11 @@ class Chronostratigraphic_Unit(object):
         val = md.find(util.nspath_eval('dif:Detailed_Classification', namespaces))
         self.detailed_classification = util.testXMLValue(val)
 
+
 class Spatial_Coverage(object):
+
     """ Process Spatial_Coverage """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Southernmost_Latitude', namespaces))
         self.miny = util.testXMLValue(val)
@@ -359,8 +394,11 @@ class Spatial_Coverage(object):
         val = md.find(util.nspath_eval('dif:Maximum_Depth', namespaces))
         self.maxdepth = util.testXMLValue(val)
 
+
 class Location(object):
+
     """ Process Location """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Location_Category', namespaces))
         self.category = util.testXMLValue(val)
@@ -380,8 +418,11 @@ class Location(object):
         val = md.find(util.nspath_eval('dif:Detailed_Location', namespaces))
         self.detailed_location = util.testXMLValue(val)
 
+
 class Data_Resolution(object):
+
     """ Process Data_Resolution"""
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Latitude_Resolution', namespaces))
         self.y = util.testXMLValue(val)
@@ -404,8 +445,11 @@ class Data_Resolution(object):
         val = md.find(util.nspath_eval('dif:Temporal_Resolution_Range', namespaces))
         self.temporal_res_range = util.testXMLValue(val)
 
+
 class Data_Center(object):
+
     """ Process Data_Center """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Data_Center_Name', namespaces))
         self.name = util.testXMLValue(val)
@@ -419,8 +463,11 @@ class Data_Center(object):
         val = md.find(util.nspath_eval('dif:Personnel', namespaces))
         self.personnel = util.testXMLValue(val)
 
+
 class Distribution(object):
+
     """ Process Distribution """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Distribution_Media', namespaces))
         self.media = util.testXMLValue(val)
@@ -434,8 +481,11 @@ class Distribution(object):
         val = md.find(util.nspath_eval('dif:Fees', namespaces))
         self.fees = util.testXMLValue(val)
 
+
 class Multimedia_Sample(object):
+
     """ Process Multimedia_Sample """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:File', namespaces))
         self.file = util.testXMLValue(val)
@@ -467,8 +517,11 @@ class Multimedia_Sample(object):
         val = md.find(util.nspath_eval('dif:Visualization_File_Size', namespaces))
         self.file_size = util.testXMLValue(val)
 
+
 class Related_URL(object):
+
     """ Process Related_URL """
+
     def __init__(self, md):
         self.content_type = []
         for el in md.findall(util.nspath_eval('dif:URL_Content_Type', namespaces)):
@@ -480,22 +533,14 @@ class Related_URL(object):
         val = md.find(util.nspath_eval('dif:Description', namespaces))
         self.description = util.testXMLValue(val)
 
+
 class URL_Content_Type(object):
+
     """ Process URL_Content_Type """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('dif:Type', namespaces))
         self.type = util.testXMLValue(val)
 
         val = md.find(util.nspath_eval('dif:SubType', namespaces))
         self.subtype = util.testXMLValue(val)
-
-
-
-
-
-
-
-
-
-
-

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -4,6 +4,8 @@
 # Contact email: sgillies@frii.com
 # =============================================================================
 
+from six import iteritems
+
 
 def patch_well_known_namespaces(etree_module):
     """Monkey patches the etree module to add some well-known namespaces."""
@@ -24,7 +26,7 @@ def patch_well_known_namespaces(etree_module):
                 pass
             warnings.warn("Only 'lxml.etree' >= 2.3 and 'xml.etree.ElementTree' >= 1.3 are fully supported!")
 
-    for k, v in ns.get_namespaces().iteritems():
+    for k, v in iteritems(ns.get_namespaces()):
         register_namespace(k, v)
 
 # try to find lxml or elementtree

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -6,12 +6,10 @@
 
 
 def patch_well_known_namespaces(etree_module):
-
+    """Monkey patches the etree module to add some well-known namespaces."""
     import warnings
     from owslib.namespaces import Namespaces
     ns = Namespaces()
-
-    """Monkey patches the etree module to add some well-known namespaces."""
 
     try:
         register_namespace = etree_module.register_namespace

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -5,8 +5,10 @@
 #
 # =============================================================================
 
+from six.moves.urllib.parse import urlencode
+
 from owslib.crs import Crs
-from owslib.util import urlencode, log
+from owslib.util import log
 
 
 class WebFeatureService_(object):

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -6,10 +6,7 @@
 # =============================================================================
 
 from owslib.crs import Crs
-
-from urllib import urlencode
-import logging
-from owslib.util import log
+from owslib.util import urlencode, log
 
 
 class WebFeatureService_(object):

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -11,15 +11,17 @@ from urllib import urlencode
 import logging
 from owslib.util import log
 
+
 class WebFeatureService_:
+
     """Base class for WebFeatureService implementations"""
 
-    def getBBOXKVP (self,bbox,typename):
+    def getBBOXKVP(self, bbox, typename):
         """Formate bounding box for KVP request type (HTTP GET)
 
         @param bbox: (minx,miny,maxx,maxy[,srs])
         @type bbox: List
-        @param typename:  feature name 
+        @param typename:  feature name
         @type typename: String
         @returns: String properly formated according to version and
             coordinate reference system
@@ -28,34 +30,34 @@ class WebFeatureService_:
 
         # srs of the bbox is specified in the bbox as fifth paramter
         if len(bbox) == 5:
-            srs = self.getSRS(bbox[4],typename[0])
+            srs = self.getSRS(bbox[4], typename[0])
         # take default srs
         else:
             srs = self.contents[typename[0]].crsOptions[0]
 
         # 1.1.0 and 2.0.0 have same encoding
-        if self.version in ["1.1.0","2.0.0"]:
+        if self.version in ["1.1.0", "2.0.0"]:
 
             # format bbox parameter
-            if srs.encoding == "urn" :
-                    if srs.axisorder == "yx":
-                        return "%s,%s,%s,%s,%s" % \
-                            (bbox[1],bbox[0],bbox[3],bbox[2],srs.getcodeurn())
-                    else:
-                        return "%s,%s,%s,%s,%s" % \
-                        (bbox[0],bbox[1],bbox[2],bbox[3],srs.getcodeurn())
+            if srs.encoding == "urn":
+                if srs.axisorder == "yx":
+                    return "%s,%s,%s,%s,%s" % \
+                        (bbox[1], bbox[0], bbox[3], bbox[2], srs.getcodeurn())
+                else:
+                    return "%s,%s,%s,%s,%s" % \
+                        (bbox[0], bbox[1], bbox[2], bbox[3], srs.getcodeurn())
             else:
                 return "%s,%s,%s,%s,%s" % \
-                        (bbox[0],bbox[1],bbox[2],bbox[3],srs.getcode())
+                    (bbox[0], bbox[1], bbox[2], bbox[3], srs.getcode())
         # 1.0.0
         else:
             return "%s,%s,%s,%s,%s" % \
-                    (bbox[0],bbox[1],bbox[2],bbox[3],srs.getcode())
+                (bbox[0], bbox[1], bbox[2], bbox[3], srs.getcode())
 
     def getSRS(self, srsname, typename):
         """Returns None or Crs object for given name
 
-        @param typename:  feature name 
+        @param typename:  feature name
         @type typename: String
         """
         if not isinstance(srsname, Crs):
@@ -75,13 +77,13 @@ class WebFeatureService_:
             return None
 
     def getGETGetFeatureRequest(self, typename=None, filter=None, bbox=None, featureid=None,
-                   featureversion=None, propertyname=None, maxfeatures=None,storedQueryID=None, storedQueryParams={},
-                   outputFormat=None, method='Get'):
+                                featureversion=None, propertyname=None, maxfeatures=None, storedQueryID=None, storedQueryParams={},
+                                outputFormat=None, method='Get'):
         """Formulate proper GetFeature request using KVP encoding
         ----------
         typename : list
             List of typenames (string)
-        filter : string 
+        filter : string
             XML-encoded OGC filter expression.
         bbox : tuple
             (left, bottom, right, top) in the feature type's coordinates == (minx, miny, maxx, maxy)
@@ -106,33 +108,33 @@ class WebFeatureService_:
         """
 
         base_url = self.getOperationByName('GetFeature').methods[method]['url']
-        base_url = base_url if base_url.endswith("?") else base_url+"?"
-            
+        base_url = base_url if base_url.endswith("?") else base_url + "?"
+
         request = {'service': 'WFS', 'version': self.version, 'request': 'GetFeature'}
-        
+
         # check featureid
         if featureid:
             request['featureid'] = ','.join(featureid)
         elif bbox:
-            request['bbox'] = self.getBBOXKVP(bbox,typename)
+            request['bbox'] = self.getBBOXKVP(bbox, typename)
         elif filter:
             request['query'] = str(filter)
         if typename:
             typename = [typename] if type(typename) == type("") else typename
             request['typename'] = ','.join(typename)
-        if propertyname: 
+        if propertyname:
             request['propertyname'] = ','.join(propertyname)
-        if featureversion: 
+        if featureversion:
             request['featureversion'] = str(featureversion)
-        if maxfeatures: 
+        if maxfeatures:
             request['maxfeatures'] = str(maxfeatures)
-        if storedQueryID: 
-            request['storedQuery_id']=str(storedQueryID)
+        if storedQueryID:
+            request['storedQuery_id'] = str(storedQueryID)
             for param in storedQueryParams:
-                request[param]=storedQueryParams[param]
+                request[param] = storedQueryParams[param]
         if outputFormat is not None:
             request["outputFormat"] = outputFormat
 
         data = urlencode(request)
 
-        return base_url+data
+        return base_url + data

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -12,7 +12,7 @@ import logging
 from owslib.util import log
 
 
-class WebFeatureService_:
+class WebFeatureService_(object):
 
     """Base class for WebFeatureService implementations"""
 
@@ -71,7 +71,7 @@ class WebFeatureService_:
             # GetCaps document (the 'id' attribute in the Crs object).
             return self.contents[typename].crsOptions[index]
         except ValueError:
-            options = ", ".join(map(lambda x: x.id, self.contents[typename].crsOptions))
+            options = ", ".join([x.id for x in self.contents[typename].crsOptions])
             log.warning("Requested srsName '%s' not available for requested typename '%s'. \
                          Options are: %s. " % (srs.getcode(), typename, options))
             return None
@@ -120,7 +120,7 @@ class WebFeatureService_:
         elif filter:
             request['query'] = str(filter)
         if typename:
-            typename = [typename] if type(typename) == type("") else typename
+            typename = [typename] if isinstance(typename, str) else typename
             request['typename'] = ','.join(typename)
         if propertyname:
             request['propertyname'] = ','.join(propertyname)

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -5,6 +5,7 @@
 #
 # =============================================================================
 
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode
 
 from owslib.crs import Crs
@@ -117,18 +118,18 @@ class WebFeatureService_(object):
         elif bbox:
             request['bbox'] = self.getBBOXKVP(bbox, typename)
         elif filter:
-            request['query'] = str(filter)
+            request['query'] = text_type(filter)
         if typename:
-            typename = [typename] if isinstance(typename, str) else typename
+            typename = [typename] if isinstance(typename, (text_type, binary_type)) else typename
             request['typename'] = ','.join(typename)
         if propertyname:
             request['propertyname'] = ','.join(propertyname)
         if featureversion:
-            request['featureversion'] = str(featureversion)
+            request['featureversion'] = text_type(featureversion)
         if maxfeatures:
-            request['maxfeatures'] = str(maxfeatures)
+            request['maxfeatures'] = text_type(maxfeatures)
         if storedQueryID:
-            request['storedQuery_id'] = str(storedQueryID)
+            request['storedQuery_id'] = text_type(storedQueryID)
             for param in storedQueryParams:
                 request[param] = storedQueryParams[param]
         if outputFormat is not None:

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -67,7 +67,7 @@ class WebFeatureService_1_0_0(object):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -6,17 +6,15 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-import cgi
-from cStringIO import StringIO
-from urllib import urlencode
-from urllib2 import urlopen
-from owslib.util import openURL, testXMLValue, extract_xml_list, ServiceException
+
+from owslib.util import (openURL, testXMLValue, extract_xml_list, ServiceException,
+                         urlopen, urlencode, parse_qsl, StringIO, log)
 from owslib.etree import etree
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata
 from owslib.crs import Crs
 from owslib.namespaces import Namespaces
-from owslib.util import log
+
 
 n = Namespaces()
 WFS_NAMESPACE = n.get_namespace("wfs")
@@ -361,7 +359,7 @@ class WFSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -6,9 +6,10 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
+from six.moves.urllib.parse import urlencode, parse_qsl
+from six.moves.urllib.request import urlopen
 
-from owslib.util import (openURL, testXMLValue, extract_xml_list, ServiceException,
-                         urlopen, urlencode, parse_qsl, StringIO, log)
+from owslib.util import openURL, testXMLValue, extract_xml_list, ServiceException, StringIO, log
 from owslib.etree import etree
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -51,7 +51,7 @@ class WebFeatureService_1_0_0(object):
     Implements IWebFeatureService.
     """
 
-    def __new__(self, url, version, xml, parse_remote_metadata=False):
+    def __new__(cls, url, version, xml, parse_remote_metadata=False):
         """ overridden __new__ method
 
         @type url: string
@@ -62,7 +62,7 @@ class WebFeatureService_1_0_0(object):
         @param parse_remote_metadata: whether to fully process MetadataURL elements
         @return: initialized WebFeatureService_1_0_0 object
         """
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, version, xml, parse_remote_metadata)
         return obj
 
@@ -71,7 +71,7 @@ class WebFeatureService_1_0_0(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, version, xml=None, parse_remote_metadata=False):
         """Initialize."""
@@ -231,7 +231,7 @@ class WebFeatureService_1_0_0(object):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class ServiceIdentification(object):
@@ -260,7 +260,7 @@ class ServiceProvider(object):
         self.keywords = extract_xml_list(self._root.find(nspath('Keywords')))
 
 
-class ContentMetadata:
+class ContentMetadata(object):
 
     """Abstraction for WFS metadata.
 
@@ -321,13 +321,13 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] == 'TC211':
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception as err:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)
 
 
-class OperationMetadata:
+class OperationMetadata(object):
 
     """Abstraction for WFS metadata.
 

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -22,17 +22,21 @@ from owslib.feature import WebFeatureService_
 from owslib.namespaces import Namespaces
 from owslib.util import log
 
+
 def get_namespaces():
     n = Namespaces()
-    return n.get_namespaces(["gml","ogc","ows","wfs"])
+    return n.get_namespaces(["gml", "ogc", "ows", "wfs"])
 namespaces = get_namespaces()
 
+
 class WebFeatureService_1_1_0(WebFeatureService_):
+
     """Abstraction for OGC Web Feature Service (WFS).
 
     Implements IWebFeatureService.
     """
-    def __new__(self,url, version, xml, parse_remote_metadata=False):
+
+    def __new__(self, url, version, xml, parse_remote_metadata=False):
         """ overridden __new__ method
 
         @type url: string
@@ -43,17 +47,16 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         @param parse_remote_metadata: whether to fully process MetadataURL elements
         @return: initialized WebFeatureService_1_1_0 object
         """
-        obj=object.__new__(self)
+        obj = object.__new__(self)
         obj.__init__(url, version, xml, parse_remote_metadata)
         return obj
 
-    def __getitem__(self,name):
+    def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
-
 
     def __init__(self, url, version, xml=None, parse_remote_metadata=False):
         """Initialize."""
@@ -73,31 +76,31 @@ class WebFeatureService_1_1_0(WebFeatureService_):
 
         # ServiceIdentification
         val = self._capabilities.find(util.nspath_eval('ows:ServiceIdentification', namespaces))
-        self.identification=ServiceIdentification(val,self.owscommon.namespace)
+        self.identification = ServiceIdentification(val, self.owscommon.namespace)
         # ServiceProvider
         val = self._capabilities.find(util.nspath_eval('ows:ServiceProvider', namespaces))
-        self.provider=ServiceProvider(val,self.owscommon.namespace)
+        self.provider = ServiceProvider(val, self.owscommon.namespace)
         # ServiceOperations metadata
-        self.operations=[]
+        self.operations = []
         for elem in self._capabilities.findall(util.nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
             self.operations.append(OperationsMetadata(elem, self.owscommon.namespace))
 
         # FilterCapabilities
         val = self._capabilities.find(util.nspath_eval('ogc:Filter_Capabilities', namespaces))
-        self.filters=FilterCapabilities(val)
+        self.filters = FilterCapabilities(val)
 
-        #serviceContents metadata: our assumption is that services use a top-level
-        #layer as a metadata organizer, nothing more.
+        # serviceContents metadata: our assumption is that services use a top-level
+        # layer as a metadata organizer, nothing more.
 
-        self.contents={}
+        self.contents = {}
         features = self._capabilities.findall(nspath_eval('wfs:FeatureTypeList/wfs:FeatureType', namespaces))
         for feature in features:
-            cm=ContentMetadata(feature, parse_remote_metadata)
-            self.contents[cm.id]=cm
+            cm = ContentMetadata(feature, parse_remote_metadata)
+            self.contents[cm.id] = cm
 
-        #exceptions
-        self.exceptions = [f.text for f \
-                in self._capabilities.findall('Capability/Exception/Format')]
+        # exceptions
+        self.exceptions = [f.text for f
+                           in self._capabilities.findall('Capability/Exception/Format')]
 
     def getcapabilities(self, timeout=30):
         """Request and return capabilities document from the WFS as a
@@ -108,9 +111,9 @@ class WebFeatureService_1_1_0(WebFeatureService_):
 
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
 
     def getfeature(self, typename=None, filter=None, bbox=None, featureid=None,
@@ -237,8 +240,8 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         raise KeyError, "No operation named %s" % name
 
 
-
 class ContentMetadata:
+
     """Abstraction for WFS metadata.
 
     Implements IMetadata.
@@ -256,9 +259,9 @@ class ContentMetadata:
         b = BoundingBox(elem.find(nspath_eval('ows:WGS84BoundingBox', namespaces)), namespaces['ows'])
         if b is not None:
             self.boundingBoxWGS84 = (
-                    float(b.minx), float(b.miny),
-                    float(b.maxx), float(b.maxy),
-                    )
+                float(b.minx), float(b.miny),
+                float(b.maxx), float(b.maxy),
+            )
         # crs options
         self.crsOptions = [Crs(srs.text) for srs in elem.findall(nspath_eval('wfs:OtherSRS', namespaces))]
         dsrs = testXMLValue(elem.find(nspath_eval('wfs:DefaultSRS', namespaces)))
@@ -294,12 +297,14 @@ class ContentMetadata:
 
             self.metadataUrls.append(metadataUrl)
 
-        #others not used but needed for iContentMetadata harmonisation
-        self.styles=None
-        self.timepositions=None
-        self.defaulttimeposition=None
+        # others not used but needed for iContentMetadata harmonisation
+        self.styles = None
+        self.timepositions = None
+        self.defaulttimeposition = None
+
 
 class WFSCapabilitiesReader(object):
+
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
@@ -351,4 +356,3 @@ class WFSCapabilitiesReader(object):
         if not isinstance(st, str):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
-

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -51,7 +51,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,20 +7,16 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-import cgi
-from cStringIO import StringIO
-from urllib import urlencode
-from urllib2 import urlopen
-from owslib.util import openURL, testXMLValue, nspath_eval, ServiceException
+from owslib.util import (openURL, testXMLValue, nspath_eval, ServiceException,
+                         urlencode, urlopen, parse_qsl, StringIO, log)
 from owslib.etree import etree
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata
-from owslib.ows import *
-from owslib.fes import *
+from owslib.ows import OwsCommon, ServiceIdentification, ServiceProvider, OperationsMetadata, BoundingBox
+from owslib.fes import FilterCapabilities
 from owslib.crs import Crs
 from owslib.feature import WebFeatureService_
 from owslib.namespaces import Namespaces
-from owslib.util import log
 
 
 def get_namespaces():
@@ -75,18 +71,18 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         '''set up capabilities metadata objects: '''
 
         # ServiceIdentification
-        val = self._capabilities.find(util.nspath_eval('ows:ServiceIdentification', namespaces))
+        val = self._capabilities.find(nspath_eval('ows:ServiceIdentification', namespaces))
         self.identification = ServiceIdentification(val, self.owscommon.namespace)
         # ServiceProvider
-        val = self._capabilities.find(util.nspath_eval('ows:ServiceProvider', namespaces))
+        val = self._capabilities.find(nspath_eval('ows:ServiceProvider', namespaces))
         self.provider = ServiceProvider(val, self.owscommon.namespace)
         # ServiceOperations metadata
         self.operations = []
-        for elem in self._capabilities.findall(util.nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
+        for elem in self._capabilities.findall(nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
             self.operations.append(OperationsMetadata(elem, self.owscommon.namespace))
 
         # FilterCapabilities
-        val = self._capabilities.find(util.nspath_eval('ogc:Filter_Capabilities', namespaces))
+        val = self._capabilities.find(nspath_eval('ogc:Filter_Capabilities', namespaces))
         self.filters = FilterCapabilities(val)
 
         # serviceContents metadata: our assumption is that services use a top-level
@@ -318,7 +314,7 @@ class WFSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,8 +7,10 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-from owslib.util import (openURL, testXMLValue, nspath_eval, ServiceException,
-                         urlencode, urlopen, parse_qsl, StringIO, log)
+from six.moves.urllib.parse import urlencode, parse_qsl
+from six.moves.urllib.request import urlopen
+
+from owslib.util import openURL, testXMLValue, nspath_eval, ServiceException, StringIO, log
 from owslib.etree import etree
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -36,7 +36,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
     Implements IWebFeatureService.
     """
 
-    def __new__(self, url, version, xml, parse_remote_metadata=False):
+    def __new__(cls, url, version, xml, parse_remote_metadata=False):
         """ overridden __new__ method
 
         @type url: string
@@ -47,7 +47,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         @param parse_remote_metadata: whether to fully process MetadataURL elements
         @return: initialized WebFeatureService_1_1_0 object
         """
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, version, xml, parse_remote_metadata)
         return obj
 
@@ -56,7 +56,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, version, xml=None, parse_remote_metadata=False):
         """Initialize."""
@@ -165,7 +165,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
                 if srsnameobj is not None:
                     request['srsname'] = srsnameobj.id
                 else:
-                    options = ", ".join(map(lambda x: x.id, self.contents[typename[0]].crsOptions))
+                    options = ", ".join([x.id for x in self.contents[typename[0]].crsOptions])
                     raise ServiceException("SRSNAME %s not supported.  Options: %s" % (srsname, options))
             else:
                 request['srsname'] = str(srsname)
@@ -237,10 +237,10 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
-class ContentMetadata:
+class ContentMetadata(object):
 
     """Abstraction for WFS metadata.
 
@@ -292,7 +292,7 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] in ['TC211', '19115', '19139']:
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception as err:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -6,22 +6,17 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-# owslib imports:
+import logging
+
+from owslib.fgdc import Metadata
+from owslib.iso import MD_Metadata
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata
 from owslib.etree import etree
-from owslib.util import nspath, testXMLValue
+from owslib.util import nspath, testXMLValue, urlencode, urlopen, parse_qsl, StringIO, log
 from owslib.crs import Crs
 from owslib.feature import WebFeatureService_
 from owslib.namespaces import Namespaces
 
-# other imports
-import cgi
-from cStringIO import StringIO
-from urllib import urlencode
-from urllib2 import urlopen
-
-import logging
-from owslib.util import log
 
 n = Namespaces()
 WFS_NAMESPACE = n.get_namespace("wfs20")
@@ -376,7 +371,7 @@ class ContentMetadata(object):
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urllib2.urlopen(metadataUrl['url'], timeout=timeout)
+                    content = urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     try:  # FGDC
                         metadataUrl['metadata'] = Metadata(doc)
@@ -403,7 +398,7 @@ class WFSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -57,7 +57,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)
@@ -226,7 +226,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         if typename:
             request['typename'] = str(typename)
         if kwargs:
-            for kw in kwargs.keys():
+            for kw in kwargs:
                 request[kw] = str(kwargs[kw])
         encoded_request = urlencode(request)
         u = urlopen(base_url + encoded_request)
@@ -276,7 +276,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             tempdict2[id] = (abstract, params)  # store in another temporary dictionary
 
         # now group the results into StoredQuery objects:
-        for key in tempdict.keys():
+        for key in tempdict:
             abstract = 'blah'
             parameters = []
             sqs.append(StoredQuery(key, tempdict[key][0], tempdict[key][1], tempdict2[key][0], tempdict2[key][1]))

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -8,11 +8,14 @@
 
 import logging
 
+from six.moves.urllib.parse import urlencode, parse_qsl
+from six.moves.urllib.request import urlopen
+
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata
 from owslib.etree import etree
-from owslib.util import nspath, testXMLValue, urlencode, urlopen, parse_qsl, StringIO, log
+from owslib.util import nspath, testXMLValue, StringIO, log
 from owslib.crs import Crs
 from owslib.feature import WebFeatureService_
 from owslib.namespaces import Namespaces

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -6,7 +6,7 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-#owslib imports:
+# owslib imports:
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata
 from owslib.etree import etree
 from owslib.util import nspath, testXMLValue
@@ -14,7 +14,7 @@ from owslib.crs import Crs
 from owslib.feature import WebFeatureService_
 from owslib.namespaces import Namespaces
 
-#other imports
+# other imports
 import cgi
 from cStringIO import StringIO
 from urllib import urlencode
@@ -36,13 +36,15 @@ class ServiceException(Exception):
 
 
 class WebFeatureService_2_0_0(WebFeatureService_):
+
     """Abstraction for OGC Web Feature Service (WFS).
 
     Implements IWebFeatureService.
     """
-    def __new__(self,url, version, xml, parse_remote_metadata=False):
-        """ overridden __new__ method 
-        
+
+    def __new__(self, url, version, xml, parse_remote_metadata=False):
+        """ overridden __new__ method
+
         @type url: string
         @param url: url of WFS capabilities document
         @type xml: string
@@ -51,22 +53,21 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         @param parse_remote_metadata: whether to fully process MetadataURL elements
         @return: initialized WebFeatureService_2_0_0 object
         """
-        obj=object.__new__(self)
+        obj = object.__new__(self)
         obj.__init__(url, version, xml, parse_remote_metadata)
         return obj
-    
-    def __getitem__(self,name):
+
+    def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
-    
-    
-    def __init__(self, url,  version, xml=None, parse_remote_metadata=False):
+
+    def __init__(self, url, version, xml=None, parse_remote_metadata=False):
         """Initialize."""
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('building WFS %s'%url)
+            log.debug('building WFS %s' % url)
         self.url = url
         self.version = version
         self._capabilities = None
@@ -76,65 +77,64 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         else:
             self._capabilities = reader.read(self.url)
         self._buildMetadata(parse_remote_metadata)
-    
+
     def _buildMetadata(self, parse_remote_metadata=False):
         '''set up capabilities metadata objects: '''
-        
-        #serviceIdentification metadata
-        serviceidentelem=self._capabilities.find(nspath('ServiceIdentification'))
-        self.identification=ServiceIdentification(serviceidentelem)  
-        #need to add to keywords list from featuretypelist information:
-        featuretypelistelem=self._capabilities.find(nspath('FeatureTypeList', ns=WFS_NAMESPACE))
-        featuretypeelems=featuretypelistelem.findall(nspath('FeatureType', ns=WFS_NAMESPACE))
-        for f in featuretypeelems:  
-            kwds=f.findall(nspath('Keywords/Keyword',ns=OWS_NAMESPACE))
+
+        # serviceIdentification metadata
+        serviceidentelem = self._capabilities.find(nspath('ServiceIdentification'))
+        self.identification = ServiceIdentification(serviceidentelem)
+        # need to add to keywords list from featuretypelist information:
+        featuretypelistelem = self._capabilities.find(nspath('FeatureTypeList', ns=WFS_NAMESPACE))
+        featuretypeelems = featuretypelistelem.findall(nspath('FeatureType', ns=WFS_NAMESPACE))
+        for f in featuretypeelems:
+            kwds = f.findall(nspath('Keywords/Keyword', ns=OWS_NAMESPACE))
             if kwds is not None:
                 for kwd in kwds[:]:
                     if kwd.text not in self.identification.keywords:
                         self.identification.keywords.append(kwd.text)
-	
-   
-        #TODO: update serviceProvider metadata, miss it out for now
-        serviceproviderelem=self._capabilities.find(nspath('ServiceProvider'))
-        self.provider=ServiceProvider(serviceproviderelem)   
-        
-        #serviceOperations metadata 
-        self.operations=[]
-        
+
+        # TODO: update serviceProvider metadata, miss it out for now
+        serviceproviderelem = self._capabilities.find(nspath('ServiceProvider'))
+        self.provider = ServiceProvider(serviceproviderelem)
+
+        # serviceOperations metadata
+        self.operations = []
+
         for elem in self._capabilities.find(nspath('OperationsMetadata'))[:]:
-            if elem.tag !=nspath('ExtendedCapabilities'):
+            if elem.tag != nspath('ExtendedCapabilities'):
                 self.operations.append(OperationsMetadata(elem))
-                   
-        #serviceContents metadata: our assumption is that services use a top-level 
-        #layer as a metadata organizer, nothing more. 
-        
-        self.contents={} 
-        featuretypelist=self._capabilities.find(nspath('FeatureTypeList',ns=WFS_NAMESPACE))
+
+        # serviceContents metadata: our assumption is that services use a top-level
+        # layer as a metadata organizer, nothing more.
+
+        self.contents = {}
+        featuretypelist = self._capabilities.find(nspath('FeatureTypeList', ns=WFS_NAMESPACE))
         features = self._capabilities.findall(nspath('FeatureTypeList/FeatureType', ns=WFS_NAMESPACE))
         for feature in features:
-            cm=ContentMetadata(feature, featuretypelist, parse_remote_metadata)
-            self.contents[cm.id]=cm       
-        
-        #exceptions
-        self.exceptions = [f.text for f \
-                in self._capabilities.findall('Capability/Exception/Format')]
-      
+            cm = ContentMetadata(feature, featuretypelist, parse_remote_metadata)
+            self.contents[cm.id] = cm
+
+        # exceptions
+        self.exceptions = [f.text for f
+                           in self._capabilities.findall('Capability/Exception/Format')]
+
     def getcapabilities(self, timeout=30):
-        """Request and return capabilities document from the WFS as a 
+        """Request and return capabilities document from the WFS as a
         file-like object.
         NOTE: this is effectively redundant now"""
         reader = WFSCapabilitiesReader(self.version)
         return urlopen(reader.capabilities_url(self.url), timeout=timeout)
-    
+
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
-    
+
     def getfeature(self, typename=None, filter=None, bbox=None, featureid=None,
-                   featureversion=None, propertyname=None, maxfeatures=None,storedQueryID=None, storedQueryParams={},
+                   featureversion=None, propertyname=None, maxfeatures=None, storedQueryID=None, storedQueryParams={},
                    method='Get', timeout=30, outputFormat=None):
         """Request and return feature data as a file-like object.
         #TODO: NOTE: have changed property name from ['*'] to None - check the use of this in WFS 2.0
@@ -142,7 +142,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         ----------
         typename : list
             List of typenames (string)
-        filter : string 
+        filter : string
             XML-encoded OGC filter expression.
         bbox : tuple
             (left, bottom, right, top) in the feature type's coordinates == (minx, miny, maxx, maxy)
@@ -177,14 +177,13 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                                                  maxfeatures, storedQueryID,
                                                  storedQueryParams, outputFormat)
             if log.isEnabledFor(logging.DEBUG):
-                log.debug('GetFeature WFS GET url %s'% url)
+                log.debug('GetFeature WFS GET url %s' % url)
         else:
-            (url,data) = self.getPOSTGetFeatureRequest()
-
+            (url, data) = self.getPOSTGetFeatureRequest()
 
         # If method is 'Post', data will be None here
         u = urlopen(url, data, timeout)
-        
+
         # check for service exceptions, rewrap, and return
         # We're going to assume that anything with a content-length > 32k
         # is data. We'll check anything smaller.
@@ -195,7 +194,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             data = u.read()
             have_read = True
             length = len(data)
-     
+
         if length < 32000:
             if not have_read:
                 data = u.read()
@@ -216,74 +215,72 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 return StringIO(data)
             return u
 
-
-    def getpropertyvalue(self, query=None, storedquery_id=None, valuereference=None, typename=None, method=nspath('Get'),**kwargs):
-        ''' the WFS GetPropertyValue method'''         
+    def getpropertyvalue(self, query=None, storedquery_id=None, valuereference=None, typename=None, method=nspath('Get'), **kwargs):
+        ''' the WFS GetPropertyValue method'''
         base_url = self.getOperationByName('GetPropertyValue').methods[method]['url']
         request = {'service': 'WFS', 'version': self.version, 'request': 'GetPropertyValue'}
         if query:
             request['query'] = str(query)
-        if valuereference: 
+        if valuereference:
             request['valueReference'] = str(valuereference)
-        if storedquery_id: 
+        if storedquery_id:
             request['storedQuery_id'] = str(storedquery_id)
         if typename:
-            request['typename']=str(typename)
+            request['typename'] = str(typename)
         if kwargs:
             for kw in kwargs.keys():
-                request[kw]=str(kwargs[kw])
-        encoded_request=urlencode(request)
+                request[kw] = str(kwargs[kw])
+        encoded_request = urlencode(request)
         u = urlopen(base_url + encoded_request)
         return u.read()
-        
-        
+
     def _getStoredQueries(self, timeout=30):
         ''' gets descriptions of the stored queries available on the server '''
-        sqs=[]
-        #This method makes two calls to the WFS - one ListStoredQueries, and one DescribeStoredQueries. The information is then
-        #aggregated in 'StoredQuery' objects
-        method=nspath('Get')
-        
-        #first make the ListStoredQueries response and save the results in a dictionary if form {storedqueryid:(title, returnfeaturetype)}
+        sqs = []
+        # This method makes two calls to the WFS - one ListStoredQueries, and one DescribeStoredQueries. The information is then
+        # aggregated in 'StoredQuery' objects
+        method = nspath('Get')
+
+        # first make the ListStoredQueries response and save the results in a dictionary if form {storedqueryid:(title, returnfeaturetype)}
         base_url = self.getOperationByName('ListStoredQueries').methods[method]['url']
         request = {'service': 'WFS', 'version': self.version, 'request': 'ListStoredQueries'}
         encoded_request = urlencode(request)
         u = urlopen(base_url + encoded_request, timeout=timeout)
-        tree=etree.fromstring(u.read())
+        tree = etree.fromstring(u.read())
         base_url = self.getOperationByName('ListStoredQueries').methods[method]['url']
-        tempdict={}       
+        tempdict = {}
         for sqelem in tree[:]:
-            title=rft=id=None
-            id=sqelem.get('id')
+            title = rft = id = None
+            id = sqelem.get('id')
             for elem in sqelem[:]:
-                if elem.tag==nspath('Title', WFS_NAMESPACE):
-                    title=elem.text
-                elif elem.tag==nspath('ReturnFeatureType', WFS_NAMESPACE):
-                    rft=elem.text
-            tempdict[id]=(title,rft)        #store in temporary dictionary
-        
-        #then make the DescribeStoredQueries request and get the rest of the information about the stored queries 
+                if elem.tag == nspath('Title', WFS_NAMESPACE):
+                    title = elem.text
+                elif elem.tag == nspath('ReturnFeatureType', WFS_NAMESPACE):
+                    rft = elem.text
+            tempdict[id] = (title, rft)  # store in temporary dictionary
+
+        # then make the DescribeStoredQueries request and get the rest of the information about the stored queries
         base_url = self.getOperationByName('DescribeStoredQueries').methods[method]['url']
         request = {'service': 'WFS', 'version': self.version, 'request': 'DescribeStoredQueries'}
         encoded_request = urlencode(request)
         u = urlopen(base_url + encoded_request, timeout=timeout)
-        tree=etree.fromstring(u.read())
-        tempdict2={} 
+        tree = etree.fromstring(u.read())
+        tempdict2 = {}
         for sqelem in tree[:]:
-            params=[] #list to store parameters for the stored query description
-            id =sqelem.get('id')
+            params = []  # list to store parameters for the stored query description
+            id = sqelem.get('id')
             for elem in sqelem[:]:
-                if elem.tag==nspath('Abstract', WFS_NAMESPACE):
-                    abstract=elem.text
-                elif elem.tag==nspath('Parameter', WFS_NAMESPACE):
-                    newparam=Parameter(elem.get('name'), elem.get('type'))
+                if elem.tag == nspath('Abstract', WFS_NAMESPACE):
+                    abstract = elem.text
+                elif elem.tag == nspath('Parameter', WFS_NAMESPACE):
+                    newparam = Parameter(elem.get('name'), elem.get('type'))
                     params.append(newparam)
-            tempdict2[id]=(abstract, params) #store in another temporary dictionary
-        
-        #now group the results into StoredQuery objects:
-        for key in tempdict.keys(): 
-            abstract='blah'
-            parameters=[]
+            tempdict2[id] = (abstract, params)  # store in another temporary dictionary
+
+        # now group the results into StoredQuery objects:
+        for key in tempdict.keys():
+            abstract = 'blah'
+            parameters = []
             sqs.append(StoredQuery(key, tempdict[key][0], tempdict[key][1], tempdict2[key][0], tempdict2[key][1]))
         return sqs
     storedqueries = property(_getStoredQueries, None)
@@ -295,47 +292,53 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 return item
         raise KeyError, "No operation named %s" % name
 
+
 class StoredQuery(object):
+
     '''' Class to describe a storedquery '''
+
     def __init__(self, id, title, returntype, abstract, parameters):
-        self.id=id
-        self.title=title
-        self.returnfeaturetype=returntype
-        self.abstract=abstract
-        self.parameters=parameters
-        
+        self.id = id
+        self.title = title
+        self.returnfeaturetype = returntype
+        self.abstract = abstract
+        self.parameters = parameters
+
+
 class Parameter(object):
+
     def __init__(self, name, type):
-        self.name=name
-        self.type=type
-        
-    
+        self.name = name
+        self.type = type
+
+
 class ContentMetadata:
+
     """Abstraction for WFS metadata.
-    
+
     Implements IMetadata.
     """
 
     def __init__(self, elem, parent, parse_remote_metadata=False, timeout=30):
         """."""
-        self.id = elem.find(nspath('Name',ns=WFS_NAMESPACE)).text
-        self.title = elem.find(nspath('Title',ns=WFS_NAMESPACE)).text
-        abstract = elem.find(nspath('Abstract',ns=WFS_NAMESPACE))
+        self.id = elem.find(nspath('Name', ns=WFS_NAMESPACE)).text
+        self.title = elem.find(nspath('Title', ns=WFS_NAMESPACE)).text
+        abstract = elem.find(nspath('Abstract', ns=WFS_NAMESPACE))
         if abstract is not None:
             self.abstract = abstract.text
         else:
             self.abstract = None
-        self.keywords = [f.text for f in elem.findall(nspath('Keywords',ns=WFS_NAMESPACE))]
+        self.keywords = [f.text for f in elem.findall(nspath('Keywords', ns=WFS_NAMESPACE))]
 
         # bboxes
         self.boundingBoxWGS84 = None
-        b = elem.find(nspath('WGS84BoundingBox',ns=OWS_NAMESPACE))
+        b = elem.find(nspath('WGS84BoundingBox', ns=OWS_NAMESPACE))
         if b is not None:
-            lc = b.find(nspath("LowerCorner",ns=OWS_NAMESPACE))
-            uc = b.find(nspath("UpperCorner",ns=OWS_NAMESPACE))
+            lc = b.find(nspath("LowerCorner", ns=OWS_NAMESPACE))
+            uc = b.find(nspath("UpperCorner", ns=OWS_NAMESPACE))
             ll = [float(s) for s in lc.text.split()]
             ur = [float(s) for s in uc.text.split()]
-            self.boundingBoxWGS84 = (ll[0],ll[1],ur[0],ur[1])
+            self.boundingBoxWGS84 = (ll[0], ll[1], ur[0], ur[1])
 
         # there is no such think as bounding box
         # make copy of the WGS84BoundingBox
@@ -345,23 +348,22 @@ class ContentMetadata:
                             self.boundingBoxWGS84[3],
                             Crs("epsg:4326"))
         # crs options
-        self.crsOptions = [Crs(srs.text) for srs in elem.findall(nspath('OtherCRS',ns=WFS_NAMESPACE))]
-        defaultCrs =  elem.findall(nspath('DefaultCRS',ns=WFS_NAMESPACE))
+        self.crsOptions = [Crs(srs.text) for srs in elem.findall(nspath('OtherCRS', ns=WFS_NAMESPACE))]
+        defaultCrs = elem.findall(nspath('DefaultCRS', ns=WFS_NAMESPACE))
         if len(defaultCrs) > 0:
-            self.crsOptions.insert(0,Crs(defaultCrs[0].text))
-
+            self.crsOptions.insert(0, Crs(defaultCrs[0].text))
 
         # verbs
-        self.verbOptions = [op.tag for op \
-            in parent.findall(nspath('Operations/*',ns=WFS_NAMESPACE))]
-        self.verbOptions + [op.tag for op \
-            in elem.findall(nspath('Operations/*',ns=WFS_NAMESPACE)) \
-            if op.tag not in self.verbOptions]
-        
-        #others not used but needed for iContentMetadata harmonisation
-        self.styles=None
-        self.timepositions=None
-        self.defaulttimeposition=None
+        self.verbOptions = [op.tag for op
+                            in parent.findall(nspath('Operations/*', ns=WFS_NAMESPACE))]
+        self.verbOptions + [op.tag for op
+                            in elem.findall(nspath('Operations/*', ns=WFS_NAMESPACE))
+                            if op.tag not in self.verbOptions]
+
+        # others not used but needed for iContentMetadata harmonisation
+        self.styles = None
+        self.timepositions = None
+        self.defaulttimeposition = None
 
         # MetadataURLs
         self.metadataUrls = []
@@ -387,6 +389,7 @@ class ContentMetadata:
 
 
 class WFSCapabilitiesReader(object):
+
     """Read and parse capabilities document into a lxml.etree infoset
     """
 

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -42,7 +42,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
     Implements IWebFeatureService.
     """
 
-    def __new__(self, url, version, xml, parse_remote_metadata=False):
+    def __new__(cls, url, version, xml, parse_remote_metadata=False):
         """ overridden __new__ method
 
         @type url: string
@@ -53,7 +53,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         @param parse_remote_metadata: whether to fully process MetadataURL elements
         @return: initialized WebFeatureService_2_0_0 object
         """
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, version, xml, parse_remote_metadata)
         return obj
 
@@ -62,7 +62,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, version, xml=None, parse_remote_metadata=False):
         """Initialize."""
@@ -169,7 +169,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         """
 
         url = data = None
-        if typename and type(typename) == type(""):
+        if typename and isinstance(typename, str):
             typename = [typename]
         if method.upper() == "GET":
             (url) = self.getGETGetFeatureRequest(typename, filter, bbox, featureid,
@@ -290,7 +290,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class StoredQuery(object):
@@ -312,7 +312,7 @@ class Parameter(object):
         self.type = type
 
 
-class ContentMetadata:
+class ContentMetadata(object):
 
     """Abstraction for WFS metadata.
 
@@ -382,7 +382,7 @@ class ContentMetadata:
                         metadataUrl['metadata'] = Metadata(doc)
                     except:  # ISO
                         metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception as err:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/fes.py
+++ b/owslib/fes.py
@@ -100,7 +100,7 @@ class FilterRequest(object):
                 keyword_filter = PropertyIsLike(propertyname, "*%s*" % keywords[0], wildCard="*")
 
         # And together filters if more than one exists
-        filters = filter(None, [keyword_filter, bbox_filter, dc_type_equals_filter])
+        filters = [f for f in [keyword_filter, bbox_filter, dc_type_equals_filter] if f]
         if len(filters) == 1:
             self._root.append(filters[0].toXML())
         elif len(filters) > 1:

--- a/owslib/fes.py
+++ b/owslib/fes.py
@@ -20,23 +20,28 @@ from owslib import util
 from owslib.namespaces import Namespaces
 
 # default variables
+
+
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["dif","fes","gml","ogc","xs","xsi"])
+    ns = n.get_namespaces(["dif", "fes", "gml", "ogc", "xs", "xsi"])
     ns[None] = n.get_namespace("ogc")
     return ns
 namespaces = get_namespaces()
 schema = 'http://schemas.opengis.net/filter/1.1.0/filter.xsd'
 schema_location = '%s %s' % (namespaces['ogc'], schema)
 
+
 class FilterRequest(object):
+
     """ filter class """
+
     def __init__(self, parent=None, version='1.1.0'):
         """
 
         filter Constructor
 
-        Parameters 
+        Parameters
         ----------
 
         - parent: parent etree.Element object (default is None)
@@ -53,14 +58,14 @@ class FilterRequest(object):
         """
 
         Construct and process a  GetRecords request
-    
+
         Parameters
         ----------
 
         - parent: the parent Element object.  If this is not, then generate a standalone request
         - qtype: type of resource to query (i.e. service, dataset)
         - keywords: list of keywords
-        - propertyname: the PropertyName to Filter against 
+        - propertyname: the PropertyName to Filter against
         - bbox: the bounding box of the spatial query in the form [minx,miny,maxx,maxy]
         - identifier: the dc:identifier to query against with a PropertyIsEqualTo.  Ignores all other inputs.
 
@@ -72,7 +77,7 @@ class FilterRequest(object):
             dc_identifier_equals_filter = PropertyIsEqualTo('dc:identifier', identifier)
             self._root.append(dc_identifier_equals_filter.toXML())
             return self._root
-   
+
         # Set the query type if passed
         dc_type_equals_filter = None
         if qtype is not None:
@@ -82,32 +87,31 @@ class FilterRequest(object):
         bbox_filter = None
         if bbox is not None:
             bbox_filter = BBox(bbox)
-    
+
         # Set a keyword query if passed
         keyword_filter = None
         if len(keywords) > 0:
-            if len(keywords) > 1: # loop multiple keywords into an Or
-                ks = []    
+            if len(keywords) > 1:  # loop multiple keywords into an Or
+                ks = []
                 for i in keywords:
                     ks.append(PropertyIsLike(propertyname, "*%s*" % i, wildCard="*"))
                 keyword_filter = Or(operations=ks)
-            elif len(keywords) == 1: # one keyword
+            elif len(keywords) == 1:  # one keyword
                 keyword_filter = PropertyIsLike(propertyname, "*%s*" % keywords[0], wildCard="*")
-    
 
         # And together filters if more than one exists
-        filters = filter(None,[keyword_filter, bbox_filter, dc_type_equals_filter])
+        filters = filter(None, [keyword_filter, bbox_filter, dc_type_equals_filter])
         if len(filters) == 1:
             self._root.append(filters[0].toXML())
         elif len(filters) > 1:
             self._root.append(And(operations=filters).toXML())
 
         return self._root
-       
+
     def setConstraint(self, constraint):
         """
         Construct and process a  GetRecords request
-    
+
         Parameters
         ----------
 
@@ -120,7 +124,7 @@ class FilterRequest(object):
     def setConstraintList(self, constraints):
         """
         Construct and process a  GetRecords request
-    
+
         Parameters
         ----------
 
@@ -163,7 +167,9 @@ class FilterRequest(object):
 
 
 class FilterCapabilities(object):
+
     """ Abstraction for Filter_Capabilities """
+
     def __init__(self, elem):
         # Spatial_Capabilities
         self.spatial_operands = [f.text for f in elem.findall(util.nspath_eval('ogc:Spatial_Capabilities/ogc:GeometryOperands/ogc:GeometryOperand', namespaces))]
@@ -180,8 +186,11 @@ class FilterCapabilities(object):
         # Scalar_Capabilities
         self.scalar_comparison_operators = [f.text for f in elem.findall(util.nspath_eval('ogc:Scalar_Capabilities/ogc:ComparisonOperators/ogc:ComparisonOperator', namespaces))]
 
+
 class FilterCapabilities200(object):
+
     """Abstraction for Filter_Capabilities 2.0"""
+
     def __init__(self, elem):
         # Spatial_Capabilities
         self.spatial_operands = [f.attrib.get('name') for f in elem.findall(util.nspath_eval('fes:Spatial_Capabilities/fes:GeometryOperands/fes:GeometryOperand', namespaces))]
@@ -201,8 +210,7 @@ class FilterCapabilities200(object):
         # Conformance
         self.conformance = []
         for f in elem.findall(util.nspath_eval('fes:Conformance/fes:Constraint', namespaces)):
-           self.conformance[f.attrib.get('name')] = f.find(util.nspath_eval('fes:DefaultValue', namespaces)).text
-
+            self.conformance[f.attrib.get('name')] = f.find(util.nspath_eval('fes:DefaultValue', namespaces)).text
 
 
 def setsortby(parent, propertyname, order='ASC'):
@@ -223,39 +231,51 @@ def setsortby(parent, propertyname, order='ASC'):
     tmp2 = etree.SubElement(tmp, util.nspath_eval('ogc:SortProperty', namespaces))
     etree.SubElement(tmp2, util.nspath_eval('ogc:PropertyName', namespaces)).text = propertyname
     etree.SubElement(tmp2, util.nspath_eval('ogc:SortOrder', namespaces)).text = order
-    
+
+
 class SortProperty(object):
+
     def __init__(self, propertyname, order='ASC'):
-        self.propertyname   = propertyname
-        self.order          = order.upper()
-        if self.order not in ['DESC','ASC']:
+        self.propertyname = propertyname
+        self.order = order.upper()
+        if self.order not in ['DESC', 'ASC']:
             raise ValueError("SortOrder can only be 'ASC' or 'DESC'")
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval("ogc:SortProperty", namespaces))
         etree.SubElement(node0, util.nspath_eval('ogc:PropertyName', namespaces)).text = self.propertyname
         etree.SubElement(node0, util.nspath_eval('ogc:SortOrder', namespaces)).text = self.order
         return node0
 
+
 class SortBy(object):
+
     def __init__(self, properties):
         self.properties = properties
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval("ogc:SortBy", namespaces))
         for prop in self.properties:
             node0.append(prop.toXML())
         return node0
 
+
 class OgcExpression(object):
+
     def __init__(self):
         pass
 
+
 class BinaryComparisonOpType(OgcExpression):
+
     """ Super class of all the property operation classes"""
+
     def __init__(self, propertyoperator, propertyname, literal, matchcase=True):
         self.propertyoperator = propertyoperator
         self.propertyname = propertyname
         self.literal = literal
         self.matchcase = matchcase
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval(self.propertyoperator, namespaces))
         if not self.matchcase:
@@ -263,39 +283,60 @@ class BinaryComparisonOpType(OgcExpression):
         etree.SubElement(node0, util.nspath_eval('ogc:PropertyName', namespaces)).text = self.propertyname
         etree.SubElement(node0, util.nspath_eval('ogc:Literal', namespaces)).text = self.literal
         return node0
-    
+
+
 class PropertyIsEqualTo(BinaryComparisonOpType):
+
     """ PropertyIsEqualTo class"""
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsEqualTo',  propertyname, literal, matchcase)
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsEqualTo', propertyname, literal, matchcase)
+
 
 class PropertyIsNotEqualTo(BinaryComparisonOpType):
+
     """ PropertyIsNotEqualTo class """
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsNotEqualTo',  propertyname, literal, matchcase)
-        
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsNotEqualTo', propertyname, literal, matchcase)
+
+
 class PropertyIsLessThan(BinaryComparisonOpType):
+
     """PropertyIsLessThan class"""
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsLessThan',  propertyname, literal, matchcase)
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsLessThan', propertyname, literal, matchcase)
+
 
 class PropertyIsGreaterThan(BinaryComparisonOpType):
+
     """PropertyIsGreaterThan class"""
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsGreaterThan',  propertyname, literal, matchcase)
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsGreaterThan', propertyname, literal, matchcase)
+
 
 class PropertyIsLessThanOrEqualTo(BinaryComparisonOpType):
+
     """PropertyIsLessThanOrEqualTo class"""
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsLessThanOrEqualTo',  propertyname, literal, matchcase)
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsLessThanOrEqualTo', propertyname, literal, matchcase)
+
 
 class PropertyIsGreaterThanOrEqualTo(BinaryComparisonOpType):
+
     """PropertyIsGreaterThanOrEqualTo class"""
+
     def __init__(self, propertyname, literal, matchcase=True):
-        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsGreaterThanOrEqualTo',  propertyname, literal, matchcase)
+        BinaryComparisonOpType.__init__(self, 'ogc:PropertyIsGreaterThanOrEqualTo', propertyname, literal, matchcase)
+
 
 class PropertyIsLike(OgcExpression):
+
     """PropertyIsLike class"""
+
     def __init__(self, propertyname, literal, escapeChar='\\', singleChar='_', wildCard='%', matchCase=True):
         self.propertyname = propertyname
         self.literal = literal
@@ -303,6 +344,7 @@ class PropertyIsLike(OgcExpression):
         self.singleChar = singleChar
         self.wildCard = wildCard
         self.matchCase = matchCase
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval('ogc:PropertyIsLike', namespaces))
         node0.set('wildCard', self.wildCard)
@@ -314,21 +356,29 @@ class PropertyIsLike(OgcExpression):
         etree.SubElement(node0, util.nspath_eval('ogc:Literal', namespaces)).text = self.literal
         return node0
 
+
 class PropertyIsNull(OgcExpression):
+
     """PropertyIsNull class"""
+
     def __init__(self, propertyname):
         self.propertyname = propertyname
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval('ogc:PropertyIsNull', namespaces))
         etree.SubElement(node0, util.nspath_eval('ogc:PropertyName', namespaces)).text = self.propertyname
         return node0
-        
+
+
 class PropertyIsBetween(OgcExpression):
+
     """PropertyIsBetween class"""
+
     def __init__(self, propertyname, lower, upper):
         self.propertyname = propertyname
         self.lower = lower
         self.upper = upper
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval('ogc:PropertyIsBetween', namespaces))
         etree.SubElement(node0, util.nspath_eval('ogc:PropertyName', namespaces)).text = self.propertyname
@@ -337,11 +387,15 @@ class PropertyIsBetween(OgcExpression):
         node2 = etree.SubElement(node0, util.nspath_eval('ogc:UpperBoundary', namespaces))
         etree.SubElement(node2, util.nspath_eval('ogc:Literal', namespaces)).text = '%s' % self.upper
         return node0
-        
+
+
 class BBox(OgcExpression):
+
     """Construct a BBox, two pairs of coordinates (west-south and east-north)"""
+
     def __init__(self, bbox):
         self.bbox = bbox
+
     def toXML(self):
         tmp = etree.Element(util.nspath_eval('ogc:BBOX', namespaces))
         etree.SubElement(tmp, util.nspath_eval('ogc:PropertyName', namespaces)).text = 'ows:BoundingBox'
@@ -351,8 +405,12 @@ class BBox(OgcExpression):
         return tmp
 
 # BINARY
+
+
 class BinaryLogicOpType(OgcExpression):
+
     """ Binary Operators: And / Or """
+
     def __init__(self, binary_operator, operations):
         self.binary_operator = binary_operator
         try:
@@ -360,33 +418,44 @@ class BinaryLogicOpType(OgcExpression):
             self.operations = operations
         except:
             raise ValueError("Binary operations (And / Or) require a minimum of two operations to operate against")
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval(self.binary_operator, namespaces))
         for op in self.operations:
             node0.append(op.toXML())
         return node0
 
+
 class And(BinaryLogicOpType):
+
     def __init__(self, operations):
-        super(And,self).__init__('ogc:And', operations)
+        super(And, self).__init__('ogc:And', operations)
+
 
 class Or(BinaryLogicOpType):
+
     def __init__(self, operations):
-        super(Or,self).__init__('ogc:Or', operations)
+        super(Or, self).__init__('ogc:Or', operations)
 
 # UNARY
+
+
 class UnaryLogicOpType(OgcExpression):
+
     """ Unary Operator: Not """
+
     def __init__(self, urary_operator, operations):
         self.urary_operator = urary_operator
         self.operations = operations
+
     def toXML(self):
         node0 = etree.Element(util.nspath_eval(self.urary_operator, namespaces))
         for op in self.operations:
             node0.append(op.toXML())
         return node0
 
-class Not(UnaryLogicOpType):
-    def __init__(self, operations):
-        super(Not,self).__init__('ogc:Not', operations)
 
+class Not(UnaryLogicOpType):
+
+    def __init__(self, operations):
+        super(Not, self).__init__('ogc:Not', operations)

--- a/owslib/fgdc.py
+++ b/owslib/fgdc.py
@@ -12,8 +12,11 @@
 from owslib.etree import etree
 from owslib import util
 
+
 class Metadata(object):
+
     """ Process metadata """
+
     def __init__(self, md):
         if hasattr(md, 'getroot'):  # standalone document
             self.xml = etree.tostring(md.getroot())
@@ -28,8 +31,11 @@ class Metadata(object):
         if self.idinfo.datasetid:
             self.identifier = self.idinfo.datasetid
 
+
 class Idinfo(object):
+
     """ Process idinfo """
+
     def __init__(self, md):
         val = md.find('idinfo/datasetid')
         self.datasetid = util.testXMLValue(val)
@@ -72,27 +78,30 @@ class Idinfo(object):
         val = md.find('idinfo/crossref')
         self.crossref = Citation(val)
 
+
 class Citation(object):
+
     """ Process citation """
+
     def __init__(self, md):
         if md is not None:
             self.citeinfo = {}
-    
+
             val = md.find('citeinfo/origin')
             self.citeinfo['origin'] = util.testXMLValue(val)
-    
+
             val = md.find('citeinfo/pubdate')
             self.citeinfo['pubdate'] = util.testXMLValue(val)
-    
+
             val = md.find('citeinfo/title')
             self.citeinfo['title'] = util.testXMLValue(val)
-    
+
             val = md.find('citeinfo/geoform')
             self.citeinfo['geoform'] = util.testXMLValue(val)
-    
+
             val = md.find('citeinfo/pubinfo/pubplace')
             self.citeinfo['pubplace'] = util.testXMLValue(val)
-    
+
             val = md.find('citeinfo/pubinfo/publish')
             self.citeinfo['publish'] = util.testXMLValue(val)
 
@@ -100,20 +109,26 @@ class Citation(object):
             for link in md.findall('citeinfo/onlink'):
                 self.citeinfo['onlink'].append(util.testXMLValue(link))
 
+
 class Descript(object):
+
     """ Process descript """
+
     def __init__(self, md):
         val = md.find('abstract')
         self.abstract = util.testXMLValue(val)
-        
+
         val = md.find('purpose')
         self.purpose = util.testXMLValue(val)
 
         val = md.find('supplinf')
         self.supplinf = util.testXMLValue(val)
 
+
 class Timeperd(object):
+
     """ Process timeperd """
+
     def __init__(self, md):
         if md is not None:
             val = md.find('current')
@@ -123,8 +138,11 @@ class Timeperd(object):
             if val is not None:
                 self.timeinfo = Timeinfo(val)
 
+
 class Timeinfo(object):
+
     """ Process timeinfo """
+
     def __init__(self, md):
         val = md.find('sngdate')
         if val is not None:
@@ -134,16 +152,22 @@ class Timeinfo(object):
         if val is not None:
             self.rngdates = Rngdates(val)
 
+
 class Sngdate(object):
+
     """ Process sngdate """
+
     def __init__(self, md):
         val = md.find('caldate')
         self.caldate = util.testXMLValue(val)
         val = md.find('time')
         self.time = util.testXMLValue(val)
 
+
 class Rngdates(object):
+
     """ Process rngdates """
+
     def __init__(self, md):
         val = md.find('begdate')
         self.begdate = util.testXMLValue(val)
@@ -154,8 +178,11 @@ class Rngdates(object):
         val = md.find('endtime')
         self.endtime = util.testXMLValue(val)
 
+
 class Status(object):
+
     """ Process status """
+
     def __init__(self, md):
         val = md.find('progress')
         self.progress = util.testXMLValue(val)
@@ -163,15 +190,18 @@ class Status(object):
         val = md.find('update')
         self.update = util.testXMLValue(val)
 
+
 class Spdom(object):
+
     """ Process spdom """
+
     def __init__(self, md):
         val = md.find('bounding/westbc')
         self.westbc = util.testXMLValue(val)
 
         val = md.find('bounding/eastbc')
         self.eastbc = util.testXMLValue(val)
-       
+
         val = md.find('bounding/northbc')
         self.northbc = util.testXMLValue(val)
 
@@ -179,19 +209,25 @@ class Spdom(object):
         self.southbc = util.testXMLValue(val)
 
         if (self.southbc is not None and self.northbc is not None and
-        self.eastbc is not None and self.westbc is not None):
+                self.eastbc is not None and self.westbc is not None):
             self.bbox = Bbox(self)
 
+
 class Bbox(object):
+
     """ Generate bbox for spdom (convenience function) """
+
     def __init__(self, spdom):
         self.minx = spdom.westbc
         self.miny = spdom.southbc
         self.maxx = spdom.eastbc
         self.maxy = spdom.northbc
 
+
 class Keywords(object):
+
     """ Process keywords """
+
     def __init__(self, md):
         self.theme = []
         self.place = []
@@ -228,17 +264,20 @@ class Keywords(object):
                 theme['tempkey'].append(util.testXMLValue(j))
             self.temporal.append(temporal)
 
+
 class Ptcontac(object):
+
     """ Process ptcontac """
+
     def __init__(self, md):
         val = md.find('cntinfo/cntorgp/cntorg')
-        self.cntorg = util.testXMLValue(val)    
+        self.cntorg = util.testXMLValue(val)
 
         val = md.find('cntinfo/cntorgp/cntper')
-        self.cntper = util.testXMLValue(val)    
+        self.cntper = util.testXMLValue(val)
 
         val = md.find('cntinfo/cntpos')
-        self.cntpos = util.testXMLValue(val)    
+        self.cntpos = util.testXMLValue(val)
 
         val = md.find('cntinfo/cntaddr/addrtype')
         self.addrtype = util.testXMLValue(val)
@@ -264,8 +303,11 @@ class Ptcontac(object):
         val = md.find('cntinfo/cntemail')
         self.email = util.testXMLValue(val)
 
+
 class Eainfo(object):
+
     """ Process eainfo """
+
     def __init__(self, md):
         val = md.find('eainfo/detailed/enttyp/enttypl')
         self.enttypl = util.testXMLValue(val)
@@ -293,8 +335,11 @@ class Eainfo(object):
 
             self.attr.append(attr)
 
+
 class Distinfo(object):
+
     """ Process distinfo """
+
     def __init__(self, md):
         val = md.find('distinfo')
         if val is not None:
@@ -307,8 +352,11 @@ class Distinfo(object):
                     digform['url'] = util.testXMLValue(link.find('digtopt/onlinopt/computer/networka/networkr/'))
                     self.stdorder['digform'].append(digform)
 
+
 class Metainfo(object):
+
     """ Process metainfo """
+
     def __init__(self, md):
         val = md.find('metainfo/metd')
         self.metd = util.testXMLValue(val)
@@ -316,7 +364,7 @@ class Metainfo(object):
         val = md.find('metainfo/metrd')
         self.metrd = util.testXMLValue(val)
 
-        val = md.find('metainfo/metc')        
+        val = md.find('metainfo/metc')
         if val is not None:
             self.metc = Ptcontac(val)
 

--- a/owslib/interfaces.py
+++ b/owslib/interfaces.py
@@ -2,7 +2,7 @@
 # Follows the 4 aspects of service metadata
 
 
-class IServiceIdentificationMetadata:
+class IServiceIdentificationMetadata(object):
 
     """OO-interface to service identification metadata.
     """
@@ -16,7 +16,7 @@ class IServiceIdentificationMetadata:
     fees = property("""Explanation of fees associated with service (string).""")
 
 
-class IServiceProviderMetadata:
+class IServiceProviderMetadata(object):
 
     """OO-interface to service provider metadata.
     """
@@ -26,7 +26,7 @@ class IServiceProviderMetadata:
     contact = property("""How to contact the service provider (string).""")
 
 
-class IServiceOperations:
+class IServiceOperations(object):
 
     """OO-interface to service operations metadata.
     """
@@ -35,7 +35,7 @@ class IServiceOperations:
     exceptions = property("""List of exception formats (list).""")
 
 
-class IServiceContents:
+class IServiceContents(object):
 
     """OO-interface to service contents metadata.
     """
@@ -127,7 +127,7 @@ class ISensorObservationService(IService):
 # Second level metadata interfaces
 
 
-class IOperationMetadata:
+class IOperationMetadata(object):
 
     """OO-interface to operation metadata.
     """
@@ -137,7 +137,7 @@ class IOperationMetadata:
     methods = property("""Mapping of method descriptors, keyed to HTTP verbs. Items must implement IMethodMetadata (below).""")
 
 
-class IMethodMetadata:
+class IMethodMetadata(object):
 
     """OO-interface to method metadata.
     """
@@ -146,7 +146,7 @@ class IMethodMetadata:
     # TODO: constraint
 
 
-class IContentMetadata:
+class IContentMetadata(object):
 
     """OO-interface to content metadata.
     """
@@ -169,7 +169,7 @@ class iSensorObservationServiceContentMetadata(IContentMetadata):
 # XXX: needed?
 
 
-class IContactMetadata:
+class IContactMetadata(object):
 
     """OO-interface to OWS metadata.
 

--- a/owslib/interfaces.py
+++ b/owslib/interfaces.py
@@ -1,7 +1,9 @@
 
 # Follows the 4 aspects of service metadata
 
+
 class IServiceIdentificationMetadata:
+
     """OO-interface to service identification metadata.
     """
 
@@ -12,9 +14,10 @@ class IServiceIdentificationMetadata:
     keywords = property("""Keyword list (list).""")
     accessconstraints = property("""Explanation of access constraints associated with service (string).""")
     fees = property("""Explanation of fees associated with service (string).""")
-    
+
 
 class IServiceProviderMetadata:
+
     """OO-interface to service provider metadata.
     """
 
@@ -24,6 +27,7 @@ class IServiceProviderMetadata:
 
 
 class IServiceOperations:
+
     """OO-interface to service operations metadata.
     """
 
@@ -32,6 +36,7 @@ class IServiceOperations:
 
 
 class IServiceContents:
+
     """OO-interface to service contents metadata.
     """
 
@@ -41,6 +46,7 @@ class IServiceContents:
 # IServiceMetadata aggregates the 4 aspects above
 
 class IServiceMetadata(IServiceOperations, IServiceContents):
+
     """OWS Metadata.
 
     operations and contents properties are inherited.
@@ -53,6 +59,7 @@ class IServiceMetadata(IServiceOperations, IServiceContents):
 # A Service has an online resource URL as well as metadata collections
 
 class IService(IServiceMetadata):
+
     """The OGC Web Service interface.
     """
 
@@ -62,11 +69,12 @@ class IService(IServiceMetadata):
 # 3 specific service types are described below: WMS, WFS, and WCS
 
 class IWebMapService(IService):
+
     """Abstraction for an OGC Web Map Service (WMS).
     """
 
     def getcapabilities():
-        """Make a request to the WMS, returns an XML document wrapped in a 
+        """Make a request to the WMS, returns an XML document wrapped in a
         Python file object."""
 
     def getmap(**kw):
@@ -78,11 +86,12 @@ class IWebMapService(IService):
 
 
 class IWebFeatureService(IService):
+
     """Abstraction for an OGC Web Feature Service (WFS).
     """
 
     def getcapabilities():
-        """Make a request to the WFS, returns an XML document wrapped in a 
+        """Make a request to the WFS, returns an XML document wrapped in a
         Python file object."""
 
     def getfeature(**kw):
@@ -97,25 +106,29 @@ class IWebCoverageService(IService):
     # TODO
     pass
 
+
 class ISensorObservationService(IService):
+
     """Abstraction for an OGC Sensor Observation Service (SOS).
     """
 
     def getcapabilities():
-        """Make a request to the SOS, returns an XML document wrapped in a 
+        """Make a request to the SOS, returns an XML document wrapped in a
         Python file object."""
 
     def describesensor():
-        """Make a request to the SOS, returns an XML document wrapped in a 
+        """Make a request to the SOS, returns an XML document wrapped in a
         Python file object."""
 
     def getobservation():
-        """Make a request to the SOS, returns an XML document wrapped in a 
+        """Make a request to the SOS, returns an XML document wrapped in a
         Python file object."""
 
 # Second level metadata interfaces
 
+
 class IOperationMetadata:
+
     """OO-interface to operation metadata.
     """
 
@@ -125,13 +138,16 @@ class IOperationMetadata:
 
 
 class IMethodMetadata:
+
     """OO-interface to method metadata.
     """
 
     url = property("""Method endpoint URL (string).""")
     # TODO: constraint
 
+
 class IContentMetadata:
+
     """OO-interface to content metadata.
     """
 
@@ -141,16 +157,20 @@ class IContentMetadata:
     boundingBoxWGS84 = property("""Four bounding values in WGS coordinates.""")
     crsOptions = property("""List of available coordinate/spatial reference systems (list).""")
     styles = property("""List of style dicts (list).""")
-    timepositions=property("""List of times for which data is available""")
-    defaulttimeposition=property("""Default time position""")
+    timepositions = property("""List of times for which data is available""")
+    defaulttimeposition = property("""Default time position""")
+
 
 class iSensorObservationServiceContentMetadata(IContentMetadata):
+
     """Extension class for SOS specifics"""
     pass
 
 # XXX: needed?
 
+
 class IContactMetadata:
+
     """OO-interface to OWS metadata.
 
     Properties

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -1,5 +1,5 @@
-# -*- coding: ISO-8859-15 -*- 
-# ============================================================================= 
+# -*- coding: ISO-8859-15 -*-
+# =============================================================================
 # Copyright (c) 2009 Tom Kralidis
 #
 # Authors : Tom Kralidis <tomkralidis@gmail.com>
@@ -15,16 +15,20 @@ from owslib import util
 from owslib.namespaces import Namespaces
 
 # default variables
+
+
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["gco","gmd","gml","gml32","gmx","gts","srv","xlink"])
+    ns = n.get_namespaces(["gco", "gmd", "gml", "gml32", "gmx", "gts", "srv", "xlink"])
     ns[None] = n.get_namespace("gmd")
     return ns
 namespaces = get_namespaces()
 
 
 class MD_Metadata(object):
+
     """ Process gmd:MD_Metadata """
+
     def __init__(self, md):
 
         if hasattr(md, 'getroot'):  # standalone document
@@ -40,13 +44,13 @@ class MD_Metadata(object):
 
         val = md.find(util.nspath_eval('gmd:language/gco:CharacterString', namespaces))
         self.language = util.testXMLValue(val)
-        
+
         val = md.find(util.nspath_eval('gmd:dataSetURI/gco:CharacterString', namespaces))
         self.dataseturi = util.testXMLValue(val)
 
         val = md.find(util.nspath_eval('gmd:language/gmd:LanguageCode', namespaces))
         self.languagecode = util.testXMLValue(val)
-        
+
         val = md.find(util.nspath_eval('gmd:dateStamp/gco:Date', namespaces))
         self.datestamp = util.testXMLValue(val)
 
@@ -55,17 +59,17 @@ class MD_Metadata(object):
             self.datestamp = util.testXMLValue(val)
 
         self.charset = _testCodeListValue(md.find(util.nspath_eval('gmd:characterSet/gmd:MD_CharacterSetCode', namespaces)))
-  
+
         self.hierarchy = _testCodeListValue(md.find(util.nspath_eval('gmd:hierarchyLevel/gmd:MD_ScopeCode', namespaces)))
 
         self.contact = []
         for i in md.findall(util.nspath_eval('gmd:contact/gmd:CI_ResponsibleParty', namespaces)):
             o = CI_ResponsibleParty(i)
             self.contact.append(o)
-        
+
         val = md.find(util.nspath_eval('gmd:dateStamp/gco:DateTime', namespaces))
         self.datetimestamp = util.testXMLValue(val)
-        
+
         val = md.find(util.nspath_eval('gmd:metadataStandardName/gco:CharacterString', namespaces))
         self.stdname = util.testXMLValue(val)
 
@@ -79,7 +83,7 @@ class MD_Metadata(object):
             self.referencesystem = None
 
         # TODO: merge .identificationinfo into .identification
-        #warnings.warn(
+        # warnings.warn(
         #    'the .identification and .serviceidentification properties will merge into '
         #    '.identification being a list of properties.  This is currently implemented '
         #    'in .identificationinfo.  '
@@ -103,11 +107,11 @@ class MD_Metadata(object):
         for idinfo in md.findall(util.nspath_eval('gmd:identificationInfo', namespaces)):
             val = list(idinfo)[0]
             tagval = util.xmltag_split(val.tag)
-            if tagval == 'MD_DataIdentification': 
+            if tagval == 'MD_DataIdentification':
                 self.identificationinfo.append(MD_DataIdentification(val, 'dataset'))
-            elif tagval == 'MD_ServiceIdentification': 
+            elif tagval == 'MD_ServiceIdentification':
                 self.identificationinfo.append(MD_DataIdentification(val, 'service'))
-            elif tagval == 'SV_ServiceIdentification': 
+            elif tagval == 'SV_ServiceIdentification':
                 self.identificationinfo.append(SV_ServiceIdentification(val))
 
         val = md.find(util.nspath_eval('gmd:distributionInfo/gmd:MD_Distribution', namespaces))
@@ -116,15 +120,18 @@ class MD_Metadata(object):
             self.distribution = MD_Distribution(val)
         else:
             self.distribution = None
-        
+
         val = md.find(util.nspath_eval('gmd:dataQualityInfo/gmd:DQ_DataQuality', namespaces))
         if val is not None:
             self.dataquality = DQ_DataQuality(val)
         else:
             self.dataquality = None
 
+
 class CI_Date(object):
+
     """ process CI_Date """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:date/gco:Date', namespaces))
         if val is not None:
@@ -139,8 +146,11 @@ class CI_Date(object):
         val = md.find(util.nspath_eval('gmd:dateType/gmd:CI_DateTypeCode', namespaces))
         self.type = _testCodeListValue(val)
 
+
 class CI_ResponsibleParty(object):
+
     """ process CI_ResponsibleParty """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:individualName/gco:CharacterString', namespaces))
         self.name = util.testXMLValue(val)
@@ -178,19 +188,22 @@ class CI_ResponsibleParty(object):
 
         val = md.find(util.nspath_eval('gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource', namespaces))
         if val is not None:
-          self.onlineresource = CI_OnlineResource(val)
+            self.onlineresource = CI_OnlineResource(val)
         else:
-          self.onlineresource = None
-      
+            self.onlineresource = None
+
         self.role = _testCodeListValue(md.find(util.nspath_eval('gmd:role/gmd:CI_RoleCode', namespaces)))
 
+
 class MD_DataIdentification(object):
+
     """ process MD_DataIdentification """
+
     def __init__(self, md, identtype):
         self.identtype = identtype
         val = md.find(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString', namespaces))
         self.title = util.testXMLValue(val)
-        
+
         val = md.find(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:alternateTitle/gco:CharacterString', namespaces))
         self.alternatetitle = util.testXMLValue(val)
 
@@ -199,28 +212,28 @@ class MD_DataIdentification(object):
 
         self.date = []
         self.datetype = []
-        
+
         for i in md.findall(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date', namespaces)):
             self.date.append(CI_Date(i))
-        
+
         self.uselimitation = []
         for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gco:CharacterString', namespaces)):
             val = util.testXMLValue(i)
             if val is not None:
                 self.uselimitation.append(val)
-        
+
         self.accessconstraints = []
         for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:accessConstraints/gmd:MD_RestrictionCode', namespaces)):
             val = _testCodeListValue(i)
             if val is not None:
                 self.accessconstraints.append(val)
-        
+
         self.classification = []
         for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:accessConstraints/gmd:MD_ClassificationCode', namespaces)):
             val = _testCodeListValue(i)
             if val is not None:
                 self.classification.append(val)
-        
+
         self.otherconstraints = []
         for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints/gco:CharacterString', namespaces)):
             val = util.testXMLValue(i)
@@ -238,13 +251,13 @@ class MD_DataIdentification(object):
             val = _testCodeListValue(i)
             if val is not None:
                 self.useconstraints.append(val)
-        
+
         self.denominators = []
         for i in md.findall(util.nspath_eval('gmd:spatialResolution/gmd:MD_Resolution/gmd:equivalentScale/gmd:MD_RepresentativeFraction/gmd:denominator/gco:Integer', namespaces)):
             val = util.testXMLValue(i)
             if val is not None:
                 self.denominators.append(val)
-        
+
         self.distance = []
         self.uom = []
         for i in md.findall(util.nspath_eval('gmd:spatialResolution/gmd:MD_Resolution/gmd:distance/gco:Distance', namespaces)):
@@ -252,7 +265,7 @@ class MD_DataIdentification(object):
             if val is not None:
                 self.distance.append(val)
             self.uom.append(i.get("uom"))
-        
+
         self.resourcelanguage = []
         for i in md.findall(util.nspath_eval('gmd:language/gmd:LanguageCode', namespaces)):
             val = _testCodeListValue(i)
@@ -261,7 +274,7 @@ class MD_DataIdentification(object):
 
         val = md.find(util.nspath_eval('gmd:pointOfContact/gmd:CI_ResponsibleParty/gmd:organisationName', namespaces))
         if val is not None:
-            val2 = val.find(util.nspath_eval('gmd:role/gmd:CI_RoleCode', namespaces)) 
+            val2 = val.find(util.nspath_eval('gmd:role/gmd:CI_RoleCode', namespaces))
             if val2 is not None:
                 clv = _testCodeListValue(val)
                 if clv == 'originator':
@@ -286,7 +299,7 @@ class MD_DataIdentification(object):
         for i in md.findall(util.nspath_eval('gmd:pointOfContact/gmd:CI_ResponsibleParty', namespaces)):
             o = CI_ResponsibleParty(i)
             self.contact.append(o)
-        
+
         self.keywords = []
 
         for i in md.findall(util.nspath_eval('gmd:descriptiveKeywords', namespaces)):
@@ -309,7 +322,7 @@ class MD_DataIdentification(object):
             for k in i.findall(util.nspath_eval('gmd:MD_Keywords/gmd:keyword', namespaces)):
                 val = k.find(util.nspath_eval('gco:CharacterString', namespaces))
                 if val is not None:
-                    val2 = util.testXMLValue(val) 
+                    val2 = util.testXMLValue(val)
                     if val2 is not None:
                         mdkw['keywords'].append(val2)
 
@@ -320,10 +333,10 @@ class MD_DataIdentification(object):
             val = util.testXMLValue(i)
             if val is not None:
                 self.topiccategory.append(val)
-        
+
         val = md.find(util.nspath_eval('gmd:supplementalInformation/gco:CharacterString', namespaces))
         self.supplementalinformation = util.testXMLValue(val)
-        
+
         # There may be multiple geographicElement, create an extent
         # from the one containing either an EX_GeographicBoundingBox or EX_BoundingPolygon.
         # The schema also specifies an EX_GeographicDescription. This is not implemented yet.
@@ -353,8 +366,11 @@ class MD_DataIdentification(object):
                     val3 = extent.find(util.nspath_eval('gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml32:TimePeriod/gml32:endPosition', namespaces))
                 self.temporalextent_end = util.testXMLValue(val3)
 
-class MD_Distributor(object):        
+
+class MD_Distributor(object):
+
     """ process MD_Distributor """
+
     def __init__(self, md):
         self.contact = None
         val = md.find(util.nspath_eval('gmd:MD_Distributor/gmd:distributorContact/gmd:CI_ResponsibleParty', namespaces))
@@ -366,8 +382,11 @@ class MD_Distributor(object):
         for ol in md.findall(util.nspath_eval('gmd:MD_Distributor/gmd:distributorTransferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource', namespaces)):
             self.online.append(CI_OnlineResource(ol))
 
+
 class MD_Distribution(object):
+
     """ process MD_Distribution """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:distributionFormat/gmd:MD_Format/gmd:name/gco:CharacterString', namespaces))
         self.format = util.testXMLValue(val)
@@ -384,35 +403,37 @@ class MD_Distribution(object):
         for ol in md.findall(util.nspath_eval('gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource', namespaces)):
             self.online.append(CI_OnlineResource(ol))
 
-        
+
 class DQ_DataQuality(object):
+
     ''' process DQ_DataQuality'''
+
     def __init__(self, md):
-        
+
         self.conformancetitle = []
         for i in md.findall(util.nspath_eval('gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/gco:CharacterString', namespaces)):
             val = util.testXMLValue(i)
             if val is not None:
                 self.conformancetitle.append(val)
-        
+
         self.conformancedate = []
         for i in md.findall(util.nspath_eval('gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date', namespaces)):
             val = util.testXMLValue(i)
             if val is not None:
                 self.conformancedate.append(val)
-        
+
         self.conformancedatetype = []
         for i in md.findall(util.nspath_eval('gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode', namespaces)):
             val = _testCodeListValue(i)
             if val is not None:
                 self.conformancedatetype.append(val)
-        
+
         self.conformancedegree = []
         for i in md.findall(util.nspath_eval('gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:pass/gco:Boolean', namespaces)):
             val = util.testXMLValue(i)
             if val is not None:
                 self.conformancedegree.append(val)
-        
+
         val = md.find(util.nspath_eval('gmd:lineage/gmd:LI_Lineage/gmd:statement/gco:CharacterString', namespaces))
         self.lineage = util.testXMLValue(val)
 
@@ -425,13 +446,16 @@ class DQ_DataQuality(object):
             if val is not None:
                 self.specificationdate.append(val)
 
+
 class SV_ServiceIdentification(object):
+
     """ process SV_ServiceIdentification """
+
     def __init__(self, md):
         self.identtype = 'service'
         val = md.find(util.nspath_eval('srv:serviceType/gco:LocalName', namespaces))
         self.type = util.testXMLValue(val)
-      
+
         val = md.find(util.nspath_eval('srv:serviceTypeVersion/gco:CharacterString', namespaces))
         self.version = util.testXMLValue(val)
 
@@ -457,16 +481,16 @@ class SV_ServiceIdentification(object):
             for d in i.findall(util.nspath_eval('srv:SV_OperationMetadata/srv:DCP', namespaces)):
                 tmp2 = _testCodeListValue(d.find(util.nspath_eval('srv:DCPList', namespaces)))
                 tmp['dcplist'].append(tmp2)
-         
+
             tmp['connectpoint'] = []
- 
+
             for d in i.findall(util.nspath_eval('srv:SV_OperationMetadata/srv:connectPoint', namespaces)):
                 tmp3 = d.find(util.nspath_eval('gmd:CI_OnlineResource', namespaces))
                 tmp['connectpoint'].append(CI_OnlineResource(tmp3))
             self.operations.append(tmp)
 
         self.operateson = []
-         
+
         for i in md.findall(util.nspath_eval('srv:operatesOn', namespaces)):
             tmp = {}
             tmp['uuidref'] = i.attrib.get('uuidref')
@@ -474,9 +498,12 @@ class SV_ServiceIdentification(object):
             tmp['title'] = i.attrib.get(util.nspath_eval('xlink:title', namespaces))
             self.operateson.append(tmp)
 
+
 class CI_OnlineResource(object):
+
     """ process CI_OnlineResource """
-    def __init__(self,md):
+
+    def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:linkage/gmd:URL', namespaces))
         self.url = util.testXMLValue(val)
 
@@ -493,6 +520,7 @@ class CI_OnlineResource(object):
 
 
 class EX_GeographicBoundingBox(object):
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:westBoundLongitude/gco:Decimal', namespaces))
         self.minx = util.testXMLValue(val)
@@ -502,19 +530,21 @@ class EX_GeographicBoundingBox(object):
         self.miny = util.testXMLValue(val)
         val = md.find(util.nspath_eval('gmd:northBoundLatitude/gco:Decimal', namespaces))
         self.maxy = util.testXMLValue(val)
-    
+
+
 class EX_Polygon(object):
+
     def __init__(self, md):
         linear_ring = md.find(util.nspath_eval('gml32:Polygon/gml32:exterior/gml32:LinearRing', namespaces))
         if linear_ring is not None:
             self.exterior_ring = self._coordinates_for_ring(linear_ring)
-                    
+
         interior_ring_elements = md.findall(util.nspath_eval('gml32:Polygon/gml32:interior', namespaces))
         self.interior_rings = []
         for iring_element in interior_ring_elements:
             linear_ring = iring_element.find(util.nspath_eval('gml32:LinearRing', namespaces))
             self.interior_rings.append(self._coordinates_for_ring(linear_ring))
-            
+
     def _coordinates_for_ring(self, linear_ring):
         coordinates = []
         positions = linear_ring.findall(util.nspath_eval('gml32:pos', namespaces))
@@ -523,20 +553,25 @@ class EX_Polygon(object):
             coords = tuple([float(t) for t in tokens])
             coordinates.append(coords)
         return coordinates
-        
+
+
 class EX_GeographicBoundingPolygon(object):
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:extentTypeCode', namespaces))
         self.is_extent = util.testXMLValue(val)
-        
+
         md_polygons = md.findall(util.nspath_eval('gmd:polygon', namespaces))
-        
+
         self.polygons = []
         for val in md_polygons:
             self.polygons.append(EX_Polygon(val))
-            
+
+
 class EX_Extent(object):
+
     """ process EX_Extent """
+
     def __init__(self, md):
         self.boundingBox = None
         self.boundingPolygon = None
@@ -545,19 +580,23 @@ class EX_Extent(object):
             bboxElement = md.find(util.nspath_eval('gmd:EX_GeographicBoundingBox', namespaces))
             if bboxElement is not None:
                 self.boundingBox = EX_GeographicBoundingBox(bboxElement)
-        
+
             polygonElement = md.find(util.nspath_eval('gmd:EX_BoundingPolygon', namespaces))
             if polygonElement is not None:
                 self.boundingPolygon = EX_GeographicBoundingPolygon(polygonElement)
- 
+
             val = md.find(util.nspath_eval('gmd:EX_GeographicDescription/gmd:geographicIdentifier/gmd:MD_Identifier/gmd:code/gco:CharacterString', namespaces))
             self.description_code = util.testXMLValue(val)
 
+
 class MD_ReferenceSystem(object):
+
     """ process MD_ReferenceSystem """
+
     def __init__(self, md):
         val = md.find(util.nspath_eval('gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code/gco:CharacterString', namespaces))
         self.code = util.testXMLValue(val)
+
 
 def _testCodeListValue(elpath):
     """ get gco:CodeListValue_Type attribute, else get text content """
@@ -570,8 +609,11 @@ def _testCodeListValue(elpath):
     else:
         return None
 
+
 class CodelistCatalogue(object):
+
     """ process CT_CodelistCatalogue """
+
     def __init__(self, ct):
         val = ct.find(util.nspath_eval('gmx:name/gco:CharacterString', namespaces))
         self.name = util.testXMLValue(val)
@@ -618,4 +660,3 @@ class CodelistCatalogue(object):
             return ids
         else:
             return None
-

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -653,7 +653,7 @@ class CodelistCatalogue(object):
         return self.dictionaries.keys()
 
     def getcodedefinitionidentifiers(self, cdl):
-        if self.dictionaries.has_key(cdl):
+        if cdl in self.dictionaries:
             ids = []
             for i in self.dictionaries[cdl]['entries']:
                 ids.append(self.dictionaries[cdl]['entries'][i]['identifier'])

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -650,7 +650,7 @@ class CodelistCatalogue(object):
                 self.dictionaries[id]['entries'][id2]['codespace'] = util.testXMLValue(val, True)
 
     def getcodelistdictionaries(self):
-        return self.dictionaries.keys()
+        return list(self.dictionaries.keys())
 
     def getcodedefinitionidentifiers(self, cdl):
         if cdl in self.dictionaries:

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,3 +1,6 @@
+from six import iteritems
+
+
 class Namespaces(object):
 
     """
@@ -69,7 +72,7 @@ class Namespaces(object):
             'http://www.opengis.net/wfs/2.0'
         """
         retval = None
-        if key in self.namespace_dict.keys():
+        if key in self.namespace_dict:
             retval = self.namespace_dict[key]
         return retval
 
@@ -99,7 +102,7 @@ class Namespaces(object):
         key += version
 
         retval = None
-        if key in self.namespace_dict.keys():
+        if key in self.namespace_dict:
             retval = self.namespace_dict[key]
 
         return retval
@@ -138,7 +141,7 @@ class Namespaces(object):
         return retval
 
     def get_namespace_from_url(self, url):
-        for k, v in self.namespace_dict.items():
+        for k, v in iteritems(self.namespace_dict):
             if v == url:
                 return k
         return None

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,4 +1,5 @@
 class Namespaces(object):
+
     """
         Class for holding and maniputlating a dictionary containing the various namespaces for
         each standard.
@@ -51,7 +52,7 @@ class Namespaces(object):
         'xs'    :   'http://www.w3.org/2001/XMLSchema',
         'xs2'   :   'http://www.w3.org/XML/Schema',
         'xsi'   :   'http://www.w3.org/2001/XMLSchema-instance'
-    }    
+    }
 
     def get_namespace(self, key):
         """
@@ -71,7 +72,7 @@ class Namespaces(object):
         if key in self.namespace_dict.keys():
             retval = self.namespace_dict[key]
         return retval
-    
+
     def get_versioned_namespace(self, key, ver=None):
         """
             Retrieves a namespace from the dictionary with a specific version number
@@ -86,7 +87,7 @@ class Namespaces(object):
             >>> ns.get_versioned_namespace('ows','1.1.0')
             'http://www.opengis.net/ows/1.1'
         """
-        
+
         if ver is None:
             return self.get_namespace(key)
 
@@ -94,15 +95,15 @@ class Namespaces(object):
         # Strip the decimals out of the passed in version
         for s in ver.split('.'):
             version += s
-        
+
         key += version
 
         retval = None
         if key in self.namespace_dict.keys():
             retval = self.namespace_dict[key]
-            
+
         return retval
-    
+
     def get_namespaces(self, keys=None):
         """
             Retrieves a dict of namespaces from the namespace mapping
@@ -128,7 +129,7 @@ class Namespaces(object):
             return self.namespace_dict
 
         if isinstance(keys, unicode) or isinstance(keys, str):
-            return { keys: self.get_namespace(keys) }
+            return {keys: self.get_namespace(keys)}
 
         retval = {}
         for key in keys:

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,4 +1,4 @@
-from six import iteritems
+from six import iteritems, text_type, binary_type
 
 
 class Namespaces(object):
@@ -131,7 +131,7 @@ class Namespaces(object):
         if keys is None or len(keys) == 0:
             return self.namespace_dict
 
-        if isinstance(keys, unicode) or isinstance(keys, str):
+        if isinstance(keys, (text_type, binary_type)):
             return {keys: self.get_namespace(keys)}
 
         retval = {}

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -22,24 +22,30 @@ n = Namespaces()
 
 OWS_NAMESPACE_1_0_0 = n.get_namespace("ows")
 OWS_NAMESPACE_1_1_0 = n.get_namespace("ows110")
-OWS_NAMESPACE_2_0   = n.get_namespace("ows200")
-XSI_NAMESPACE       = n.get_namespace("xsi")
-XLINK_NAMESPACE     = n.get_namespace("xlink")
+OWS_NAMESPACE_2_0 = n.get_namespace("ows200")
+XSI_NAMESPACE = n.get_namespace("xsi")
+XLINK_NAMESPACE = n.get_namespace("xlink")
 
-DEFAULT_OWS_NAMESPACE=OWS_NAMESPACE_1_1_0     #Use this as default for OWSCommon objects
+DEFAULT_OWS_NAMESPACE = OWS_NAMESPACE_1_1_0  # Use this as default for OWSCommon objects
+
 
 class OwsCommon(object):
+
     """Initialize OWS Common object"""
-    def __init__(self,version):
+
+    def __init__(self, version):
         self.version = version
         if version == '1.0.0':
             self.namespace = OWS_NAMESPACE_1_0_0
         else:
             self.namespace = OWS_NAMESPACE_1_1_0
-    
+
+
 class ServiceIdentification(object):
+
     """Initialize an OWS Common ServiceIdentification construct"""
-    def __init__(self,infoset,namespace=DEFAULT_OWS_NAMESPACE): 
+
+    def __init__(self, infoset, namespace=DEFAULT_OWS_NAMESPACE):
         self._root = infoset
 
         val = self._root.find(util.nspath('Title', namespace))
@@ -52,7 +58,6 @@ class ServiceIdentification(object):
         for f in self._root.findall(util.nspath('Keywords/Keyword', namespace)):
             if f.text is not None:
                 self.keywords.append(f.text)
-    
 
         val = self._root.find(util.nspath('AccessConstraints', namespace))
         self.accessconstraints = util.testXMLValue(val)
@@ -62,7 +67,7 @@ class ServiceIdentification(object):
 
         val = self._root.find(util.nspath('ServiceType', namespace))
         self.type = util.testXMLValue(val)
-        self.service=self.type #alternative? keep both?discuss
+        self.service = self.type  # alternative? keep both?discuss
 
         val = self._root.find(util.nspath('ServiceTypeVersion', namespace))
         self.version = util.testXMLValue(val)
@@ -71,29 +76,35 @@ class ServiceIdentification(object):
         for p in self._root.findall(util.nspath('Profile', namespace)):
             self.profiles.append(util.testXMLValue(val))
 
+
 class ServiceProvider(object):
+
     """Initialize an OWS Common ServiceProvider construct"""
-    def __init__(self, infoset,namespace=DEFAULT_OWS_NAMESPACE):
+
+    def __init__(self, infoset, namespace=DEFAULT_OWS_NAMESPACE):
         self._root = infoset
         val = self._root.find(util.nspath('ProviderName', namespace))
         self.name = util.testXMLValue(val)
         self.contact = ServiceContact(infoset, namespace)
         val = self._root.find(util.nspath('ProviderSite', namespace))
         if val is not None:
-            urlattrib=val.attrib[util.nspath('href', XLINK_NAMESPACE)]
+            urlattrib = val.attrib[util.nspath('href', XLINK_NAMESPACE)]
             self.url = util.testXMLValue(urlattrib, True)
         else:
-            self.url =None
+            self.url = None
+
 
 class ServiceContact(object):
+
     """Initialize an OWS Common ServiceContact construct"""
-    def __init__(self, infoset,namespace=DEFAULT_OWS_NAMESPACE):
+
+    def __init__(self, infoset, namespace=DEFAULT_OWS_NAMESPACE):
         self._root = infoset
         val = self._root.find(util.nspath('ProviderName', namespace))
         self.name = util.testXMLValue(val)
-        
-        self.organization=util.testXMLValue(self._root.find(util.nspath('ContactPersonPrimary/ContactOrganization', namespace)))
-        
+
+        self.organization = util.testXMLValue(self._root.find(util.nspath('ContactPersonPrimary/ContactOrganization', namespace)))
+
         val = self._root.find(util.nspath('ProviderSite', namespace))
         if val is not None:
             self.site = util.testXMLValue(val.attrib.get(util.nspath('href', XLINK_NAMESPACE)), True)
@@ -105,31 +116,31 @@ class ServiceContact(object):
 
         val = self._root.find(util.nspath('ServiceContact/IndividualName', namespace))
         self.name = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/PositionName', namespace))
         self.position = util.testXMLValue(val)
- 
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Phone/Voice', namespace))
         self.phone = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Phone/Facsimile', namespace))
         self.fax = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/DeliveryPoint', namespace))
         self.address = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/City', namespace))
         self.city = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/AdministrativeArea', namespace))
         self.region = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/PostalCode', namespace))
         self.postcode = util.testXMLValue(val)
 
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/Country', namespace))
         self.country = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/Address/ElectronicMailAddress', namespace))
         self.email = util.testXMLValue(val)
 
@@ -141,13 +152,16 @@ class ServiceContact(object):
 
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/HoursOfService', namespace))
         self.hours = util.testXMLValue(val)
-    
+
         val = self._root.find(util.nspath('ServiceContact/ContactInfo/ContactInstructions', namespace))
         self.instructions = util.testXMLValue(val)
-   
+
+
 class OperationsMetadata(object):
+
     """Initialize an OWS OperationMetadata construct"""
-    def __init__(self,elem,namespace=DEFAULT_OWS_NAMESPACE):
+
+    def __init__(self, elem, namespace=DEFAULT_OWS_NAMESPACE):
         self.name = elem.attrib['name']
         self.formatOptions = ['text/xml']
         methods = []
@@ -171,9 +185,12 @@ class OperationsMetadata(object):
             constraints.append((constraint.attrib['name'], {'values': [i.text for i in constraint.findall(util.nspath('Value', namespace))]}))
         self.constraints = dict(constraints)
 
+
 class BoundingBox(object):
+
     """Initialize an OWS BoundingBox construct"""
-    def __init__(self, elem, namespace=DEFAULT_OWS_NAMESPACE): 
+
+    def __init__(self, elem, namespace=DEFAULT_OWS_NAMESPACE):
         self.minx = None
         self.miny = None
         self.maxx = None
@@ -197,7 +214,7 @@ class BoundingBox(object):
             xy = tmp.split()
             if len(xy) > 1:
                 if self.crs is not None and self.crs.axisorder == 'yx':
-                    self.minx, self.miny = xy[1], xy[0] 
+                    self.minx, self.miny = xy[1], xy[0]
                 else:
                     self.minx, self.miny = xy[0], xy[1]
 
@@ -211,16 +228,19 @@ class BoundingBox(object):
                 else:
                     self.maxx, self.maxy = xy[0], xy[1]
 
+
 class WGS84BoundingBox(BoundingBox):
+
     """WGS84 bbox, axis order xy"""
+
     def __init__(self, elem, namespace=DEFAULT_OWS_NAMESPACE):
         BoundingBox.__init__(self, elem, namespace)
         self.dimensions = 2
         self.crs = crs.Crs('urn:ogc:def:crs:OGC:2:84')
 
 
-
 class ExceptionReport(Exception):
+
     """OWS ExceptionReport"""
 
     def __init__(self, elem, namespace=DEFAULT_OWS_NAMESPACE):
@@ -228,7 +248,7 @@ class ExceptionReport(Exception):
 
         if hasattr(elem, 'getroot'):
             elem = elem.getroot()
-            
+
         for i in elem.findall(util.nspath('Exception', namespace)):
             tmp = {}
             val = i.attrib.get('exceptionCode')

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -18,6 +18,8 @@ Currently supports version 1.1.0 (06-121r3).
 from owslib.etree import etree
 from owslib import crs, util
 from owslib.namespaces import Namespaces
+
+
 n = Namespaces()
 
 OWS_NAMESPACE_1_0_0 = n.get_namespace("ows")

--- a/owslib/sos.py
+++ b/owslib/sos.py
@@ -11,7 +11,7 @@
 Sensor Observation Service (SOS) methods and metadata. Factory function.
 """
 
-from swe.observation import sos100, sos200
+from owslib.swe.observation import sos100, sos200
 
 
 def SensorObservationService(url, version='1.0.0', xml=None):

--- a/owslib/sos.py
+++ b/owslib/sos.py
@@ -13,10 +13,10 @@ Sensor Observation Service (SOS) methods and metadata. Factory function.
 
 from swe.observation import sos100, sos200
 
+
 def SensorObservationService(url, version='1.0.0', xml=None):
     """sos factory function, returns a version specific SensorObservationService object"""
-    if version in  ['1.0', '1.0.0']:
+    if version in ['1.0', '1.0.0']:
         return sos100.SensorObservationService_1_0_0.__new__(sos100.SensorObservationService_1_0_0, url, version, xml)
     elif version in ['2.0', '2.0.0']:
         return sos200.SensorObservationService_2_0_0.__new__(sos200.SensorObservationService_2_0_0, url, version, xml)
-

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -460,11 +460,11 @@ class AbstractEncoding(object):
     def __new__(cls, element):
         t = element[-1].tag.split("}")[-1]
         if t == "TextEncoding":
-            return super(AbstractEncoding, cls).__new__(TextEncoding, element)
+            return super(AbstractEncoding, cls).__new__(TextEncoding)
         elif t == "XMLEncoding":
-            return super(AbstractEncoding, cls).__new__(XMLEncoding, element)
+            return super(AbstractEncoding, cls).__new__(XMLEncoding)
         elif t == "BinaryEncoding":
-            return super(AbstractEncoding, cls).__new__(BinaryEncoding, element)
+            return super(AbstractEncoding, cls).__new__(BinaryEncoding)
 
 
 class TextEncoding(AbstractEncoding):

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -7,13 +7,16 @@ from datetime import timedelta
 
 from owslib.etree import etree
 
+
 def get_namespaces():
     ns = Namespaces()
     return ns.get_namespaces(["swe20", "xlink"])
 namespaces = get_namespaces()
 
+
 def nspv(path):
     return nspath_eval(path, namespaces)
+
 
 def make_pair(string, cast=None):
     if string is None:
@@ -29,6 +32,7 @@ def make_pair(string, cast=None):
 
     return tuple(string)
 
+
 def get_uom(element):
 
     uom = testXMLAttribute(element, "code")
@@ -36,15 +40,17 @@ def get_uom(element):
         uom = testXMLAttribute(element, nspv("xlink:href"))
     return uom
 
+
 def get_boolean(value):
     if value is None:
         return None
-    if value is True or value.lower() in ["yes","true"]:
+    if value is True or value.lower() in ["yes", "true"]:
         return True
-    elif value is False or value.lower() in ["no","false"]:
+    elif value is False or value.lower() in ["no", "false"]:
         return False
     else:
         return None
+
 
 def get_int(value):
     try:
@@ -52,24 +58,27 @@ def get_int(value):
     except:
         return None
 
+
 def get_float(value):
     try:
         return float(value)
     except:
         return None
 
-AnyScalar    = map(lambda x: nspv(x), ["swe20:Boolean", "swe20:Count", "swe20:Quantity", "swe20:Time", "swe20:Category", "swe20:Text"])
+AnyScalar = map(lambda x: nspv(x), ["swe20:Boolean", "swe20:Count", "swe20:Quantity", "swe20:Time", "swe20:Category", "swe20:Text"])
 AnyNumerical = map(lambda x: nspv(x), ["swe20:Count", "swe20:Quantity", "swe20:Time"])
-AnyRange     = map(lambda x: nspv(x), ["swe20:QuantityRange", "swe20:TimeRange", "swe20:CountRange", "swe20:CategoryRange"])
+AnyRange = map(lambda x: nspv(x), ["swe20:QuantityRange", "swe20:TimeRange", "swe20:CountRange", "swe20:CategoryRange"])
+
 
 class NamedObject(object):
+
     def __init__(self, element):
         # No call to super(), the type object will process that.
-        self.name           = testXMLAttribute(element, "name")
+        self.name = testXMLAttribute(element, "name")
         try:
-            self.content    = eval(element[-1].tag.split("}")[-1])(element[-1])
+            self.content = eval(element[-1].tag.split("}")[-1])(element[-1])
         except IndexError:
-            self.content    = None
+            self.content = None
         except BaseException:
             raise
 
@@ -77,45 +86,55 @@ class NamedObject(object):
     def __getattr__(self, name):
         return getattr(self.content, name)
 
+
 class AbstractSWE(object):
+
     def __init__(self, element):
         # Attributes
-        self.id             = testXMLAttribute(element,"id")   # string, optional
+        self.id = testXMLAttribute(element, "id")   # string, optional
 
         # Elements
-        self.extention      = []                            # anyType, min=0, max=X
+        self.extention = []                            # anyType, min=0, max=X
+
 
 class AbstractSWEIdentifiable(AbstractSWE):
+
     def __init__(self, element):
         super(AbstractSWEIdentifiable, self).__init__(element)
         # Elements
-        self.identifier     = testXMLValue(element.find(nspv("swe20:identifier")))    # anyURI, min=0
-        self.label          = testXMLValue(element.find(nspv("swe20:label")))         # string, min=0
-        self.description    = testXMLValue(element.find(nspv("swe20:description")))   # string, min=0
+        self.identifier = testXMLValue(element.find(nspv("swe20:identifier")))    # anyURI, min=0
+        self.label = testXMLValue(element.find(nspv("swe20:label")))         # string, min=0
+        self.description = testXMLValue(element.find(nspv("swe20:description")))   # string, min=0
+
 
 class AbstractDataComponent(AbstractSWEIdentifiable):
+
     def __init__(self, element):
         super(AbstractDataComponent, self).__init__(element)
         # Attributes
-        self.definition     = testXMLAttribute(element,"definition")                        # anyURI, required
-        self.updatable      = get_boolean(testXMLAttribute(element,"updatable"))            # boolean, optional
-        self.optional       = get_boolean(testXMLAttribute(element,"optional")) or False    # boolean, default=False
+        self.definition = testXMLAttribute(element, "definition")                        # anyURI, required
+        self.updatable = get_boolean(testXMLAttribute(element, "updatable"))            # boolean, optional
+        self.optional = get_boolean(testXMLAttribute(element, "optional")) or False    # boolean, default=False
+
 
 class AbstractSimpleComponent(AbstractDataComponent):
+
     def __init__(self, element):
         super(AbstractSimpleComponent, self).__init__(element)
         # Attributes
-        self.referenceFrame = testXMLAttribute(element,"referenceFrame")    # anyURI, optional
-        self.axisID         = testXMLAttribute(element,"axisID")            # string, optional
+        self.referenceFrame = testXMLAttribute(element, "referenceFrame")    # anyURI, optional
+        self.axisID = testXMLAttribute(element, "axisID")            # string, optional
 
         # Elements
-        self.quality        = filter(None, [Quality(q) for q in [e.find('*') for e in element.findall(nspv("swe20:quality"))] if q is not None])
+        self.quality = filter(None, [Quality(q) for q in [e.find('*') for e in element.findall(nspv("swe20:quality"))] if q is not None])
         try:
-            self.nilValues  = NilValues(element.find(nspv("swe20:nilValues")))
+            self.nilValues = NilValues(element.find(nspv("swe20:nilValues")))
         except:
-            self.nilValues  = None
+            self.nilValues = None
+
 
 class Quality(object):
+
     def __new__(cls, element):
         t = element.tag.split("}")[-1]
         if t == "Quantity":
@@ -129,37 +148,49 @@ class Quality(object):
         else:
             return None
 
+
 class NilValues(AbstractSWE):
+
     def __init__(self, element):
         super(NilValues, self).__init__(element)
-        self.nilValue           = filter(None, [nilValue(x) for x in element.findall(nspv("swe20:nilValue"))]) # string, min=0, max=X
+        self.nilValue = filter(None, [nilValue(x) for x in element.findall(nspv("swe20:nilValue"))])  # string, min=0, max=X
+
 
 class nilValue(object):
+
     def __init__(self, element):
-        self.reason             = testXMLAttribute(element, "reason")
-        self.value              = testXMLValue(element)
+        self.reason = testXMLAttribute(element, "reason")
+        self.value = testXMLValue(element)
+
 
 class AllowedTokens(AbstractSWE):
+
     def __init__(self, element):
         super(AllowedTokens, self).__init__(element)
-        self.value              = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))]) # string, min=0, max=X
-        self.pattern            = testXMLValue(element.find(nspv("swe20:pattern")))                             # string (Unicode Technical Standard #18, Version 13), min=0
+        self.value = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))])  # string, min=0, max=X
+        self.pattern = testXMLValue(element.find(nspv("swe20:pattern")))                             # string (Unicode Technical Standard #18, Version 13), min=0
+
 
 class AllowedValues(AbstractSWE):
+
     def __init__(self, element):
         super(AllowedValues, self).__init__(element)
-        self.value              = filter(None, map(lambda x: get_float(x), [testXMLValue(x) for x in element.findall(nspv("swe20:value"))]))
-        self.interval           = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
+        self.value = filter(None, map(lambda x: get_float(x), [testXMLValue(x) for x in element.findall(nspv("swe20:value"))]))
+        self.interval = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
         self.significantFigures = get_int(testXMLValue(element.find(nspv("swe20:significantFigures"))))                                         # integer, min=0
 
+
 class AllowedTimes(AbstractSWE):
+
     def __init__(self, element):
         super(AllowedTimes, self).__init__(element)
-        self.value              = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))])
-        self.interval           = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
+        self.value = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))])
+        self.interval = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
         self.significantFigures = get_int(testXMLValue(element.find(nspv("swe20:significantFigures"))))                         # integer, min=0
 
+
 class Boolean(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Boolean, self).__init__(element)
         # Elements
@@ -167,224 +198,265 @@ class Boolean(AbstractSimpleComponent):
         6.2.1 Boolean
                 A Boolean representation of a proptery can take only two values that should be "true/false" or "yes/no".
         """
-        value               = get_boolean(testXMLValue(element.find(nspv("swe20:value"))))   # boolean, min=0, max=1
+        value = get_boolean(testXMLValue(element.find(nspv("swe20:value"))))   # boolean, min=0, max=1
+
 
 class Text(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Text, self).__init__(element)
         # Elements
         """
         Req 6. A textual representation shall at least consist of a character string.
         """
-        self.value          = testXMLValue(element.find(nspv("swe20:value")))                               # string, min=0, max=1
+        self.value = testXMLValue(element.find(nspv("swe20:value")))                               # string, min=0, max=1
 
         try:
-            self.constraint     = AllowedTokens(element.find(nspv("swe20:constraint/swe20:AllowedTokens"))) # AllowedTokens, min=0, max=1
+            self.constraint = AllowedTokens(element.find(nspv("swe20:constraint/swe20:AllowedTokens")))  # AllowedTokens, min=0, max=1
         except:
-            self.constraint     = None
+            self.constraint = None
 
 
 class Category(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Category, self).__init__(element)
         # Elements
-        self.codeSpace      = testXMLAttribute(element.find(nspv("swe20:codeSpace")), nspv("xlink:href"))   # Reference, min=0, max=1
-        self.value          = testXMLValue(element.find(nspv("swe20:value")))                               # string, min=0, max=1
+        self.codeSpace = testXMLAttribute(element.find(nspv("swe20:codeSpace")), nspv("xlink:href"))   # Reference, min=0, max=1
+        self.value = testXMLValue(element.find(nspv("swe20:value")))                               # string, min=0, max=1
 
         try:
-            self.constraint     = AllowedTokens(element.find(nspv("swe20:constraint/swe20:AllowedTokens"))) # AllowedTokens, min=0, max=1
+            self.constraint = AllowedTokens(element.find(nspv("swe20:constraint/swe20:AllowedTokens")))  # AllowedTokens, min=0, max=1
         except:
-            self.constraint     = None
+            self.constraint = None
 
 
 class CategoryRange(Category):
+
     def __init__(self, element):
         super(CategoryRange, self).__init__(element)
         # Elements
-        value               = testXMLValue(element.find(nspv("swe20:value")))
-        self.values         = make_pair(value) if value is not None else None
+        value = testXMLValue(element.find(nspv("swe20:value")))
+        self.values = make_pair(value) if value is not None else None
+
 
 class Count(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Count, self).__init__(element)
         # Elements
-        self.value          = get_int(testXMLValue(element.find(nspv("swe20:value"))))                  # integer, min=0, max=1
+        self.value = get_int(testXMLValue(element.find(nspv("swe20:value"))))                  # integer, min=0, max=1
 
         try:
-            self.constraint = AllowedValues(element.find(nspv("swe20:constraint/swe20:AllowedValues"))) # AllowedValues, min=0, max=1
+            self.constraint = AllowedValues(element.find(nspv("swe20:constraint/swe20:AllowedValues")))  # AllowedValues, min=0, max=1
         except:
             self.constraint = None
 
 
 class CountRange(Count):
+
     def __init__(self, element):
         super(CountRange, self).__init__(element)
         # Elements
-        value               = testXMLValue(element.find(nspv("swe20:value")))
-        self.value          = make_pair(value,int) if value is not None else None
+        value = testXMLValue(element.find(nspv("swe20:value")))
+        self.value = make_pair(value, int) if value is not None else None
+
 
 class Quantity(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Quantity, self).__init__(element)
         # Elements
-        self.uom            = get_uom(element.find(nspv("swe20:uom")))
-        self.value          = get_float(testXMLValue(element.find(nspv("swe20:value"))))                  # double, min=0, max=1
+        self.uom = get_uom(element.find(nspv("swe20:uom")))
+        self.value = get_float(testXMLValue(element.find(nspv("swe20:value"))))                  # double, min=0, max=1
 
         try:
             self.constraint = AllowedValues(element.find(nspv("swe20:constraint/swe20:AllowedValues")))   # AllowedValues, min=0, max=1
         except:
             self.constraint = None
 
+
 class QuantityRange(Quantity):
+
     def __init__(self, element):
         super(QuantityRange, self).__init__(element)
         # Elements
-        value               = testXMLValue(element.find(nspv("swe20:value")))
-        self.value          = make_pair(value,float) if value is not None else None
+        value = testXMLValue(element.find(nspv("swe20:value")))
+        self.value = make_pair(value, float) if value is not None else None
+
 
 def get_time(value, referenceTime, uom):
     try:
         value = parser.parse(value)
 
-    except (AttributeError, ValueError): # Most likely an integer/float using a referenceTime
+    except (AttributeError, ValueError):  # Most likely an integer/float using a referenceTime
         try:
             if uom.lower() == "s":
-                value  = referenceTime + timedelta(seconds=float(value))
+                value = referenceTime + timedelta(seconds=float(value))
             elif uom.lower() == "min":
-                value  = referenceTime + timedelta(minutes=float(value))
+                value = referenceTime + timedelta(minutes=float(value))
             elif uom.lower() == "h":
-                value  = referenceTime + timedelta(hours=float(value))
+                value = referenceTime + timedelta(hours=float(value))
             elif uom.lower() == "d":
-                value  = referenceTime + timedelta(days=float(value))
+                value = referenceTime + timedelta(days=float(value))
 
         except (AttributeError, ValueError):
             pass
 
-    except OverflowError: # Too many numbers (> 10) or INF/-INF
+    except OverflowError:  # Too many numbers (> 10) or INF/-INF
         if value.lower() == "inf":
-            value  = InfiniteDateTime()
+            value = InfiniteDateTime()
         elif value.lower() == "-inf":
-            value  = NegativeInfiniteDateTime()
+            value = NegativeInfiniteDateTime()
 
     return value
 
+
 class Time(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(Time, self).__init__(element)
         # Elements
-        self.uom                = get_uom(element.find(nspv("swe20:uom")))
+        self.uom = get_uom(element.find(nspv("swe20:uom")))
 
         try:
-            self.constraint     = AllowedTimes(element.find(nspv("swe20:constraint/swe20:AllowedTimes"))) # AllowedTimes, min=0, max=1
+            self.constraint = AllowedTimes(element.find(nspv("swe20:constraint/swe20:AllowedTimes")))  # AllowedTimes, min=0, max=1
         except:
-            self.constraint     = None
+            self.constraint = None
 
         # Attributes
-        self.localFrame         = testXMLAttribute(element,"localFrame")                                    # anyURI, optional
+        self.localFrame = testXMLAttribute(element, "localFrame")                                    # anyURI, optional
         try:
-            self.referenceTime  = parser.parse(testXMLAttribute(element,"referenceTime"))                   # dateTime, optional
+            self.referenceTime = parser.parse(testXMLAttribute(element, "referenceTime"))                   # dateTime, optional
         except (AttributeError, ValueError):
-            self.referenceTime  = None
+            self.referenceTime = None
 
-        value                   = testXMLValue(element.find(nspv("swe20:value")))                           # TimePosition, min=0, max=1
-        self.value              = get_time(value, self.referenceTime, self.uom)
+        value = testXMLValue(element.find(nspv("swe20:value")))                           # TimePosition, min=0, max=1
+        self.value = get_time(value, self.referenceTime, self.uom)
+
 
 class TimeRange(AbstractSimpleComponent):
+
     def __init__(self, element):
         super(TimeRange, self).__init__(element)
         # Elements
-        self.uom                = get_uom(element.find(nspv("swe20:uom")))
+        self.uom = get_uom(element.find(nspv("swe20:uom")))
 
         try:
-            self.constraint     = AllowedTimes(element.find(nspv("swe20:constraint/swe20:AllowedTimes"))) # AllowedTimes, min=0, max=1
+            self.constraint = AllowedTimes(element.find(nspv("swe20:constraint/swe20:AllowedTimes")))  # AllowedTimes, min=0, max=1
         except:
-            self.constraint     = None
+            self.constraint = None
 
         # Attributes
-        self.localFrame         = testXMLAttribute(element,"localFrame")                                # anyURI, optional
+        self.localFrame = testXMLAttribute(element, "localFrame")                                # anyURI, optional
         try:
-            self.referenceTime  = parser.parse(testXMLAttribute(element,"referenceTime"))               # dateTime, optional
+            self.referenceTime = parser.parse(testXMLAttribute(element, "referenceTime"))               # dateTime, optional
         except (AttributeError, ValueError):
-            self.referenceTime  = None
+            self.referenceTime = None
 
-        values                  = make_pair(testXMLValue(element.find(nspv("swe20:value"))))            # TimePosition, min=0, max=1
-        self.value              = [get_time(t, self.referenceTime, self.uom) for t in values]
+        values = make_pair(testXMLValue(element.find(nspv("swe20:value"))))            # TimePosition, min=0, max=1
+        self.value = [get_time(t, self.referenceTime, self.uom) for t in values]
+
 
 class DataRecord(AbstractDataComponent):
+
     def __init__(self, element):
         super(DataRecord, self).__init__(element)
         # Elements
-        self.field          = [Field(x) for x in element.findall(nspv("swe20:field"))]
+        self.field = [Field(x) for x in element.findall(nspv("swe20:field"))]
+
     def get_by_name(self, name):
         return next((x for x in self.field if x.name == name), None)
 
+
 class Field(NamedObject):
+
     def __init__(self, element):
         super(Field, self).__init__(element)
 
+
 class Vector(AbstractDataComponent):
+
     def __init__(self, element):
         super(Vector, self).__init__(element)
         # Elements
-        self.coordinate     = [Coordinate(x) for x in element.findall(nspv("swe20:coordinate"))]
+        self.coordinate = [Coordinate(x) for x in element.findall(nspv("swe20:coordinate"))]
 
         # Attributes
-        self.referenceFrame = testXMLAttribute(element,"referenceFrame")        # anyURI, required
-        self.localFrame     = testXMLAttribute(element,"localFrame")            # anyURI, optional
+        self.referenceFrame = testXMLAttribute(element, "referenceFrame")        # anyURI, required
+        self.localFrame = testXMLAttribute(element, "localFrame")            # anyURI, optional
+
     def get_by_name(self, name):
         return next((x for x in self.coordinate if x.name == name), None)
 
+
 class Coordinate(NamedObject):
+
     def __init__(self, element):
         super(Coordinate, self).__init__(element)
-        #if element[-1].tag not in AnyNumerical:
+        # if element[-1].tag not in AnyNumerical:
         #    print "Coordinate does not appear to be an AnyNumerical member"
 
+
 class DataChoice(AbstractDataComponent):
+
     def __init__(self, element):
         super(DataChoice, self).__init__(element)
-        self.item           = [Item(x) for x in element.findall(nspv("swe20:item"))]
+        self.item = [Item(x) for x in element.findall(nspv("swe20:item"))]
+
     def get_by_name(self, name):
         return next((x for x in self.item if x.name == name), None)
 
+
 class Item(NamedObject):
+
     def __init__(self, element):
         super(Item, self).__init__(element)
 
+
 class DataArray(AbstractDataComponent):
+
     def __init__(self, element):
         super(DataArray, self).__init__(element)
-        self.elementCount   = element.find(nspv("swe20:elementCount/swe20:Count"))      # required
-        self.elementType    = ElementType(element.find(nspv("swe20:elementType")))      # required
-        self.values         = testXMLValue(element.find(nspv("swe20:values")))
+        self.elementCount = element.find(nspv("swe20:elementCount/swe20:Count"))      # required
+        self.elementType = ElementType(element.find(nspv("swe20:elementType")))      # required
+        self.values = testXMLValue(element.find(nspv("swe20:values")))
         try:
-            self.encoding   = AbstractEncoding(element.find(nspv("swe20:encoding")))
+            self.encoding = AbstractEncoding(element.find(nspv("swe20:encoding")))
         except:
-            self.encoding   = None
+            self.encoding = None
+
 
 class Matrix(AbstractDataComponent):
+
     def __init__(self, element):
         super(Matrix, self).__init__(element)
-        self.elementCount   = element.find(nspv("swe20:elementCount/swe20:Count"))      # required
-        self.elementType    = ElementType(element.find(nspv("swe20:elementType")))      # required
-        self.encoding       = AbstractEncoding(element.find(nspv("swe20:encoding")))
-        self.values         = testXMLValue(element.find(nspv("swe20:values")))
+        self.elementCount = element.find(nspv("swe20:elementCount/swe20:Count"))      # required
+        self.elementType = ElementType(element.find(nspv("swe20:elementType")))      # required
+        self.encoding = AbstractEncoding(element.find(nspv("swe20:encoding")))
+        self.values = testXMLValue(element.find(nspv("swe20:values")))
         self.referenceFrame = testXMLAttribute(element, "referenceFrame")               # anyURI, required
-        self.localFrame     = testXMLAttribute(element, "localFrame")                   # anyURI, optional
+        self.localFrame = testXMLAttribute(element, "localFrame")                   # anyURI, optional
+
 
 class DataStream(AbstractSWEIdentifiable):
+
     def __init__(self, element):
         super(DataStream, self).__init__(element)
-        self.elementCount   = element.find(nspv("swe20:elementCount/swe20:Count"))      # optional
-        self.elementType    = ElementType(element.find(nspv("swe20:elementType")))      # optional
-        self.encoding       = AbstractEncoding(element.find(nspv("swe20:encoding")))
-        self.values         = testXMLValue(element.find(nspv("swe20:values")))
+        self.elementCount = element.find(nspv("swe20:elementCount/swe20:Count"))      # optional
+        self.elementType = ElementType(element.find(nspv("swe20:elementType")))      # optional
+        self.encoding = AbstractEncoding(element.find(nspv("swe20:encoding")))
+        self.values = testXMLValue(element.find(nspv("swe20:values")))
+
 
 class ElementType(NamedObject):
+
     def __init__(self, element):
         super(ElementType, self).__init__(element)
 
+
 class AbstractEncoding(object):
+
     def __new__(cls, element):
         t = element[-1].tag.split("}")[-1]
         if t == "TextEncoding":
@@ -394,17 +466,23 @@ class AbstractEncoding(object):
         elif t == "BinaryEncoding":
             return super(AbstractEncoding, cls).__new__(BinaryEncoding, element)
 
+
 class TextEncoding(AbstractEncoding):
+
     def __init__(self, element):
-        self.tokenSeparator         = testXMLAttribute(element[-1], "tokenSeparator")                           # string,  required
-        self.blockSeparator         = testXMLAttribute(element[-1], "blockSeparator")                           # string,  required
-        self.decimalSeparator       = testXMLAttribute(element[-1], "decimalSeparator") or "."                  # string,  optional, default="."
-        self.collapseWhiteSpaces    = get_boolean(testXMLAttribute(element[-1], "collapseWhiteSpaces")) or True # boolean, optional, default=True
+        self.tokenSeparator = testXMLAttribute(element[-1], "tokenSeparator")                           # string,  required
+        self.blockSeparator = testXMLAttribute(element[-1], "blockSeparator")                           # string,  required
+        self.decimalSeparator = testXMLAttribute(element[-1], "decimalSeparator") or "."                  # string,  optional, default="."
+        self.collapseWhiteSpaces = get_boolean(testXMLAttribute(element[-1], "collapseWhiteSpaces")) or True  # boolean, optional, default=True
+
 
 class XMLEncoding(AbstractEncoding):
+
     def __init__(self, element):
         raise NotImplementedError
 
+
 class BinaryEncoding(AbstractEncoding):
+
     def __init__(self, element):
         raise NotImplementedError

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -25,9 +25,9 @@ def make_pair(string, cast=None):
     string = string.split(" ")
     if cast is not None:
         try:
-            string = map(lambda x: cast(x), string)
+            string = [cast(x) for x in string]
         except:
-            print "Could not cast pair to correct type.  Setting to an empty tuple!"
+            print("Could not cast pair to correct type.  Setting to an empty tuple!")
             string = ""
 
     return tuple(string)
@@ -65,9 +65,9 @@ def get_float(value):
     except:
         return None
 
-AnyScalar = map(lambda x: nspv(x), ["swe20:Boolean", "swe20:Count", "swe20:Quantity", "swe20:Time", "swe20:Category", "swe20:Text"])
-AnyNumerical = map(lambda x: nspv(x), ["swe20:Count", "swe20:Quantity", "swe20:Time"])
-AnyRange = map(lambda x: nspv(x), ["swe20:QuantityRange", "swe20:TimeRange", "swe20:CountRange", "swe20:CategoryRange"])
+AnyScalar = [nspv(x) for x in ["swe20:Boolean", "swe20:Count", "swe20:Quantity", "swe20:Time", "swe20:Category", "swe20:Text"]]
+AnyNumerical = [nspv(x) for x in ["swe20:Count", "swe20:Quantity", "swe20:Time"]]
+AnyRange = [nspv(x) for x in ["swe20:QuantityRange", "swe20:TimeRange", "swe20:CountRange", "swe20:CategoryRange"]]
 
 
 class NamedObject(object):
@@ -126,7 +126,7 @@ class AbstractSimpleComponent(AbstractDataComponent):
         self.axisID = testXMLAttribute(element, "axisID")            # string, optional
 
         # Elements
-        self.quality = filter(None, [Quality(q) for q in [e.find('*') for e in element.findall(nspv("swe20:quality"))] if q is not None])
+        self.quality = [q for q in [Quality(q) for q in [e.find('*') for e in element.findall(nspv("swe20:quality"))] if q is not None] if q]
         try:
             self.nilValues = NilValues(element.find(nspv("swe20:nilValues")))
         except:
@@ -153,7 +153,7 @@ class NilValues(AbstractSWE):
 
     def __init__(self, element):
         super(NilValues, self).__init__(element)
-        self.nilValue = filter(None, [nilValue(x) for x in element.findall(nspv("swe20:nilValue"))])  # string, min=0, max=X
+        self.nilValue = [x for x in [nilValue(x) for x in element.findall(nspv("swe20:nilValue"))] if x]  # string, min=0, max=X
 
 
 class nilValue(object):
@@ -167,7 +167,7 @@ class AllowedTokens(AbstractSWE):
 
     def __init__(self, element):
         super(AllowedTokens, self).__init__(element)
-        self.value = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))])  # string, min=0, max=X
+        self.value = [x for x in [testXMLValue(x) for x in element.findall(nspv("swe20:value"))] if x]  # string, min=0, max=X
         self.pattern = testXMLValue(element.find(nspv("swe20:pattern")))                             # string (Unicode Technical Standard #18, Version 13), min=0
 
 
@@ -175,8 +175,8 @@ class AllowedValues(AbstractSWE):
 
     def __init__(self, element):
         super(AllowedValues, self).__init__(element)
-        self.value = filter(None, map(lambda x: get_float(x), [testXMLValue(x) for x in element.findall(nspv("swe20:value"))]))
-        self.interval = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
+        self.value = [x for x in [get_float(x) for x in [testXMLValue(x) for x in element.findall(nspv("swe20:value"))]] if x]
+        self.interval = [x for x in [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))] if x]
         self.significantFigures = get_int(testXMLValue(element.find(nspv("swe20:significantFigures"))))                                         # integer, min=0
 
 
@@ -184,31 +184,33 @@ class AllowedTimes(AbstractSWE):
 
     def __init__(self, element):
         super(AllowedTimes, self).__init__(element)
-        self.value = filter(None, [testXMLValue(x) for x in element.findall(nspv("swe20:value"))])
-        self.interval = filter(None, [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))])
+        self.value = [x for x in [testXMLValue(x) for x in element.findall(nspv("swe20:value"))] if x]
+        self.interval = [x for x in [make_pair(testXMLValue(x)) for x in element.findall(nspv("swe20:interval"))] if x]
         self.significantFigures = get_int(testXMLValue(element.find(nspv("swe20:significantFigures"))))                         # integer, min=0
 
 
 class Boolean(AbstractSimpleComponent):
 
+    """
+    6.2.1 Boolean
+            A Boolean representation of a proptery can take only two values that should be "true/false" or "yes/no".
+    """
+
     def __init__(self, element):
         super(Boolean, self).__init__(element)
         # Elements
-        """
-        6.2.1 Boolean
-                A Boolean representation of a proptery can take only two values that should be "true/false" or "yes/no".
-        """
         value = get_boolean(testXMLValue(element.find(nspv("swe20:value"))))   # boolean, min=0, max=1
 
 
 class Text(AbstractSimpleComponent):
 
+    """
+    Req 6. A textual representation shall at least consist of a character string.
+    """
+
     def __init__(self, element):
         super(Text, self).__init__(element)
         # Elements
-        """
-        Req 6. A textual representation shall at least consist of a character string.
-        """
         self.value = testXMLValue(element.find(nspv("swe20:value")))                               # string, min=0, max=1
 
         try:

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -1,11 +1,9 @@
-from owslib.util import nspath_eval
-from owslib.namespaces import Namespaces
-from owslib.util import testXMLAttribute, testXMLValue, InfiniteDateTime, NegativeInfiniteDateTime
-
-from dateutil import parser
 from datetime import timedelta
 
-from owslib.etree import etree
+from dateutil import parser
+
+from owslib.namespaces import Namespaces
+from owslib.util import nspath_eval, testXMLAttribute, testXMLValue, InfiniteDateTime, NegativeInfiniteDateTime
 
 
 def get_namespaces():

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -32,7 +32,7 @@ class SensorObservationService_1_0_0(object):
 
     def __getitem__(self, id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
-        if name in self.__getattribute__('contents').keys():
+        if id in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[id]
         else:
             raise KeyError('No Observational Offering with id: %s' % id)

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,8 +1,10 @@
+from six.moves.urllib.parse import urlencode, parse_qsl
+
 from owslib.etree import etree
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities
-from owslib.util import openURL, testXMLValue, nspath_eval, extract_time, urlencode, parse_qsl
+from owslib.util import openURL, testXMLValue, nspath_eval, extract_time
 from owslib.namespaces import Namespaces
 
 

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -8,27 +8,30 @@ from owslib.fes import FilterCapabilities
 from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
 from owslib.namespaces import Namespaces
 
+
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["ogc","sml","gml","sos","swe","xlink"])
+    ns = n.get_namespaces(["ogc", "sml", "gml", "sos", "swe", "xlink"])
     ns["ows"] = n.get_namespace("ows110")
     return ns
 namespaces = get_namespaces()
 
+
 class SensorObservationService_1_0_0(object):
+
     """
         Abstraction for OGC Sensor Observation Service (SOS).
 
         Implements ISensorObservationService.
     """
 
-    def __new__(self,url, version, xml=None, username=None, password=None):
+    def __new__(self, url, version, xml=None, username=None, password=None):
         """overridden __new__ method"""
-        obj=object.__new__(self)
+        obj = object.__new__(self)
         obj.__init__(url, version, xml, username, password)
         return obj
 
-    def __getitem__(self,id):
+    def __getitem__(self, id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
@@ -45,8 +48,8 @@ class SensorObservationService_1_0_0(object):
 
         # Authentication handled by Reader
         reader = SosCapabilitiesReader(
-                version=self.version, url=self.url, username=self.username, password=self.password
-                )
+            version=self.version, url=self.url, username=self.username, password=self.password
+        )
         if xml:  # read from stored xml
             self._capabilities = reader.read_string(xml)
         else:  # read from server
@@ -60,19 +63,19 @@ class SensorObservationService_1_0_0(object):
         self._build_metadata()
 
     def _build_metadata(self):
-        """ 
+        """
             Set up capabilities metadata objects
         """
         # ows:ServiceIdentification metadata
         service_id_element = self._capabilities.find(nspath_eval('ows:ServiceIdentification', namespaces))
         self.identification = ows.ServiceIdentification(service_id_element)
-        
+
         # ows:ServiceProvider metadata
         service_provider_element = self._capabilities.find(nspath_eval('ows:ServiceProvider', namespaces))
         self.provider = ows.ServiceProvider(service_provider_element)
-            
+
         # ows:OperationsMetadata metadata
-        self.operations=[]
+        self.operations = []
         for elem in self._capabilities.findall(nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
             self.operations.append(ows.OperationsMetadata(elem))
 
@@ -91,12 +94,12 @@ class SensorObservationService_1_0_0(object):
             self.contents[off.id] = off
             self.offerings.append(off)
 
-    def describe_sensor(self,   outputFormat=None,
-                                procedure=None,
-                                method='Get',
-                                **kwargs):
+    def describe_sensor(self, outputFormat=None,
+                        procedure=None,
+                        method='Get',
+                        **kwargs):
 
-        base_url = self.get_operation_by_name('DescribeSensor').methods[method]['url']        
+        base_url = self.get_operation_by_name('DescribeSensor').methods[method]['url']
         request = {'service': 'SOS', 'version': self.version, 'request': 'DescribeSensor'}
 
         # Required Fields
@@ -109,9 +112,9 @@ class SensorObservationService_1_0_0(object):
         # Optional Fields
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
-       
-        data = urlencode(request)        
+                request[kw] = kwargs[kw]
+
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password).read()
         tr = etree.fromstring(response)
@@ -121,12 +124,12 @@ class SensorObservationService_1_0_0(object):
 
         return response
 
-    def get_observation(self,   responseFormat=None,
-                                offerings=None,
-                                observedProperties=None,
-                                eventTime=None,
-                                method='Get',
-                                **kwargs):
+    def get_observation(self, responseFormat=None,
+                        offerings=None,
+                        observedProperties=None,
+                        eventTime=None,
+                        method='Get',
+                        **kwargs):
         """
         Parameters
         ----------
@@ -138,7 +141,7 @@ class SensorObservationService_1_0_0(object):
             anything else e.g. vendor specific parameters
         """
 
-        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']        
+        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']
         request = {'service': 'SOS', 'version': self.version, 'request': 'GetObservation'}
 
         # Required Fields
@@ -151,16 +154,15 @@ class SensorObservationService_1_0_0(object):
         assert isinstance(responseFormat, str)
         request['responseFormat'] = responseFormat
 
-
         # Optional Fields
         if eventTime is not None:
             request['eventTime'] = eventTime
 
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
+                request[kw] = kwargs[kw]
 
-        data = urlencode(request)        
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password).read()
         try:
@@ -168,13 +170,13 @@ class SensorObservationService_1_0_0(object):
             if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):
                 raise ows.ExceptionReport(tr)
             else:
-                return response                
+                return response
         except ows.ExceptionReport:
             raise
         except BaseException:
             return response
 
-    def get_operation_by_name(self, name): 
+    def get_operation_by_name(self, name):
         """
             Return a Operation item by name, case insensitive
         """
@@ -183,7 +185,9 @@ class SensorObservationService_1_0_0(object):
                 return item
         raise KeyError, "No Operation named %s" % name
 
+
 class SosObservationOffering(object):
+
     def __init__(self, element):
         self._root = element
 
@@ -241,8 +245,10 @@ class SosObservationOffering(object):
 
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
-        
+
+
 class SosCapabilitiesReader(object):
+
     def __init__(self, version="1.0.0", url=None, username=None, password=None):
         self.version = version
         self.url = url
@@ -278,7 +284,7 @@ class SosCapabilitiesReader(object):
             acceptVersions, and request parameters
         """
         getcaprequest = self.capabilities_url(service_url)
-        spliturl=getcaprequest.split('?')
+        spliturl = getcaprequest.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
         return etree.fromstring(u.read())
 
@@ -291,4 +297,3 @@ class SosCapabilitiesReader(object):
         if not isinstance(st, str):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
-

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,3 +1,4 @@
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode, parse_qsl
 
 from owslib.etree import etree
@@ -102,10 +103,10 @@ class SensorObservationService_1_0_0(object):
         request = {'service': 'SOS', 'version': self.version, 'request': 'DescribeSensor'}
 
         # Required Fields
-        assert isinstance(outputFormat, str)
+        assert isinstance(outputFormat, (text_type, binary_type))
         request['outputFormat'] = outputFormat
 
-        assert isinstance(procedure, str)
+        assert isinstance(procedure, (text_type, binary_type))
         request['procedure'] = procedure
 
         # Optional Fields
@@ -150,7 +151,7 @@ class SensorObservationService_1_0_0(object):
         assert isinstance(observedProperties, list) and len(observedProperties) > 0
         request['observedProperty'] = ','.join(observedProperties)
 
-        assert isinstance(responseFormat, str)
+        assert isinstance(responseFormat, (text_type, binary_type))
         request['responseFormat'] = responseFormat
 
         # Optional Fields
@@ -293,6 +294,6 @@ class SosCapabilitiesReader(object):
 
             st should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -25,9 +25,9 @@ class SensorObservationService_1_0_0(object):
         Implements ISensorObservationService.
     """
 
-    def __new__(self, url, version, xml=None, username=None, password=None):
+    def __new__(cls, url, version, xml=None, username=None, password=None):
         """overridden __new__ method"""
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, version, xml, username, password)
         return obj
 
@@ -36,7 +36,7 @@ class SensorObservationService_1_0_0(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
-            raise KeyError, "No Observational Offering with id: %s" % id
+            raise KeyError('No Observational Offering with id: %s' % id)
 
     def __init__(self, url, version='1.0.0', xml=None, username=None, password=None):
         """Initialize."""
@@ -183,7 +183,7 @@ class SensorObservationService_1_0_0(object):
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No Operation named %s" % name
+        raise KeyError('No Operation named %s' % name)
 
 
 class SosObservationOffering(object):
@@ -207,7 +207,7 @@ class SosObservationOffering(object):
             # (left, bottom, right, top) in self.bbox_srs units
             self.bbox = (float(lower_left_corner[1]), float(lower_left_corner[0]), float(upper_right_corner[1]), float(upper_right_corner[0]))
             self.bbox_srs = Crs(testXMLValue(envelope.attrib.get('srsName'), True))
-        except Exception, err:
+        except Exception as err:
             self.bbox = None
             self.bbox_srs = None
 

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,11 +1,8 @@
-import cgi
 from owslib.etree import etree
-from datetime import datetime
-from urllib import urlencode
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities
-from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
+from owslib.util import openURL, testXMLValue, nspath_eval, extract_time, urlencode, parse_qsl
 from owslib.namespaces import Namespaces
 
 
@@ -261,7 +258,7 @@ class SosCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,11 +1,8 @@
-import cgi
 from owslib.etree import etree
-from datetime import datetime
-from urllib import urlencode
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities200
-from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
+from owslib.util import openURL, testXMLValue, nspath_eval, extract_time, urlencode, parse_qsl
 from owslib.namespaces import Namespaces
 
 
@@ -267,7 +264,7 @@ class SosCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -8,9 +8,10 @@ from owslib.fes import FilterCapabilities200
 from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
 from owslib.namespaces import Namespaces
 
+
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["fes","ogc","om","gml32","sml","swe20","swes","xlink"])
+    ns = n.get_namespaces(["fes", "ogc", "om", "gml32", "sml", "swe20", "swes", "xlink"])
     ns["ows"] = n.get_namespace("ows110")
     ns["sos"] = n.get_namespace("sos20")
     return ns
@@ -18,19 +19,20 @@ namespaces = get_namespaces()
 
 
 class SensorObservationService_2_0_0(object):
+
     """
         Abstraction for OGC Sensor Observation Service (SOS).
 
         Implements ISensorObservationService.
     """
 
-    def __new__(self,url, version, xml=None, username=None, password=None):
+    def __new__(self, url, version, xml=None, username=None, password=None):
         """overridden __new__ method"""
-        obj=object.__new__(self)
+        obj = object.__new__(self)
         obj.__init__(url, version, xml, username, password)
         return obj
 
-    def __getitem__(self,id):
+    def __getitem__(self, id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
@@ -47,8 +49,8 @@ class SensorObservationService_2_0_0(object):
 
         # Authentication handled by Reader
         reader = SosCapabilitiesReader(
-                version=self.version, url=self.url, username=self.username, password=self.password
-                )
+            version=self.version, url=self.url, username=self.username, password=self.password
+        )
         if xml:  # read from stored xml
             self._capabilities = reader.read_string(xml)
         else:  # read from server
@@ -56,26 +58,26 @@ class SensorObservationService_2_0_0(object):
 
         # Avoid building metadata if the response is an Exception
         se = self._capabilities.find(nspath_eval('ows:ExceptionReport', namespaces))
-        if se is not None: 
-            raise ows.ExceptionReport(se) 
+        if se is not None:
+            raise ows.ExceptionReport(se)
 
         # build metadata objects
         self._build_metadata()
 
     def _build_metadata(self):
-        """ 
+        """
             Set up capabilities metadata objects
         """
         # ows:ServiceIdentification metadata
         service_id_element = self._capabilities.find(nspath_eval('ows:ServiceIdentification', namespaces))
         self.identification = ows.ServiceIdentification(service_id_element)
-        
+
         # ows:ServiceProvider metadata
         service_provider_element = self._capabilities.find(nspath_eval('ows:ServiceProvider', namespaces))
         self.provider = ows.ServiceProvider(service_provider_element)
-            
+
         # ows:OperationsMetadata metadata
-        self.operations= []
+        self.operations = []
         for elem in self._capabilities.findall(nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
             self.operations.append(ows.OperationsMetadata(elem))
 
@@ -95,12 +97,12 @@ class SensorObservationService_2_0_0(object):
             self.offerings.append(off)
 
     def describe_sensor(self, outputFormat=None,
-                              procedure=None,
-                              method='Get',
-                              **kwargs):
+                        procedure=None,
+                        method='Get',
+                        **kwargs):
 
         try:
-            base_url = self.get_operation_by_name('DescribeSensor').methods[method]['url']        
+            base_url = self.get_operation_by_name('DescribeSensor').methods[method]['url']
         except:
             base_url = self.url
         request = {'service': 'SOS', 'version': self.version, 'request': 'DescribeSensor'}
@@ -115,9 +117,9 @@ class SensorObservationService_2_0_0(object):
         # Optional Fields
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
-       
-        data = urlencode(request)        
+                request[kw] = kwargs[kw]
+
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password).read()
         tr = etree.fromstring(response)
@@ -128,11 +130,11 @@ class SensorObservationService_2_0_0(object):
         return response
 
     def get_observation(self, responseFormat=None,
-                              offerings=None,
-                              observedProperties=None,
-                              eventTime=None,
-                              method='Get',
-                              **kwargs):
+                        offerings=None,
+                        observedProperties=None,
+                        eventTime=None,
+                        method='Get',
+                        **kwargs):
         """
         Parameters
         ----------
@@ -144,7 +146,7 @@ class SensorObservationService_2_0_0(object):
             anything else e.g. vendor specific parameters
         """
 
-        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']        
+        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']
 
         request = {'service': 'SOS', 'version': self.version, 'request': 'GetObservation'}
 
@@ -164,9 +166,9 @@ class SensorObservationService_2_0_0(object):
 
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
+                request[kw] = kwargs[kw]
 
-        data = urlencode(request)        
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password).read()
         try:
@@ -174,13 +176,13 @@ class SensorObservationService_2_0_0(object):
             if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):
                 raise ows.ExceptionReport(tr)
             else:
-                return response                
+                return response
         except ows.ExceptionReport:
             raise
         except BaseException:
             return response
 
-    def get_operation_by_name(self, name): 
+    def get_operation_by_name(self, name):
         """
             Return a Operation item by name, case insensitive
         """
@@ -189,7 +191,9 @@ class SensorObservationService_2_0_0(object):
                 return item
         raise KeyError, "No Operation named %s" % name
 
+
 class SosObservationOffering(object):
+
     def __init__(self, element):
         self._root = element
 
@@ -247,8 +251,10 @@ class SosObservationOffering(object):
 
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
-        
+
+
 class SosCapabilitiesReader(object):
+
     def __init__(self, version="2.0.0", url=None, username=None, password=None):
         self.version = version
         self.url = url
@@ -284,7 +290,7 @@ class SosCapabilitiesReader(object):
             version, and request parameters
         """
         getcaprequest = self.capabilities_url(service_url)
-        spliturl=getcaprequest.split('?')
+        spliturl = getcaprequest.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
         return etree.fromstring(u.read())
 
@@ -297,4 +303,3 @@ class SosCapabilitiesReader(object):
         if not isinstance(st, str):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
-

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,8 +1,10 @@
+from six.moves.urllib.parse import urlencode, parse_qsl
+
 from owslib.etree import etree
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities200
-from owslib.util import openURL, testXMLValue, nspath_eval, extract_time, urlencode, parse_qsl
+from owslib.util import openURL, testXMLValue, nspath_eval, extract_time
 from owslib.namespaces import Namespaces
 
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -26,9 +26,9 @@ class SensorObservationService_2_0_0(object):
         Implements ISensorObservationService.
     """
 
-    def __new__(self, url, version, xml=None, username=None, password=None):
+    def __new__(cls, url, version, xml=None, username=None, password=None):
         """overridden __new__ method"""
-        obj = object.__new__(self)
+        obj = object.__new__(cls)
         obj.__init__(url, version, xml, username, password)
         return obj
 
@@ -37,7 +37,7 @@ class SensorObservationService_2_0_0(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
-            raise KeyError, "No Observational Offering with id: %s" % id
+            raise KeyError('No Observational Offering with id: %s' % id)
 
     def __init__(self, url, version='2.0.0', xml=None, username=None, password=None):
         """Initialize."""
@@ -189,7 +189,7 @@ class SensorObservationService_2_0_0(object):
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No Operation named %s" % name
+        raise KeyError('No Operation named %s' % name)
 
 
 class SosObservationOffering(object):
@@ -211,7 +211,7 @@ class SosObservationOffering(object):
             # (left, bottom, right, top) in self.bbox_srs units
             self.bbox = (float(lower_left_corner[1]), float(lower_left_corner[0]), float(upper_right_corner[1]), float(upper_right_corner[0]))
             self.bbox_srs = Crs(testXMLValue(envelope.attrib.get('srsName'), True))
-        except Exception, err:
+        except Exception as err:
             self.bbox = None
             self.bbox_srs = None
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -33,7 +33,7 @@ class SensorObservationService_2_0_0(object):
 
     def __getitem__(self, id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
-        if name in self.__getattribute__('contents').keys():
+        if id in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[id]
         else:
             raise KeyError('No Observational Offering with id: %s' % id)

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,3 +1,4 @@
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode, parse_qsl
 
 from owslib.etree import etree
@@ -107,10 +108,10 @@ class SensorObservationService_2_0_0(object):
         request = {'service': 'SOS', 'version': self.version, 'request': 'DescribeSensor'}
 
         # Required Fields
-        assert isinstance(outputFormat, str)
+        assert isinstance(outputFormat, (text_type, binary_type))
         request['procedureDescriptionFormat'] = outputFormat
 
-        assert isinstance(procedure, str)
+        assert isinstance(procedure, (text_type, binary_type))
         request['procedure'] = procedure
 
         # Optional Fields
@@ -299,6 +300,6 @@ class SosCapabilitiesReader(object):
 
             st should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -65,13 +65,13 @@ class PropertyGroup(object):
         """
             Return list of element by name, case insensitive
         """
-        return [self.capabilities[capab] for capab in self.capabilities.keys() if capab.lower() == name.lower()]
+        return [self.capabilities[capab] for capab in self.capabilities if capab.lower() == name.lower()]
 
     def get_characteristics_by_name(self, name):
         """
             Return list of element objects by name, case insensitive
         """
-        return [self.characteristics[charac] for charac in self.characteristics.keys() if charac.lower() == name.lower()]
+        return [self.characteristics[charac] for charac in self.characteristics if charac.lower() == name.lower()]
 
 
 class ConstraintGroup(object):
@@ -131,7 +131,7 @@ class ReferenceGroup(object):
         """
             Return a Contact by role, case insensitive
         """
-        return [self.contacts[contact] for contact in self.contacts.keys() if contact.lower() == role.lower()]
+        return [self.contacts[contact] for contact in self.contacts if contact.lower() == role.lower()]
 
 
 class GeneralInfoGroup(object):
@@ -153,13 +153,13 @@ class GeneralInfoGroup(object):
         """
             Return list of Identifier objects by name, case insensitive
         """
-        return [self.identifiers[identifier] for identifier in self.identifiers.keys() if identifier.lower() == name.lower()]
+        return [self.identifiers[identifier] for identifier in self.identifiers if identifier.lower() == name.lower()]
 
     def get_classifiers_by_name(self, name):
         """
             Return list of Classifier objects by name, case insensitive
         """
-        return [self.classifiers[classi] for classi in self.classifiers.keys() if classi.lower() == name.lower()]
+        return [self.classifiers[classi] for classi in self.classifiers if classi.lower() == name.lower()]
 
 
 class Contact(object):

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -5,17 +5,21 @@ from owslib import crs, util
 from owslib.util import testXMLValue, testXMLAttribute, nspath_eval, xmltag_split, dict_union, extract_xml_list
 from owslib.namespaces import Namespaces
 
+
 def get_namespaces():
     n = Namespaces()
-    namespaces = n.get_namespaces(["sml","gml","xlink"])
+    namespaces = n.get_namespaces(["sml", "gml", "xlink"])
     namespaces["ism"] = "urn:us:gov:ic:ism:v2"
     return namespaces
 namespaces = get_namespaces()
 
+
 def nsp(path):
     return nspath_eval(path, namespaces)
 
+
 class SensorML(object):
+
     def __init__(self, element):
         if isinstance(element, str):
             self._root = etree.fromstring(element)
@@ -27,7 +31,9 @@ class SensorML(object):
 
         self.members = [Member(x) for x in self._root.findall(nsp('sml:member'))]
 
+
 class Member(object):
+
     def __new__(cls, element):
         t = element[-1].tag.split("}")[-1]
         if t == "System":
@@ -39,7 +45,9 @@ class Member(object):
         elif t == "Component":
             return Component(element.find(nsp("sml:Component")))
 
+
 class PropertyGroup(object):
+
     def __init__(self, element):
         # Both capabilities and characteristics contain a single swe:DataRecord element
         self.capabilities = {}
@@ -66,46 +74,56 @@ class PropertyGroup(object):
         """
         return [self.characteristics[charac] for charac in self.characteristics.keys() if charac.lower() == name.lower()]
 
+
 class ConstraintGroup(object):
+
     def __init__(self, element):
         # ism:SecurityAttributesOptionsGroup
-        self.security            = element.findall(nsp("sml:securityConstraint/sml:Security/ism:SecurityAttributesOptionGroup"))
+        self.security = element.findall(nsp("sml:securityConstraint/sml:Security/ism:SecurityAttributesOptionGroup"))
         # gml:TimeInstant or gml:TimePeriod element
-        self.validTime           = element.find(nsp("sml:validTime"))
-        self.rights              = [Right(x) for x in element.findall(nsp("sml:legalConstraint/sml:Rights"))]
+        self.validTime = element.find(nsp("sml:validTime"))
+        self.rights = [Right(x) for x in element.findall(nsp("sml:legalConstraint/sml:Rights"))]
+
 
 class Documentation(object):
+
     def __init__(self, element):
-        self.arcrole   = testXMLAttribute(element, nsp("xlink:arcrole"))
-        self.url       = testXMLAttribute(element, nsp("xlink:href"))
+        self.arcrole = testXMLAttribute(element, nsp("xlink:arcrole"))
+        self.url = testXMLAttribute(element, nsp("xlink:href"))
         self.documents = [Document(d) for d in element.findall(nsp("sml:Document"))]
 
+
 class Document(object):
+
     def __init__(self, element):
-        self.id          = testXMLAttribute(element, nsp("gml:id"))
-        self.version     = testXMLValue(element.find(nsp("sml:version")))
+        self.id = testXMLAttribute(element, nsp("gml:id"))
+        self.version = testXMLValue(element.find(nsp("sml:version")))
         self.description = testXMLValue(element.find(nsp("gml:description")))
-        self.date        = testXMLValue(element.find(nsp("sml:date")))
+        self.date = testXMLValue(element.find(nsp("sml:date")))
         try:
-            self.contact     = Contact(element.find(nsp("sml:contact")))
+            self.contact = Contact(element.find(nsp("sml:contact")))
         except AttributeError:
-            self.contact     = None
-        self.format      = testXMLValue(element.find(nsp('sml:format')))
-        self.url         = testXMLAttribute(element.find(nsp('sml:onlineResource')), nsp('xlink:href'))
+            self.contact = None
+        self.format = testXMLValue(element.find(nsp('sml:format')))
+        self.url = testXMLAttribute(element.find(nsp('sml:onlineResource')), nsp('xlink:href'))
+
 
 class Right(object):
+
     def __init__(self, element):
-        self.id                         = testXMLAttribute(element, nsp('gml:id'))
-        self.privacyAct                 = testXMLAttribute(element, nsp('sml:privacyAct'))
+        self.id = testXMLAttribute(element, nsp('gml:id'))
+        self.privacyAct = testXMLAttribute(element, nsp('sml:privacyAct'))
         self.intellectualPropertyRights = testXMLAttribute(element, nsp('sml:intellectualPropertyRights'))
-        self.copyRights                 = testXMLAttribute(element, nsp('sml:copyRights'))
-        self.documentation              = [Documentation(x) for x in element.findall(nsp("sml:documentation"))]
+        self.copyRights = testXMLAttribute(element, nsp('sml:copyRights'))
+        self.documentation = [Documentation(x) for x in element.findall(nsp("sml:documentation"))]
+
 
 class ReferenceGroup(object):
+
     def __init__(self, element):
         self.contacts = {}
         for contact in element.findall(nsp('sml:contact')):
-            cont                     = Contact(contact)
+            cont = Contact(contact)
             self.contacts[cont.role] = cont
 
         self.documentation = [Documentation(x) for x in element.findall(nsp("sml:documentation"))]
@@ -116,9 +134,11 @@ class ReferenceGroup(object):
         """
         return [self.contacts[contact] for contact in self.contacts.keys() if contact.lower() == role.lower()]
 
+
 class GeneralInfoGroup(object):
+
     def __init__(self, element):
-        self.keywords    = extract_xml_list(element.findall(nsp('sml:keywords/sml:KeywordList/sml:keyword')))
+        self.keywords = extract_xml_list(element.findall(nsp('sml:keywords/sml:KeywordList/sml:keyword')))
 
         self.identifiers = {}
         for identifier in element.findall(nsp('sml:identification/sml:IdentifierList/sml:identifier')):
@@ -142,23 +162,27 @@ class GeneralInfoGroup(object):
         """
         return [self.classifiers[classi] for classi in self.classifiers.keys() if classi.lower() == name.lower()]
 
+
 class Contact(object):
+
     def __init__(self, element):
         # TODO: This only supports the sml:contact/sml:ResponsibleParty elements, but there are numerous ways to store
         # contact information here.
-        self.role         = testXMLAttribute(element, nsp("xlink:role"))
-        self.href         = testXMLAttribute(element, nsp("xlink:href"))
+        self.role = testXMLAttribute(element, nsp("xlink:role"))
+        self.href = testXMLAttribute(element, nsp("xlink:href"))
         self.organization = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:organizationName')))
-        self.phone        = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:phone/sml:voice')))
-        self.address      = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:deliveryPoint')))
-        self.city         = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:city')))
-        self.region       = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:administrativeArea')))
-        self.postcode     = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:postalCode')))
-        self.country      = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:country')))
-        self.email        = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:electronicMailAddress')))
-        self.url          = testXMLAttribute(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:onlineResource')), nsp("xlink:href"))
+        self.phone = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:phone/sml:voice')))
+        self.address = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:deliveryPoint')))
+        self.city = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:city')))
+        self.region = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:administrativeArea')))
+        self.postcode = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:postalCode')))
+        self.country = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:country')))
+        self.email = testXMLValue(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:address/sml:electronicMailAddress')))
+        self.url = testXMLAttribute(element.find(nsp('sml:ResponsibleParty/sml:contactInfo/sml:onlineResource')), nsp("xlink:href"))
+
 
 class HistoryGroup(object):
+
     def __init__(self, element):
         self.history = {}
         for event_member in element.findall(nsp('sml:history/sml:EventList/sml:member')):
@@ -174,15 +198,19 @@ class HistoryGroup(object):
         """
         return self.history.get(name.lower(), [])
 
+
 class Event(ReferenceGroup, GeneralInfoGroup):
+
     def __init__(self, element):
         ReferenceGroup.__init__(self, element)
         GeneralInfoGroup.__init__(self, element)
-        self.id            = testXMLAttribute(element, nsp("gml:id"))
-        self.date          = testXMLValue(element.find(nsp('sml:date')))
-        self.description   = testXMLValue(element.find(nsp('gml:description')))
+        self.id = testXMLAttribute(element, nsp("gml:id"))
+        self.date = testXMLValue(element.find(nsp('sml:date')))
+        self.description = testXMLValue(element.find(nsp('gml:description')))
+
 
 class MetadataGroup(GeneralInfoGroup, PropertyGroup, ConstraintGroup, ReferenceGroup, HistoryGroup):
+
     def __init__(self, element):
         GeneralInfoGroup.__init__(self, element)
         PropertyGroup.__init__(self, element)
@@ -190,130 +218,168 @@ class MetadataGroup(GeneralInfoGroup, PropertyGroup, ConstraintGroup, ReferenceG
         ReferenceGroup.__init__(self, element)
         HistoryGroup.__init__(self, element)
 
+
 class AbstractFeature(object):
+
     def __init__(self, element):
-        self.name         = testXMLValue(element.find(nsp("gml:name")))
-        self.description  = testXMLValue(element.find(nsp("gml:description")))
+        self.name = testXMLValue(element.find(nsp("gml:name")))
+        self.description = testXMLValue(element.find(nsp("gml:description")))
         self.gmlBoundedBy = testXMLValue(element.find(nsp("gml:boundedBy")))
 
+
 class AbstractProcess(AbstractFeature, MetadataGroup):
+
     def __init__(self, element):
         AbstractFeature.__init__(self, element)
         MetadataGroup.__init__(self, element)
         # sml:IoComponentPropertyType
-        self.inputs     = element.findall(nsp("sml:input"))
+        self.inputs = element.findall(nsp("sml:input"))
         # sml:IoComponentPropertyType
-        self.outputs    = element.findall(nsp("sml:output"))
+        self.outputs = element.findall(nsp("sml:output"))
         # swe:DataComponentPropertyType
         self.parameters = element.findall(nsp("sml:parameter"))
 
+
 class AbstractRestrictedProcess(AbstractFeature):
+
     """ Removes ('restricts' in xml schema language) gml:name, gml:description, and sml:metadataGroup from an AbstractProcess """
+
     def __init__(self, element):
         AbstractFeature.__init__(self, element)
-        self.name        = None
+        self.name = None
         self.description = None
 
+
 class AbstractPureProcess(AbstractRestrictedProcess):
+
     def __init__(self, element):
         AbstractRestrictedProcess.__init__(self, element)
 
         # sml:IoComponentPropertyType
-        self.inputs      = element.findall(nsp("sml:input"))
+        self.inputs = element.findall(nsp("sml:input"))
         # sml:IoComponentPropertyType
-        self.outputs     = element.findall(nsp("sml:output"))
+        self.outputs = element.findall(nsp("sml:output"))
         # swe:DataComponentPropertyType
-        self.parameters  = element.findall(nsp("sml:parameter"))
+        self.parameters = element.findall(nsp("sml:parameter"))
+
 
 class ProcessModel(AbstractPureProcess):
+
     def __init__(self, element):
         AbstractPureProcess.__init__(self, element)
         self.method = ProcessMethod(element.find("method"))
 
+
 class CompositePropertiesGroup(object):
+
     def __init__(self, element):
         # All components should be of instance AbstractProcess (sml:_Process)
-        self.components  = element.findall(nsp("sml:components/sml:ComponentList/sml:component"))
+        self.components = element.findall(nsp("sml:components/sml:ComponentList/sml:component"))
         # sml:Link or sml:ArrayLink element
         self.connections = element.findall(nsp("sml:connections/sml:ConnectionList/sml:connection"))
 
+
 class PhysicalPropertiesGroup(object):
+
     def __init__(self, element):
         # gml:EngieeringCRS element
-        self.spatialReferenceFrame  = element.find(nsp("sml:spatialReferenceFrame/gml:EngineeringCRS"))
+        self.spatialReferenceFrame = element.find(nsp("sml:spatialReferenceFrame/gml:EngineeringCRS"))
         # gml:TemporalCRS element
         self.temporalReferenceFrame = element.find(nsp("sml:temporalReferenceFrame/gml:TemporalCRS"))
         # gml:Envelope element
-        self.smlBoundedBy           = element.find(nsp("sml:boundedBy"))
+        self.smlBoundedBy = element.find(nsp("sml:boundedBy"))
         # swe:Time or sml:_Process element
-        self.timePosition           = element.find(nsp("sml:timePosition"))
+        self.timePosition = element.find(nsp("sml:timePosition"))
 
         # It is either a sml:position OR and sml:location element here.  Process both.
         # swe:Position, swe:Vector, or sml:_Process element
-        self.positions              = element.findall(nsp("sml:position"))
+        self.positions = element.findall(nsp("sml:position"))
         # gml:Point of gml:_Curve
-        self.location               = element.find(nsp("sml:location"))
+        self.location = element.find(nsp("sml:location"))
 
         try:
             self.interface = Interface(element.find(nsp("sml:interface")))
         except AttributeError:
             self.interface = None
 
+
 class ProcessChain(AbstractPureProcess, CompositePropertiesGroup):
+
     def __init__(self, element):
         AbstractPureProcess.__init__(self, element)
         CompositePropertiesGroup.__init__(self, element)
 
+
 class System(AbstractProcess, PhysicalPropertiesGroup, CompositePropertiesGroup):
+
     def __init__(self, element):
         AbstractProcess.__init__(self, element)
         PhysicalPropertiesGroup.__init__(self, element)
         CompositePropertiesGroup.__init__(self, element)
 
+
 class Component(AbstractProcess, PhysicalPropertiesGroup):
+
     def __init__(self, element):
         AbstractProcess.__init__(self, element)
         PhysicalPropertiesGroup.__init__(self, element)
         self.method = ProcessMethod(element.find("method"))
 
+
 class Term(object):
+
     def __init__(self, element):
-        self.codeSpace  = testXMLAttribute(element.find(nsp('sml:Term/sml:codeSpace')), nsp("xlink:href"))
+        self.codeSpace = testXMLAttribute(element.find(nsp('sml:Term/sml:codeSpace')), nsp("xlink:href"))
         self.definition = testXMLAttribute(element.find(nsp('sml:Term')), "definition")
-        self.value      = testXMLValue(element.find(nsp('sml:Term/sml:value')))
+        self.value = testXMLValue(element.find(nsp('sml:Term/sml:value')))
+
 
 class Classifier(Term):
+
     def __init__(self, element):
         Term.__init__(self, element)
-        self.name      = testXMLAttribute(element, "name")
+        self.name = testXMLAttribute(element, "name")
+
 
 class Identifier(Term):
+
     def __init__(self, element):
         Term.__init__(self, element)
-        self.name      = testXMLAttribute(element, "name")
+        self.name = testXMLAttribute(element, "name")
+
 
 class ProcessMethod(MetadataGroup):
+
     """ Inherits from gml:AbstractGMLType """
+
     def __init__(self, element):
         MetadataGroup.__init__(self, element)
-        self.rules           = element.find(nsp("sml:rules"))
-        self.ioStructure     = element.find(nsp("sml:IOStructureDefinition"))
-        self.algorithm       = element.find(nsp("sml:algorithm"))
+        self.rules = element.find(nsp("sml:rules"))
+        self.ioStructure = element.find(nsp("sml:IOStructureDefinition"))
+        self.algorithm = element.find(nsp("sml:algorithm"))
         self.implementations = element.findall(nsp("sml:implementation"))
 
+
 class Interface(object):
+
     def __init__(self, element):
-        self.name                 = testXMLAttribute(element, "name")
+        self.name = testXMLAttribute(element, "name")
         self.interface_definition = InterfaceDefinition(element.find(nsp("sml:InterfaceDefinition")))
 
+
 class InterfaceDefinition(object):
+
     def __init__(self, element):
         raise NotImplementedError("InterfaceDefinition is not implemented in OWSLib (yet)")
 
+
 class Link(object):
+
     def __init__(self, element):
         raise NotImplementedError("Link is not implemented in OWSLib (yet)")
 
+
 class ArrayLink(object):
+
     def __init__(self, element):
         raise NotImplementedError("ArrayLink is not implemented in OWSLib (yet)")

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -1,8 +1,7 @@
 # encoding: utf-8
 
 from owslib.etree import etree
-from owslib import crs, util
-from owslib.util import testXMLValue, testXMLAttribute, nspath_eval, xmltag_split, dict_union, extract_xml_list
+from owslib.util import testXMLValue, testXMLAttribute, nspath_eval, extract_xml_list
 from owslib.namespaces import Namespaces
 
 

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type, binary_type
+
 from owslib.etree import etree
 from owslib.util import testXMLValue, testXMLAttribute, nspath_eval, extract_xml_list
 from owslib.namespaces import Namespaces
@@ -20,7 +22,7 @@ def nsp(path):
 class SensorML(object):
 
     def __init__(self, element):
-        if isinstance(element, str):
+        if isinstance(element, (text_type, binary_type)):
             self._root = etree.fromstring(element)
         else:
             self._root = element

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -15,10 +15,10 @@
 # TMS as defined in:
 # http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
 
-from six import itervalues
+from six import itervalues, text_type, binary_type
 
 from owslib.etree import etree
-from owslib.util import openURL, testXMLValue
+from owslib.util import openURL, testXMLValue, OrderedDict
 
 
 FORCE900913 = False
@@ -50,7 +50,7 @@ class TileMapService(object):
         self.version = version
         self.services = None
         self._capabilities = None
-        self.contents = {}
+        self.contents = OrderedDict()
 
         # Authentication handled by Reader
         reader = TMSCapabilitiesReader(
@@ -78,7 +78,7 @@ class TileMapService(object):
             self.version = self._capabilities.attrib.get('version')
         self.identification = ServiceIdentification(self._capabilities, self.version)
 
-        self.contents = {}
+        self.contents = OrderedDict()
         tilemaps = self._capabilities.find('TileMaps')
         if tilemaps is not None:
             for tilemap in tilemaps.findall('TileMap'):
@@ -118,7 +118,7 @@ class TileMapService(object):
     def _gettilefromset(self, tilesets, x, y, z, ext):
         for tileset in tilesets:
             if tileset['order'] == z:
-                url = tileset['href'] + '/' + str(x) + '/' + str(y) + '.' + ext
+                url = tileset['href'] + '/' + text_type(x) + '/' + text_type(y) + '.' + ext
                 u = openURL(url, '', username=self.username,
                             password=self.password)
                 return u
@@ -295,8 +295,8 @@ class TileMap(object):
         self._parse(etree.fromstring(u.read()))
 
     def readString(self, st):
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         self._parse(etree.fromstring(st))
 
 
@@ -325,6 +325,6 @@ class TMSCapabilitiesReader(object):
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -15,6 +15,8 @@
 # TMS as defined in:
 # http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
 
+from six import itervalues
+
 from owslib.etree import etree
 from owslib.util import openURL, testXMLValue
 
@@ -130,7 +132,7 @@ class TileMapService(object):
                                         x, y, z, self.contents[id].tilemap.extension)
 
         elif title and srs:
-            for tm in self.contents.values():
+            for tm in itervalues(self.contents):
                 if tm.title == title and tm.srs == srs:
                     if mimetype:
                         if tm.tilemap.mimetype == mimetype:

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -15,8 +15,9 @@
 # TMS as defined in:
 # http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
 
-from etree import etree
-from .util import openURL, testXMLValue
+from owslib.etree import etree
+from owslib.util import openURL, testXMLValue
+
 
 FORCE900913 = False
 

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -39,8 +39,7 @@ class TileMapService(object):
     """
 
     def __init__(self, url, version='1.0.0', xml=None,
-                 username=None, password=None, parse_remote_metadata=False
-                 ):
+                 username=None, password=None, parse_remote_metadata=False):
         """Initialize."""
         self.url = url
         self.username = username
@@ -120,8 +119,7 @@ class TileMapService(object):
                 u = openURL(url, '', username=self.username,
                             password=self.password)
                 return u
-        else:
-            raise ValueError('cannot find zoomlevel %i for TileMap' % z)
+        raise ValueError('cannot find zoomlevel %i for TileMap' % z)
 
     def gettile(self, x, y, z, id=None, title=None, srs=None, mimetype=None):
         if not id and not title and not srs:
@@ -142,9 +140,8 @@ class TileMapService(object):
                         # first tilemap that matches name and srs
                         return self._gettilefromset(tm.tilemap.tilesets,
                                                     x, y, z, tm.tilemap.extension)
-            else:
-                raise ValueError('cannot find %s with projection %s for zoomlevel %i'
-                                 % (title, srs, z))
+            raise ValueError('cannot find %s with projection %s for zoomlevel %i'
+                             % (title, srs, z))
         elif title or srs:
             ValueError('both title and srs must be specified')
         raise ValueError('''Specified Tile with id %s, title %s

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import re
 from copy import deepcopy
 
+from six import iteritems
 from six.moves.urllib.parse import urlencode, urlsplit, parse_qsl
 from six.moves.urllib.request import (urlopen, build_opener, Request, HTTPBasicAuthHandler,
                                       HTTPPasswordMgrWithDefaultRealm)
@@ -48,7 +49,7 @@ class ServiceException(Exception):
 # http://stackoverflow.com/questions/6256183/combine-two-dictionaries-of-dictionaries-python
 dict_union = lambda d1, d2: dict((x, (dict_union(d1.get(x, {}), d2[x]) if
                                       isinstance(d2.get(x), dict) else d2.get(x, d1.get(x)))) for x in
-                                 set(d1.keys() + d2.keys()))
+                                 set(list(d1.keys()) + list(d2.keys())))
 
 
 # Infinite DateTimes for Python.  Used in SWE 2.0 and other OGC specs as "INF" and "-INF"
@@ -427,7 +428,7 @@ def build_get_url(base_url, params):
 
     pars = [x[0] for x in qs]
 
-    for key, value in params.iteritems():
+    for key, value in iteritems(params):
         if key not in pars:
             qs.append((key, value))
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -11,15 +11,15 @@
 Utility functions and classes
 """
 
-import sys
 from datetime import datetime
 import re
 from copy import deepcopy
 
-PY2 = sys.version_info[0] == 2
-from urlparse import urlsplit, parse_qsl
-from urllib import urlencode
-from urllib2 import urlopen, build_opener, Request, HTTPError, HTTPBasicAuthHandler, HTTPPasswordMgrWithDefaultRealm
+from six.moves.urllib.parse import urlencode, urlsplit, parse_qsl
+from six.moves.urllib.request import (urlopen, build_opener, Request, HTTPBasicAuthHandler,
+                                      HTTPPasswordMgrWithDefaultRealm)
+from six.moves.urllib.error import HTTPError
+
 from StringIO import StringIO
 
 from dateutil import parser
@@ -132,7 +132,11 @@ def xml_to_dict(root, prefix=None, depth=1, diction=None):
 
 
 def openURL(url_base, data, method='Get', cookies=None, username=None, password=None, timeout=30):
-    ''' function to open urls - wrapper around urllib2.urlopen but with additional checks for OGC service exceptions and url formatting, also handles cookies and simple user password authentication'''
+    '''
+    function to open urls - wrapper around urllib2.urlopen/urllib.request.urlopen
+    but with additional checks for OGC service exceptions and url formatting,
+    also handles cookies and simple user password authentication
+    '''
     url_base.strip()
     lastchar = url_base[-1]
     if lastchar not in ['?', '&']:
@@ -152,7 +156,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         openit = opener.open
     else:
         # NOTE: optionally set debuglevel>0 to debug HTTP connection
-        #opener = urllib2.build_opener(urllib2.HTTPHandler(debuglevel=0))
+        #opener = build_opener(HTTPHandler(debuglevel=0))
         #openit = opener.open
         openit = urlopen
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -13,7 +13,8 @@ from datetime import datetime
 import pytz
 from owslib.etree import etree
 from owslib.namespaces import Namespaces
-import urlparse, urllib2
+import urlparse
+import urllib2
 from urllib2 import urlopen, HTTPError, Request
 from urllib2 import HTTPPasswordMgrWithDefaultRealm
 from urllib2 import HTTPBasicAuthHandler
@@ -28,45 +29,58 @@ from copy import deepcopy
 Utility functions and classes
 """
 
-class RereadableURL(StringIO,object):
+
+class RereadableURL(StringIO, object):
+
     """ Class that acts like a combination of StringIO and url - has seek method and url headers etc """
+
     def __init__(self, u):
-        #get url headers etc from url
-        self.headers = u.headers                
-        #get file like seek, read methods from StringIO
-        content=u.read()
+        # get url headers etc from url
+        self.headers = u.headers
+        # get file like seek, read methods from StringIO
+        content = u.read()
         super(RereadableURL, self).__init__(content)
 
 
 class ServiceException(Exception):
-    #TODO: this should go in ows common module when refactored.  
+    # TODO: this should go in ows common module when refactored.
     pass
 
 # http://stackoverflow.com/questions/6256183/combine-two-dictionaries-of-dictionaries-python
-dict_union = lambda d1,d2: dict((x,(dict_union(d1.get(x,{}),d2[x]) if
-  isinstance(d2.get(x),dict) else d2.get(x,d1.get(x)))) for x in
-  set(d1.keys()+d2.keys()))
+dict_union = lambda d1, d2: dict((x, (dict_union(d1.get(x, {}), d2[x]) if
+                                      isinstance(d2.get(x), dict) else d2.get(x, d1.get(x)))) for x in
+                                 set(d1.keys() + d2.keys()))
 
 
 # Infinite DateTimes for Python.  Used in SWE 2.0 and other OGC specs as "INF" and "-INF"
 class InfiniteDateTime(object):
+
     def __lt__(self, other):
         return False
+
     def __gt__(self, other):
         return True
+
     def timetuple(self):
         return tuple()
+
+
 class NegativeInfiniteDateTime(object):
+
     def __lt__(self, other):
         return True
+
     def __gt__(self, other):
         return False
+
     def timetuple(self):
         return tuple()
 
 
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
+
+
 def format_string(prop_string):
     """
         Formats a property string to remove spaces and go from CamelCase to pep8
@@ -75,8 +89,9 @@ def format_string(prop_string):
     if prop_string is None:
         return ''
     st_r = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', prop_string)
-    st_r = st_r.replace(' ','')
+    st_r = st_r.replace(' ', '')
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', st_r).lower()
+
 
 def xml_to_dict(root, prefix=None, depth=1, diction=None):
     """
@@ -93,7 +108,7 @@ def xml_to_dict(root, prefix=None, depth=1, diction=None):
         Return
         =======
         Dictionary of (key,value); where key is the element tag stripped of namespace and cleaned up to be pep8 and
-        value is the inner-text of the element. Note that duplicate elements will be replaced by the last element of the 
+        value is the inner-text of the element. Note that duplicate elements will be replaced by the last element of the
         same tag in the tree.
     """
     ret = diction if diction is not None else dict()
@@ -102,7 +117,7 @@ def xml_to_dict(root, prefix=None, depth=1, diction=None):
         # skip values that are empty or None
         if val is None or val == '':
             if depth > 1:
-                ret = xml_to_dict(child,prefix=prefix,depth=(depth-1),diction=ret)
+                ret = xml_to_dict(child, prefix=prefix, depth=(depth - 1), diction=ret)
             continue
 
         key = format_string(child.tag.split('}')[-1])
@@ -112,23 +127,24 @@ def xml_to_dict(root, prefix=None, depth=1, diction=None):
 
         ret[key] = val
         if depth > 1:
-            ret = xml_to_dict(child,prefix=prefix,depth=(depth-1),diction=ret)
+            ret = xml_to_dict(child, prefix=prefix, depth=(depth - 1), diction=ret)
 
     return ret
 
+
 def openURL(url_base, data, method='Get', cookies=None, username=None, password=None, timeout=30):
     ''' function to open urls - wrapper around urllib2.urlopen but with additional checks for OGC service exceptions and url formatting, also handles cookies and simple user password authentication'''
-    url_base.strip() 
+    url_base.strip()
     lastchar = url_base[-1]
     if lastchar not in ['?', '&']:
         if url_base.find('?') == -1:
             url_base = url_base + '?'
         else:
             url_base = url_base + '&'
-            
+
     if username and password:
         # Provide login information in order to use the WMS server
-        # Create an OpenerDirector with support for Basic HTTP 
+        # Create an OpenerDirector with support for Basic HTTP
         # Authentication...
         passman = HTTPPasswordMgrWithDefaultRealm()
         passman.add_password(None, url_base, username, password)
@@ -140,7 +156,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         #opener = urllib2.build_opener(urllib2.HTTPHandler(debuglevel=0))
         #openit = opener.open
         openit = urlopen
-   
+
     try:
         if method == 'Post':
             req = Request(url_base, data)
@@ -151,39 +167,40 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
             except:
                 pass
         else:
-            req=Request(url_base + data)
+            req = Request(url_base + data)
         if cookies is not None:
             req.add_header('Cookie', cookies)
         u = openit(req, timeout=timeout)
-    except HTTPError, e: #Some servers may set the http header to 400 if returning an OGC service exception or 401 if unauthorised.
+    except HTTPError, e:  # Some servers may set the http header to 400 if returning an OGC service exception or 401 if unauthorised.
         if e.code in [400, 401]:
             raise ServiceException, e.read()
         else:
             raise e
     # check for service exceptions without the http header set
-    if ((u.info().has_key('Content-Type')) and (u.info()['Content-Type'] in ['text/xml', 'application/xml'])):          
-        #just in case 400 headers were not set, going to have to read the xml to see if it's an exception report.
-        #wrap the url stram in a extended StringIO object so it's re-readable
-        u=RereadableURL(u)      
-        se_xml= u.read()
+    if ((u.info().has_key('Content-Type')) and (u.info()['Content-Type'] in ['text/xml', 'application/xml'])):
+        # just in case 400 headers were not set, going to have to read the xml to see if it's an exception report.
+        # wrap the url stram in a extended StringIO object so it's re-readable
+        u = RereadableURL(u)
+        se_xml = u.read()
         se_tree = etree.fromstring(se_xml)
-        serviceException=se_tree.find('{http://www.opengis.net/ows}Exception')
+        serviceException = se_tree.find('{http://www.opengis.net/ows}Exception')
         if serviceException is None:
-            serviceException=se_tree.find('ServiceException')
+            serviceException = se_tree.find('ServiceException')
         if serviceException is not None:
             raise ServiceException, \
-            str(serviceException.text).strip()
-        u.seek(0) #return cursor to start of u      
+                str(serviceException.text).strip()
+        u.seek(0)  # return cursor to start of u
     return u
 
-#default namespace for nspath is OWS common
+# default namespace for nspath is OWS common
 OWS_NAMESPACE = 'http://www.opengis.net/ows/1.1'
-def nspath(path, ns=OWS_NAMESPACE):
 
+
+def nspath(path, ns=OWS_NAMESPACE):
     """
 
     Prefix the given path with the given namespace identifier.
-    
+
     Parameters
     ----------
 
@@ -202,6 +219,7 @@ def nspath(path, ns=OWS_NAMESPACE):
         components.append(component)
     return '/'.join(components)
 
+
 def nspath_eval(xpath, namespaces):
     ''' Return an etree friendly xpath '''
     out = []
@@ -209,6 +227,7 @@ def nspath_eval(xpath, namespaces):
         namespace, element = chunks.split(':')
         out.append('{%s}%s' % (namespaces[namespace], element))
     return '/'.join(out)
+
 
 def cleanup_namespaces(element):
     """ Remove unused namespaces from an element """
@@ -273,12 +292,13 @@ def testXMLValue(val, attrib=False):
     if val is not None:
         if attrib:
             return val.strip()
-        elif val.text:  
+        elif val.text:
             return val.text.strip()
         else:
-            return None	
+            return None
     else:
         return None
+
 
 def testXMLAttribute(element, attribute):
     """
@@ -297,10 +317,11 @@ def testXMLAttribute(element, attribute):
 
     return None
 
+
 def http_post(url=None, request=None, lang='en-US', timeout=10):
     """
 
-    Invoke an HTTP POST request 
+    Invoke an HTTP POST request
 
     Parameters
     ----------
@@ -324,7 +345,7 @@ def http_post(url=None, request=None, lang='en-US', timeout=10):
         r.add_header('Host', u.netloc)
 
         try:
-            up = urllib2.urlopen(r,timeout=timeout);
+            up = urllib2.urlopen(r, timeout=timeout)
         except TypeError:
             import socket
             socket.setdefaulttimeout(timeout)
@@ -344,6 +365,7 @@ def http_post(url=None, request=None, lang='en-US', timeout=10):
 
         return response
 
+
 def xml2string(xml):
     """
 
@@ -356,6 +378,7 @@ def xml2string(xml):
 
     """
     return '<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>\n' + xml
+
 
 def xmlvalid(xml, xsd):
     """
@@ -376,6 +399,7 @@ def xmlvalid(xml, xsd):
     doc = etree.parse(StringIO(xml))
     return xsd2.validate(doc)
 
+
 def xmltag_split(tag):
     ''' Return XML element bare tag name (without prefix) '''
     try:
@@ -383,47 +407,51 @@ def xmltag_split(tag):
     except:
         return tag
 
+
 def getNamespace(element):
     ''' Utility method to extract the namespace from an XML element tag encoded as {namespace}localname. '''
-    if element.tag[0]=='{':
+    if element.tag[0] == '{':
         return element.tag[1:].split("}")[0]
     else:
         return ""
 
+
 def build_get_url(base_url, params):
     ''' Utility function to build a full HTTP GET URL from the service base URL and a dictionary of HTTP parameters. '''
-    
+
     qs = []
     if base_url.find('?') != -1:
         qs = cgi.parse_qsl(base_url.split('?')[1])
 
     pars = [x[0] for x in qs]
 
-    for key,value in params.iteritems():
+    for key, value in params.iteritems():
         if key not in pars:
-            qs.append( (key,value) )
+            qs.append((key, value))
 
     urlqs = urlencode(tuple(qs))
     return base_url.split('?')[0] + '?' + urlqs
 
+
 def dump(obj, prefix=''):
     '''Utility function to print to standard output a generic object with all its attributes.'''
-    
+
     print "%s %s : %s" % (prefix, obj.__class__, obj.__dict__)
-    
+
+
 def getTypedValue(type, value):
     ''' Utility function to cast a string value to the appropriate XSD type. '''
-    
-    if type=='boolean':
-       return bool(value)
-    elif type=='integer':
-       return int(value)
-    elif type=='float':
+
+    if type == 'boolean':
+        return bool(value)
+    elif type == 'integer':
+        return int(value)
+    elif type == 'float':
         return float(value)
-    elif type=='string':
+    elif type == 'string':
         return str(value)
     else:
-        return value # no type casting
+        return value  # no type casting
 
 
 def extract_time(element):
@@ -459,7 +487,7 @@ def extract_xml_list(elements):
 Some people don't have seperate tags for their keywords and seperate them with
 a newline. This will extract out all of the keywords correctly.
 """
-    keywords = [re.split(r'[\n\r]+',f.text) for f in elements if f.text]
+    keywords = [re.split(r'[\n\r]+', f.text) for f in elements if f.text]
     flattened = [item.strip() for sublist in keywords for item in sublist]
     remove_blank = filter(None, flattened)
     return remove_blank
@@ -467,21 +495,21 @@ a newline. This will extract out all of the keywords correctly.
 
 def bind_url(url):
     """binds an HTTP GET query string endpiont"""
-    if url.find('?') == -1: # like http://host/wms
+    if url.find('?') == -1:  # like http://host/wms
         binder = '?'
 
     # if like http://host/wms?foo=bar& or http://host/wms?foo=bar
     if url.find('=') != -1:
-        if url.find('&', -1) != -1: # like http://host/wms?foo=bar&
+        if url.find('&', -1) != -1:  # like http://host/wms?foo=bar&
             binder = ''
-        else: # like http://host/wms?foo=bar
+        else:  # like http://host/wms?foo=bar
             binder = '&'
 
     # if like http://host/wms?foo
     if url.find('?') != -1:
-        if url.find('?', -1) != -1: # like http://host/wms?
+        if url.find('?', -1) != -1:  # like http://host/wms?
             binder = ''
-        elif url.find('&', -1) == -1: # like http://host/wms?foo=bar
+        elif url.find('&', -1) == -1:  # like http://host/wms?foo=bar
             binder = '&'
     return '%s%s' % (url, binder)
 
@@ -493,6 +521,7 @@ try:
 except AttributeError:
     # Python < 2.7
     class NullHandler(logging.Handler):
+
         def emit(self, record):
             pass
 log = logging.getLogger('owslib')
@@ -503,4 +532,3 @@ try:  # 2.7
     from collections import OrderedDict
 except:  # 2.6
     from ordereddict import OrderedDict
-

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -12,21 +12,21 @@ Utility functions and classes
 """
 
 import sys
-from dateutil import parser
 from datetime import datetime
-import pytz
-from owslib.etree import etree
-from owslib.namespaces import Namespaces
-import urlparse
-import urllib2
-from urllib2 import urlopen, HTTPError, Request
-from urllib2 import HTTPPasswordMgrWithDefaultRealm
-from urllib2 import HTTPBasicAuthHandler
-from StringIO import StringIO
-import cgi
-from urllib import urlencode
 import re
 from copy import deepcopy
+
+PY2 = sys.version_info[0] == 2
+from urlparse import urlsplit, parse_qsl
+from urllib import urlencode
+from urllib2 import urlopen, build_opener, Request, HTTPError, HTTPBasicAuthHandler, HTTPPasswordMgrWithDefaultRealm
+from StringIO import StringIO
+
+from dateutil import parser
+import pytz
+
+from owslib.etree import etree
+from owslib.namespaces import Namespaces
 
 
 class RereadableURL(StringIO, object):
@@ -148,7 +148,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         passman = HTTPPasswordMgrWithDefaultRealm()
         passman.add_password(None, url_base, username, password)
         auth_handler = HTTPBasicAuthHandler(passman)
-        opener = urllib2.build_opener(auth_handler)
+        opener = build_opener(auth_handler)
         openit = opener.open
     else:
         # NOTE: optionally set debuglevel>0 to debug HTTP connection
@@ -332,8 +332,8 @@ def http_post(url=None, request=None, lang='en-US', timeout=10):
     """
 
     if url is not None:
-        u = urlparse.urlsplit(url)
-        r = urllib2.Request(url, request)
+        u = urlsplit(url)
+        r = Request(url, request)
         r.add_header('User-Agent', 'OWSLib (https://geopython.github.io/OWSLib)')
         r.add_header('Content-type', 'text/xml')
         r.add_header('Content-length', '%d' % len(request))
@@ -343,11 +343,11 @@ def http_post(url=None, request=None, lang='en-US', timeout=10):
         r.add_header('Host', u.netloc)
 
         try:
-            up = urllib2.urlopen(r, timeout=timeout)
+            up = urlopen(r, timeout=timeout)
         except TypeError:
             import socket
             socket.setdefaulttimeout(timeout)
-            up = urllib2.urlopen(r)
+            up = urlopen(r)
 
         ui = up.info()  # headers
         response = up.read()
@@ -419,7 +419,7 @@ def build_get_url(base_url, params):
 
     qs = []
     if base_url.find('?') != -1:
-        qs = cgi.parse_qsl(base_url.split('?')[1])
+        qs = parse_qsl(base_url.split('?')[1])
 
     pars = [x[0] for x in qs]
 

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -1,5 +1,7 @@
 from dateutil import parser
 
+from six import text_type, binary_type
+
 from owslib.etree import etree
 from owslib.util import testXMLValue, xml_to_dict as _xml_to_dict
 
@@ -74,12 +76,12 @@ class SitesResponse(XMLParser):
         if isinstance(key, int) and key < len(self.sites):
             return self.sites[key]
 
-        if isinstance(key, str):
+        if isinstance(key, (text_type, binary_type)):
             site = [site for site in self.sites for code in site.site_info.site_codes if code == key]
             if len(site) > 0:
                 return site[0]
 
-        raise KeyError('Unknown key ' + str(key))
+        raise KeyError('Unknown key ' + text_type(key))
 
     def parse_sites_response(self, xml=None):
         if xml is not None:
@@ -174,12 +176,12 @@ class Site(XMLParser):
         if isinstance(key, int) and key < len(self.series_catalogs):
             return self.series_catalogs[key]
 
-        if isinstance(key, str):
+        if isinstance(key, (text_type, binary_type)):
             var = [series.variable for catalog in self.series_catalogs for series in catalog if series.code == key]
             if len(var) > 0:
                 return var[0]
 
-        raise KeyError('Unknown key ' + str(key))
+        raise KeyError('Unknown key ' + text_type(key))
 
     """Accessor propeties/methods"""
     @property
@@ -342,12 +344,12 @@ class SeriesCatalog(XMLParser):
         if isinstance(key, int) and key < len(self.series):
             return self.series[key]
 
-        if isinstance(key, str):
+        if isinstance(key, (text_type, binary_type)):
             srs = [series for series in self.series if series.code == key]
             if len(srs) > 0:
                 return srs[0]
 
-        raise KeyError('Unknown key ' + str(key))
+        raise KeyError('Unknown key ' + text_type(key))
 
     def parse_seriescatalog(self, xml=None):
         if xml is not None:
@@ -925,7 +927,7 @@ class VariablesResponse(XMLParser):
         if isinstance(key, int) and key < len(self.variables):
             return self.variables[key]
 
-        if isinstance(key, str):
+        if isinstance(key, (text_type, binary_type)):
             v = [var for var in self.variables if var.variable_code == key]
             if len(v) > 0:
                 return v[0]
@@ -934,7 +936,7 @@ class VariablesResponse(XMLParser):
             if len(v) > 0:
                 return v[0]
 
-        raise KeyError('Unknown key ' + str(key))
+        raise KeyError('Unknown key ' + text_type(key))
 
     """Accessor properties/methods"""
     @property

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -1,8 +1,8 @@
-from owslib.etree import etree
-from owslib.util import nspath, testXMLValue, openURL
-from owslib.util import xml_to_dict as _xml_to_dict
-from datetime import datetime
 from dateutil import parser
+
+from owslib.etree import etree
+from owslib.util import testXMLValue, xml_to_dict as _xml_to_dict
+
 
 namespaces = {
     'wml1.1': '{http://www.cuahsi.org/waterML/1.1/}',

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -5,21 +5,25 @@ from datetime import datetime
 from dateutil import parser
 
 namespaces = {
-    'wml1.1':'{http://www.cuahsi.org/waterML/1.1/}',
-    'wml1.0':'{http://www.cuahsi.org/waterML/1.0/}',
-    'xsi':'{http://www.w3.org/2001/XMLSchema-instance',
-    'xsd':'{http://www.w3.org/2001/XMLSchema'
+    'wml1.1': '{http://www.cuahsi.org/waterML/1.1/}',
+    'wml1.0': '{http://www.cuahsi.org/waterML/1.0/}',
+    'xsi': '{http://www.w3.org/2001/XMLSchema-instance',
+    'xsd': '{http://www.w3.org/2001/XMLSchema'
 }
+
 
 def ns(namespace):
     return namespaces.get(namespace)
 
+
 class XMLParser(object):
+
     """
         Convienence class; provides some useful shortcut methods to make retrieving xml elements from etree
         a little easier.
     """
-    def __init__(self,xml_root,namespace):
+
+    def __init__(self, xml_root, namespace):
         try:
             self._root = etree.parse(xml_root)
         except:
@@ -30,19 +34,21 @@ class XMLParser(object):
 
         self._ns = namespace
 
-    def _find(self,tofind):
+    def _find(self, tofind):
         try:
             return self._root.find(namespaces.get(self._ns) + tofind)
         except:
             return None
 
-    def _findall(self,tofind):
+    def _findall(self, tofind):
         try:
             return self._root.findall(namespaces.get(self._ns) + tofind)
         except:
             return None
 
+
 class SitesResponse(XMLParser):
+
     """
         Parses the response from a 'GetSites' request
 
@@ -50,31 +56,32 @@ class SitesResponse(XMLParser):
         ===========
         :xmlio - A file-like object that holds the xml response from the request.
 
-        Return 
+        Return
         =======
         An object constructed from a dictionary parse of the response. The object has get access and can iterate
         over the sites returned.
     """
-    def __init__(self,xml,version='wml1.1'):
-        super(SitesResponse,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(SitesResponse, self).__init__(xml, version)
         self.parse_sites_response()
 
     def __iter__(self):
         for s in self.sites:
             yield s
 
-    def __getitem__(self,key):
-        if isinstance(key,int) and key < len(self.sites):
+    def __getitem__(self, key):
+        if isinstance(key, int) and key < len(self.sites):
             return self.sites[key]
 
-        if isinstance(key,str):
+        if isinstance(key, str):
             site = [site for site in self.sites for code in site.site_info.site_codes if code == key]
             if len(site) > 0:
                 return site[0]
 
         raise KeyError('Unknown key ' + str(key))
 
-    def parse_sites_response(self,xml=None):
+    def parse_sites_response(self, xml=None):
         """
         """
         if xml is not None:
@@ -98,11 +105,14 @@ class SitesResponse(XMLParser):
     def site_names(self):
         return [site.site_info.site_name for site in self.sites]
 
+
 class QueryInfo(XMLParser):
+
     """
     """
-    def __init__(self,xml_root,version='wml1.1'):
-        super(QueryInfo, self).__init__(xml_root,version)
+
+    def __init__(self, xml_root, version='wml1.1'):
+        super(QueryInfo, self).__init__(xml_root, version)
         self.parse_query_info()
 
     def parse_query_info(self, xml=None):
@@ -121,11 +131,14 @@ class QueryInfo(XMLParser):
         # except:
         #   raise ValueError('Unable to parse queryInfo element correctly')
 
+
 class Criteria(XMLParser):
+
     """
     """
-    def __init__(self,xml_root,version='wml1.1'):
-        super(Criteria, self).__init__(xml_root,version)
+
+    def __init__(self, xml_root, version='wml1.1'):
+        super(Criteria, self).__init__(xml_root, version)
         self.parse_criteria()
 
     def parse_criteria(self, xml=None):
@@ -136,7 +149,7 @@ class Criteria(XMLParser):
                 self._root = xml
 
         # try:
-        xml_dict = _xml_to_dict(self._root,depth=4)
+        xml_dict = _xml_to_dict(self._root, depth=4)
         self.method_called = self._root.attrib.get('MethodCalled')
         self.location_param = xml_dict.get('location_param')
         self.variable_param = xml_dict.get('variable_param')
@@ -150,24 +163,26 @@ class Criteria(XMLParser):
         except:
             self.end_date_time = None
 
-        self.parameters = [(param.attrib.get('name'),param.attrib.get('value')) for param in self._findall('parameter')]
+        self.parameters = [(param.attrib.get('name'), param.attrib.get('value')) for param in self._findall('parameter')]
         # except:
         #   raise ValueError('Unable to parse xml for criteria element')
 
+
 class Site(XMLParser):
+
     def __init__(self, xml, version='wml1.1'):
-        super(Site,self).__init__(xml,version)
+        super(Site, self).__init__(xml, version)
         self.parse_site()
 
     def __iter__(self):
         for c in self.series_catalogs:
             yield c
 
-    def __getitem__(self,key):
-        if isinstance(key,int) and key < len(self.series_catalogs):
+    def __getitem__(self, key):
+        if isinstance(key, int) and key < len(self.series_catalogs):
             return self.series_catalogs[key]
 
-        if isinstance(key,str):
+        if isinstance(key, str):
             var = [series.variable for catalog in self.series_catalogs for series in catalog if series.code == key]
             if len(var) > 0:
                 return var[0]
@@ -203,7 +218,7 @@ class Site(XMLParser):
     def longitudes(self):
         return [g[0] for g in self.site_info.location.geo_coords]
 
-    def parse_site(self,xml=None):
+    def parse_site(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -213,17 +228,18 @@ class Site(XMLParser):
         # try:
         self.site_info = SiteInfo(self._find('siteInfo'), self._ns)
         self.series_catalogs = [SeriesCatalog(elm, self._ns) for elm in self._findall('seriesCatalog')]
-            # self.extension = Extension(self._find('extension'), self._ns)
+        # self.extension = Extension(self._find('extension'), self._ns)
         # except:
         #   raise ValueError('Unable to parse site element correctly')
 
 
 class SiteInfo(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(SiteInfo,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(SiteInfo, self).__init__(xml, version)
         self.parse_siteinfo()
 
-    def parse_siteinfo(self,xml=None):
+    def parse_siteinfo(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -237,7 +253,7 @@ class SiteInfo(XMLParser):
         self.elevation = xml_dict.get('elevation_m')
         self.vertical_datum = xml_dict.get('vertical_datum')
         self.site_types = [testXMLValue(typ) for typ in self._findall('siteType')]
-        self.site_properties = dict([(prop.attrib.get('name'),testXMLValue(prop)) for prop in self._findall('siteProperty')])
+        self.site_properties = dict([(prop.attrib.get('name'), testXMLValue(prop)) for prop in self._findall('siteProperty')])
         self.altname = xml_dict.get('altname')
         self.notes = [testXMLValue(note) for note in self._findall('note')]
         # sub-objects
@@ -250,12 +266,14 @@ class SiteInfo(XMLParser):
         # except:
         #   raise ValueError('Unable to parse siteInfo element')
 
+
 class Location(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Location,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Location, self).__init__(xml, version)
         self.parse_location()
 
-    def parse_location(self,xml=None):
+    def parse_location(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -268,7 +286,7 @@ class Location(XMLParser):
         self.geo_coords = list()
         self.srs = list()
         for g in geogs:
-            self.geo_coords.append((testXMLValue(g.find(ns(self._ns) + 'longitude')),testXMLValue(g.find(ns(self._ns) + 'latitude'))))
+            self.geo_coords.append((testXMLValue(g.find(ns(self._ns) + 'longitude')), testXMLValue(g.find(ns(self._ns) + 'latitude'))))
             self.srs.append(g.attrib.get('srs'))
 
         locsite = self._findall('localSiteXY')
@@ -278,9 +296,9 @@ class Location(XMLParser):
         for ls in locsite:
             z = testXMLValue(ls.find(ns(self._ns) + 'Z'))
             if z is not None:
-                self.local_sites.append((testXMLValue(ls.find(ns(self._ns) + 'X')),testXMLValue(ls.find(ns(self._ns) + 'Y')),z))
+                self.local_sites.append((testXMLValue(ls.find(ns(self._ns) + 'X')), testXMLValue(ls.find(ns(self._ns) + 'Y')), z))
             else:
-                self.local_sites.append((testXMLValue(ls.find(ns(self._ns) + 'X')),testXMLValue(ls.find(ns(self._ns) + 'Y')),'0'))
+                self.local_sites.append((testXMLValue(ls.find(ns(self._ns) + 'X')), testXMLValue(ls.find(ns(self._ns) + 'Y')), '0'))
 
             self.notes.append([testXMLValue(note) for note in ls.findall(ns(self._ns) + 'note')])
             self.projections.append(ls.attrib.get('projectionInformation'))
@@ -290,11 +308,12 @@ class Location(XMLParser):
 
 
 class TimeZoneInfo(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(TimeZoneInfo,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(TimeZoneInfo, self).__init__(xml, version)
         self.parse_timezoneinfo()
 
-    def parse_timezoneinfo(self,xml=None):
+    def parse_timezoneinfo(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -305,39 +324,40 @@ class TimeZoneInfo(XMLParser):
         xml_dict = _xml_to_dict(self._root)
         default = self._find('defaultTimeZone')
         if default is not None:
-          self.zone_offset = default.attrib.get('zoneOffset')
-          self.zone_abbreviation = default.attrib.get('zoneAbbreviation')
+            self.zone_offset = default.attrib.get('zoneOffset')
+            self.zone_abbreviation = default.attrib.get('zoneAbbreviation')
 
         daylight = self._find('daylightSavingsTimeZone')
         if daylight is not None:
-          self.daylight_zone_offset = daylight.attrib.get('zoneOffset')
-          self.daylight_zone_abbreviation = daylight.attrib.get('zoneAbbreviation')
+            self.daylight_zone_offset = daylight.attrib.get('zoneOffset')
+            self.daylight_zone_abbreviation = daylight.attrib.get('zoneAbbreviation')
 
         # except:
         #   raise ValueError('Unable to properly parset the timeZoneInfo element')
-            
+
 
 class SeriesCatalog(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(SeriesCatalog,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(SeriesCatalog, self).__init__(xml, version)
         self.parse_seriescatalog()
 
     def __iter__(self):
         for s in self.series:
             yield s
 
-    def __getitem__(self,key):
-        if isinstance(key,int) and key < len(self.series):
+    def __getitem__(self, key):
+        if isinstance(key, int) and key < len(self.series):
             return self.series[key]
 
-        if isinstance(key,str):
+        if isinstance(key, str):
             srs = [series for series in self.series if series.code == key]
             if len(srs) > 0:
                 return srs[0]
 
         raise KeyError('Unknown key ' + str(key))
 
-    def parse_seriescatalog(self,xml=None):
+    def parse_seriescatalog(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -345,14 +365,15 @@ class SeriesCatalog(XMLParser):
                 self._root = xml
 
         # try:
-        self.series = [Series(elm,self._ns) for elm in self._findall('series')]
+        self.series = [Series(elm, self._ns) for elm in self._findall('series')]
         # except:
         #   raise ValueError('Unable to properly parse the seriesCatalog element')
 
 
 class Series(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Series,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Series, self).__init__(xml, version)
         self.parse_series()
 
     """Accessor proeprties/methods"""
@@ -364,7 +385,7 @@ class Series(XMLParser):
     def code(self):
         return self.variable.variable_code
 
-    def parse_series(self,xml=None):
+    def parse_series(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -372,7 +393,7 @@ class Series(XMLParser):
                 self._root = xml
 
         # try:
-        xml_dict = _xml_to_dict(self._root,depth=3)
+        xml_dict = _xml_to_dict(self._root, depth=3)
         self.value_count = xml_dict.get('value_count')
         self.value_type = xml_dict.get('value_type')
         self.general_category = xml_dict.get('general_category')
@@ -413,19 +434,20 @@ class Series(XMLParser):
             self.quality_control_level_id = None
 
         # properties
-        self.properties = dict([(prop.attrib.get('name'),testXMLValue(prop)) for prop in self._findall('seriesProperty')])
+        self.properties = dict([(prop.attrib.get('name'), testXMLValue(prop)) for prop in self._findall('seriesProperty')])
         # sub-objects
-        self.variable = Variable(self._find('variable'),self._ns)
+        self.variable = Variable(self._find('variable'), self._ns)
         # except:
         #   raise ValueError('Unable to correctly parse Series element')
 
 
 class Variable(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Variable,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Variable, self).__init__(xml, version)
         self.parse_variable()
 
-    def parse_variable(self,xml=None):
+    def parse_variable(self, xml=None):
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -444,20 +466,20 @@ class Variable(XMLParser):
         self.variable_description = xml_dict.get('variable_description')
         self.speciation = xml_dict.get('speciation')
         # notes and properties
-        notes = [(note.attrib.get('title'),testXMLValue(note)) for note in self._findall('note')]
+        notes = [(note.attrib.get('title'), testXMLValue(note)) for note in self._findall('note')]
         none_notes = [note[1] for note in notes if note[0] is None]
         self.notes = dict([note for note in notes if note[0] is not None])
         if len(none_notes) > 0:
             self.notes['none'] = none_notes
 
-        self.properties = dict([(prop.attrib.get('name'),testXMLValue(prop)) for prop in self._findall('variableProperty')])
+        self.properties = dict([(prop.attrib.get('name'), testXMLValue(prop)) for prop in self._findall('variableProperty')])
         # related
         related = self._find('related')
         if related is not None:
-            self.parent_codes = [dict([('network',code.attrib.get('network')),('vocabulary',code.attrib.get('vocabulary')),('default',code.attrib.get('default'))])
-                             for code in related.findall(ns(self._ns) + 'parentCode')]
-            self.related_codes = [dict([('network',d.get('network')),('vocabulary',d.get('vocabulary')),('default',d.get('default'))])
-                             for code in related.findall(ns(self._ns) + 'relatedCode')]
+            self.parent_codes = [dict([('network', code.attrib.get('network')), ('vocabulary', code.attrib.get('vocabulary')), ('default', code.attrib.get('default'))])
+                                 for code in related.findall(ns(self._ns) + 'parentCode')]
+            self.related_codes = [dict([('network', d.get('network')), ('vocabulary', d.get('vocabulary')), ('default', d.get('default'))])
+                                  for code in related.findall(ns(self._ns) + 'relatedCode')]
         else:
             self.parent_codes = None
             self.related_codes = None
@@ -478,7 +500,7 @@ class Variable(XMLParser):
 
         categories = self._find('categories')
         if categories is not None:
-            self.categories = [Category(cat,self._ns) for cat in categories.findall(ns(self._ns) + 'category')]
+            self.categories = [Category(cat, self._ns) for cat in categories.findall(ns(self._ns) + 'category')]
         else:
             self.categories = None
         # except:
@@ -486,8 +508,9 @@ class Variable(XMLParser):
 
 
 class TimeScale(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(TimeScale,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(TimeScale, self).__init__(xml, version)
         self.parse_timescale()
 
     def parse_timescale(self):
@@ -503,8 +526,9 @@ class TimeScale(XMLParser):
 
 
 class Unit(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Unit,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Unit, self).__init__(xml, version)
         self.parse_unit()
 
     def parse_unit(self):
@@ -521,8 +545,9 @@ class Unit(XMLParser):
 
 
 class Unit1_0(XMLParser):
-    def __init__(self,xml,version='wml1.0'):
-        super(Unit1_0,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.0'):
+        super(Unit1_0, self).__init__(xml, version)
         self.parse_unit()
 
     def parse_unit(self):
@@ -537,8 +562,9 @@ class Unit1_0(XMLParser):
 
 
 class Category(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Category,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Category, self).__init__(xml, version)
         self.parse_category()
 
     def parse_category(self):
@@ -552,6 +578,7 @@ class Category(XMLParser):
 
 
 class TimeSeriesResponse(XMLParser):
+
     """
         Parses the response from a 'GetValues' request
 
@@ -559,13 +586,14 @@ class TimeSeriesResponse(XMLParser):
         ===========
         :xmlio - A file-like object that holds the xml response from the request.
 
-        Return 
+        Return
         =======
         An object constructed from a dictionary parse of the response. The object has get access and can
         also iterate over each timeSeries element returned.
     """
-    def __init__(self,xml,version='wml1.1'):
-        super(TimeSeriesResponse,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(TimeSeriesResponse, self).__init__(xml, version)
         self.parse_timeseriesresponse()
 
     """Accessor properties/methods"""
@@ -581,7 +609,7 @@ class TimeSeriesResponse(XMLParser):
     def variable_codes(self):
         return list(set([s.variable.variable_code for s in self.time_series]))
 
-    def get_series_by_variable(self,var_name=None,var_code=None):
+    def get_series_by_variable(self, var_name=None, var_code=None):
         if var_code is not None:
             return [s for s in self.time_series if s.variable.variable_code == var_code]
 
@@ -593,29 +621,32 @@ class TimeSeriesResponse(XMLParser):
     def parse_timeseriesresponse(self):
         try:
             qi = self._find('queryInfo')
-            self.query_info = QueryInfo(qi,self._ns)
-            self.time_series = [TimeSeries(series,self._ns) for series in self._findall('timeSeries')]
+            self.query_info = QueryInfo(qi, self._ns)
+            self.time_series = [TimeSeries(series, self._ns) for series in self._findall('timeSeries')]
         except:
             raise
 
 
 class TimeSeries(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(TimeSeries,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(TimeSeries, self).__init__(xml, version)
         self.parse_timeseries()
 
     def parse_timeseries(self):
         try:
             self.variable = Variable(self._find('variable'), self._ns)
-            self.values = [Values(val,self._ns) for val in self._findall('values')]
+            self.values = [Values(val, self._ns) for val in self._findall('values')]
             self.source_info = SiteInfo(self._find('sourceInfo'), self._ns)
             self.name = self._root.attrib.get('name')
         except:
             raise
 
+
 class Values(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Values,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Values, self).__init__(xml, version)
         self.parse_values()
 
     def __iter__(self):
@@ -623,7 +654,8 @@ class Values(XMLParser):
             yield v
 
     """Accessor properties/methods"""
-    def get_date_values(self,method_id=None,source_id=None,sample_id=None,quality_level=None,utc=False):
+
+    def get_date_values(self, method_id=None, source_id=None, sample_id=None, quality_level=None, utc=False):
         varl = [v for v in self.values]
         if method_id is not None:
             varl = [v for v in varl if v.method_id == method_id]
@@ -638,26 +670,26 @@ class Values(XMLParser):
             varl = [v for v in varl if v.quality_control_level == quality_level]
 
         if not utc:
-            return [(v.date_time,v.value) for v in varl]
+            return [(v.date_time, v.value) for v in varl]
         else:
-            return [(v.date_time_utc,v.value) for v in varl]
+            return [(v.date_time_utc, v.value) for v in varl]
 
     def parse_values(self):
         xml_dict = _xml_to_dict(self._root)
         # method info
-        self.methods = [Method(method,self._ns) for method in self._findall('method')]
+        self.methods = [Method(method, self._ns) for method in self._findall('method')]
 
         # source info
-        self.sources = [Source(source,self._ns) for source in self._findall('source')]
+        self.sources = [Source(source, self._ns) for source in self._findall('source')]
 
         # quality control info
         self.qualit_control_levels = [QualityControlLevel(qal, self._ns) for qal in self._findall('qualityControlLevel')]
 
         # offset info
-        self.offsets = [Offset(os,self._ns) for os in self._findall('offset')]
+        self.offsets = [Offset(os, self._ns) for os in self._findall('offset')]
 
         # sample info
-        self.samples = [Sample(sample,self._ns) for sample in self._findall('sample')]
+        self.samples = [Sample(sample, self._ns) for sample in self._findall('sample')]
 
         # censor codes
         self.censor_codes = [CensorCode(code, self._ns) for code in self._findall('censorCode')]
@@ -676,8 +708,9 @@ class Values(XMLParser):
 
 
 class Value(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Value,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Value, self).__init__(xml, version)
         self.parse_value()
 
     def parse_value(self):
@@ -709,8 +742,9 @@ class Value(XMLParser):
 
 
 class Sample(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Sample,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Sample, self).__init__(xml, version)
         self.parse_sample()
 
     def parse_sample(self):
@@ -725,8 +759,9 @@ class Sample(XMLParser):
 
 
 class LabMethod(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(LabMethod,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(LabMethod, self).__init__(xml, version)
         self.parse_labmethod()
 
     def parse_labmethod(self):
@@ -740,20 +775,21 @@ class LabMethod(XMLParser):
             self.method_link = xml_dict.get('lab_method_link')
             # sub-objects
             source = self._find('labSourceDetails')
-            self.source_details = Source(source,self._ns) if source is not None else None
+            self.source_details = Source(source, self._ns) if source is not None else None
         except:
             raise
 
 
 class Source(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Source,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Source, self).__init__(xml, version)
         self.parse_source()
 
     def __str__(self):
         return str(self.__dict__)
 
-    def get_contact(self,name):
+    def get_contact(self, name):
         ci = [ci for ci in self.contact_info if ci.name == name]
         if len(ci) < 0:
             return ci[0]
@@ -774,14 +810,15 @@ class Source(XMLParser):
             self.profile_version = xml_dict.get('profile_version')
             self.metadata_link = xml_dict.get('metadata_link')
             # contact info
-            self.contact_info = [ContactInformation(ci,self._ns) for ci in self._findall('contactInformation')]
+            self.contact_info = [ContactInformation(ci, self._ns) for ci in self._findall('contactInformation')]
         except:
             raise
 
 
 class ContactInformation(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(ContactInformation,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(ContactInformation, self).__init__(xml, version)
         self.parse_contactinformation()
 
     def parse_contactinformation(self):
@@ -797,8 +834,9 @@ class ContactInformation(XMLParser):
 
 
 class Offset(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Offset,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Offset, self).__init__(xml, version)
         self.parse_offset()
 
     def parse_offset(self):
@@ -813,14 +851,15 @@ class Offset(XMLParser):
             if self._ns == 'wml1.0':
                 self.unit = Unit1_0(unit, self._ns) if unit is not None else None
             else:
-                self.unit = Unit(unit,self._ns) if unit is not None else None
+                self.unit = Unit(unit, self._ns) if unit is not None else None
         except:
             raise
 
 
 class Method(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(Method,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(Method, self).__init__(xml, version)
         self.parse_method()
 
     def parse_method(self):
@@ -835,8 +874,9 @@ class Method(XMLParser):
 
 
 class QualityControlLevel(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(QualityControlLevel,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(QualityControlLevel, self).__init__(xml, version)
         self.parse_qcl()
 
     def parse_qcl(self):
@@ -851,8 +891,9 @@ class QualityControlLevel(XMLParser):
 
 
 class CensorCode(XMLParser):
-    def __init__(self,xml,version='wml1.1'):
-        super(CensorCode,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(CensorCode, self).__init__(xml, version)
         self.parse_censorcode()
 
     def parse_censorcode(self):
@@ -864,7 +905,9 @@ class CensorCode(XMLParser):
         except:
             raise
 
+
 class VariablesResponse(XMLParser):
+
     """
         Parses the response from a 'GetVariableInfo' request
 
@@ -877,19 +920,20 @@ class VariablesResponse(XMLParser):
         An object constructed from a dictionary parse of the response. The object has get access to its variables and
         can also be used as an iterator.
     """
-    def __init__(self,xml,version='wml1.1'):
-        super(VariablesResponse,self).__init__(xml,version)
+
+    def __init__(self, xml, version='wml1.1'):
+        super(VariablesResponse, self).__init__(xml, version)
         self.parse_variablesresponse()
 
     def __iter__(self):
         for v in self.variables:
             yield v
 
-    def __getitem__(self,key):
-        if isinstance(key,int) and key < len(self.variables):
+    def __getitem__(self, key):
+        if isinstance(key, int) and key < len(self.variables):
             return self.variables[key]
 
-        if isinstance(key,str):
+        if isinstance(key, str):
             v = [var for var in self.variables if var.variable_code == key]
             if len(v) > 0:
                 return v[0]
@@ -907,14 +951,13 @@ class VariablesResponse(XMLParser):
 
     @property
     def variable_codes(self):
-        return  [var.variable_code for var in self.variables]
+        return [var.variable_code for var in self.variables]
 
     def parse_variablesresponse(self):
         try:
             qi = self._find('queryInfo')
             self.query_info = QueryInfo(qi, self._ns) if qi is not None else None
             varis = self._find('variables')
-            self.variables = [Variable(var,self._ns) for var in varis.findall(ns(self._ns) + 'variable')]
+            self.variables = [Variable(var, self._ns) for var in varis.findall(ns(self._ns) + 'variable')]
         except:
             raise
-

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -29,7 +29,7 @@ class XMLParser(object):
         except:
             self._root = xml_root
 
-        if not namespace in namespaces:
+        if namespace not in namespaces:
             raise ValueError('Unsupported namespace passed in to parser!')
 
         self._ns = namespace
@@ -82,8 +82,6 @@ class SitesResponse(XMLParser):
         raise KeyError('Unknown key ' + str(key))
 
     def parse_sites_response(self, xml=None):
-        """
-        """
         if xml is not None:
             try:
                 self._root = etree.parse(xml)
@@ -108,9 +106,6 @@ class SitesResponse(XMLParser):
 
 class QueryInfo(XMLParser):
 
-    """
-    """
-
     def __init__(self, xml_root, version='wml1.1'):
         super(QueryInfo, self).__init__(xml_root, version)
         self.parse_query_info()
@@ -133,9 +128,6 @@ class QueryInfo(XMLParser):
 
 
 class Criteria(XMLParser):
-
-    """
-    """
 
     def __init__(self, xml_root, version='wml1.1'):
         super(Criteria, self).__init__(xml_root, version)

--- a/owslib/waterml/wml10.py
+++ b/owslib/waterml/wml10.py
@@ -1,3 +1,5 @@
+from six import text_type, binary_type
+
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 
@@ -10,8 +12,8 @@ class WaterML_1_0(object):
 
     def __init__(self, element):
 
-        if isinstance(element, str) or isinstance(element, unicode):
-            self._root = etree.fromstring(str(element))
+        if isinstance(element, (text_type, binary_type)):
+            self._root = etree.fromstring(element)
         else:
             self._root = element
 
@@ -23,11 +25,11 @@ class WaterML_1_0(object):
     @property
     def response(self):
         try:
-            if self._root.tag == str(ns(self._ns) + 'variablesResponse'):
+            if self._root.tag == text_type(ns(self._ns) + 'variablesResponse'):
                 return VariablesResponse(self._root, self._ns)
-            elif self._root.tag == str(ns(self._ns) + 'timeSeriesResponse'):
+            elif self._root.tag == text_type(ns(self._ns) + 'timeSeriesResponse'):
                 return TimeSeriesResponse(self._root, self._ns)
-            elif self._root.tag == str(ns(self._ns) + 'sitesResponse'):
+            elif self._root.tag == text_type(ns(self._ns) + 'sitesResponse'):
                 return SitesResponse(self._root, self._ns)
         except:
             raise

--- a/owslib/waterml/wml10.py
+++ b/owslib/waterml/wml10.py
@@ -1,10 +1,13 @@
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 
+
 def ns(namespace):
     return namespaces.get(namespace)
 
+
 class WaterML_1_0(object):
+
     def __init__(self, element):
 
         if isinstance(element, str) or isinstance(element, unicode):

--- a/owslib/waterml/wml11.py
+++ b/owslib/waterml/wml11.py
@@ -1,3 +1,5 @@
+from six import text_type, binary_type
+
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 
@@ -10,8 +12,8 @@ class WaterML_1_1(object):
 
     def __init__(self, element):
 
-        if isinstance(element, str) or isinstance(element, unicode):
-            self._root = etree.fromstring(str(element))
+        if isinstance(element, (text_type, binary_type)):
+            self._root = etree.fromstring(element)
         else:
             self._root = element
 
@@ -23,11 +25,11 @@ class WaterML_1_1(object):
     @property
     def response(self):
         try:
-            if self._root.tag == str(ns(self._ns) + 'variablesResponse'):
+            if self._root.tag == text_type(ns(self._ns) + 'variablesResponse'):
                 return VariablesResponse(self._root, self._ns)
-            elif self._root.tag == str(ns(self._ns) + 'timeSeriesResponse'):
+            elif self._root.tag == text_type(ns(self._ns) + 'timeSeriesResponse'):
                 return TimeSeriesResponse(self._root, self._ns)
-            elif self._root.tag == str(ns(self._ns) + 'sitesResponse'):
+            elif self._root.tag == text_type(ns(self._ns) + 'sitesResponse'):
                 return SitesResponse(self._root, self._ns)
         except:
             raise

--- a/owslib/waterml/wml11.py
+++ b/owslib/waterml/wml11.py
@@ -1,10 +1,13 @@
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 
+
 def ns(namespace):
     return namespaces.get(namespace)
 
+
 class WaterML_1_1(object):
+
     def __init__(self, element):
 
         if isinstance(element, str) or isinstance(element, unicode):

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -13,10 +13,10 @@
 Web Coverage Server (WCS) methods and metadata. Factory function.
 """
 
+from six.moves.urllib.request import urlopen, Request
 
 from owslib.etree import etree
 from owslib.coverage import wcs100, wcs110, wcsBase
-from owslib.util import urlopen, Request
 
 
 def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2007 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <d.lowe@rl.ac.uk>
 #
 # Contact email: d.lowe@rl.ac.uk
@@ -18,9 +18,10 @@ import urllib2
 import etree
 from coverage import wcs100, wcs110, wcsBase
 
+
 def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
     ''' wcs factory function, returns a version specific WebCoverageService object '''
-    
+
     if version is None:
         if xml is None:
             reader = wcsBase.WCSCapabilitiesReader()
@@ -29,13 +30,13 @@ def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
                 xml = urllib2.urlopen(request, timeout=timeout).read()
             else:
                 req = urllib2.Request(request)
-                req.add_header('Cookie', cookies)   
-                xml=urllib2.urlopen(req, timeout=timeout)
+                req.add_header('Cookie', cookies)
+                xml = urllib2.urlopen(req, timeout=timeout)
         capabilities = etree.etree.fromstring(xml)
         version = capabilities.get('version')
         del capabilities
-        
+
     if version == '1.0.0':
         return wcs100.WebCoverageService_1_0_0.__new__(wcs100.WebCoverageService_1_0_0, url, xml, cookies)
     elif version == '1.1.0':
-        return wcs110.WebCoverageService_1_1_0.__new__(wcs110.WebCoverageService_1_1_0,url, xml, cookies)
+        return wcs110.WebCoverageService_1_1_0.__new__(wcs110.WebCoverageService_1_1_0, url, xml, cookies)

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -14,9 +14,9 @@ Web Coverage Server (WCS) methods and metadata. Factory function.
 """
 
 
-import urllib2
-import etree
-from coverage import wcs100, wcs110, wcsBase
+from owslib.etree import etree
+from owslib.coverage import wcs100, wcs110, wcsBase
+from owslib.util import urlopen, Request
 
 
 def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
@@ -27,12 +27,12 @@ def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
             reader = wcsBase.WCSCapabilitiesReader()
             request = reader.capabilities_url(url)
             if cookies is None:
-                xml = urllib2.urlopen(request, timeout=timeout).read()
+                xml = urlopen(request, timeout=timeout).read()
             else:
-                req = urllib2.Request(request)
+                req = Request(request)
                 req.add_header('Cookie', cookies)
-                xml = urllib2.urlopen(req, timeout=timeout)
-        capabilities = etree.etree.fromstring(xml)
+                xml = urlopen(req, timeout=timeout)
+        capabilities = etree.fromstring(xml)
         version = capabilities.get('version')
         del capabilities
 

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -13,7 +13,7 @@
 Web Feature Server (WFS) methods and metadata. Factory function.
 """
 
-from feature import wfs100, wfs110, wfs200
+from owslib.feature import wfs100, wfs110, wfs200
 
 
 def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=False):

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2009 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <dominic.lowe@stfc.ac.uk>
 #
 # Contact email: dominic.lowe@stfc.ac.uk
@@ -13,10 +13,12 @@
 Web Feature Server (WFS) methods and metadata. Factory function.
 """
 
-from feature import wfs100, wfs110, wfs200 
+from feature import wfs100, wfs110, wfs200
+
+
 def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=False):
     ''' wfs factory function, returns a version specific WebFeatureService object
-    
+
     @type url: string
     @param url: url of WFS capabilities document
     @type xml: string
@@ -25,10 +27,9 @@ def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=Fals
     @param parse_remote_metadata: whether to fully process MetadataURL elements
     @return: initialized WebFeatureService_2_0_0 object
     '''
-    if version in  ['1.0', '1.0.0']:
+    if version in ['1.0', '1.0.0']:
         return wfs100.WebFeatureService_1_0_0(url, version, xml, parse_remote_metadata)
-    elif version in  ['1.1', '1.1.0']:
+    elif version in ['1.1', '1.1.0']:
         return wfs110.WebFeatureService_1_1_0(url, version, xml, parse_remote_metadata)
     elif version in ['2.0', '2.0.0']:
-        return wfs200.WebFeatureService_2_0_0(url,  version, xml, parse_remote_metadata)
-
+        return wfs200.WebFeatureService_2_0_0(url, version, xml, parse_remote_metadata)

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -16,6 +16,9 @@ https://portal.opengeospatial.org/files/?artifact_id=8618
 
 """
 
+from six import iteritems
+from six.moves import zip
+
 from owslib.etree import etree
 
 
@@ -48,7 +51,7 @@ class MapContext(object):
             'id': self._map.id,
             'version': '1.0.0',
         }
-        for k, v in attrs.items():
+        for k, v in iteritems(attrs):
             root.attrib[k] = v
         return root
 

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -21,12 +21,15 @@ from etree import etree
 context_ns_uri = 'http://www.opengis.net/context'
 context_schemas_uri = 'http://schemas.opengis.net/context/1.0.0/context.xsd'
 
+
 def WMCElement(tag):
     """WMC based element
     """
-    return etree.Element("{%s}"%context_ns_uri + tag)
+    return etree.Element("{%s}" % context_ns_uri + tag)
+
 
 class MapContext:
+
     """ Map Context abstraction
 
     It uses a Map representation as input and export it as as map
@@ -41,9 +44,9 @@ class MapContext:
         attrs = {
             '{http://www.w3.org/2001/XMLSchema-instance}schemaLocation':
             context_ns_uri + ' ' + context_schemas_uri,
-            'id' : self._map.id,
-            'version' : '1.0.0',
-            }
+            'id': self._map.id,
+            'version': '1.0.0',
+        }
         for k, v in attrs.items():
             root.attrib[k] = v
         return root
@@ -91,8 +94,8 @@ class MapContext:
                     e_style.attrib['current'] = '1'
                     # Change namespace to wmc
                     for node in e_style.getiterator():
-                        tag_name = node.tag[node.tag.rfind('}')+1:]
-                        node.tag = "{%s}"%context_ns_uri + tag_name
+                        tag_name = node.tag[node.tag.rfind('}') + 1:]
+                        node.tag = "{%s}" % context_ns_uri + tag_name
                     stylelist.append(e_style)
                 layer.append(stylelist)
 
@@ -142,6 +145,7 @@ class MapContext:
 
 
 class AggregateMapContext(MapContext):
+
     """ Map Context abstraction
 
     It uses a Map representation as input and export it as as map
@@ -190,7 +194,7 @@ class AggregateMapContext(MapContext):
         formatlist.append(format)
         layer.append(formatlist)
         layerlist.append(layer)
-        
+
         return layerlist
 
 
@@ -204,4 +208,3 @@ def mapToWebMapContext(map, aggregate_layers=False):
         return AggregateMapContext(map)()
     else:
         return MapContext(map)()
-

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -16,7 +16,8 @@ https://portal.opengeospatial.org/files/?artifact_id=8618
 
 """
 
-from etree import etree
+from owslib.etree import etree
+
 
 context_ns_uri = 'http://www.opengis.net/context'
 context_schemas_uri = 'http://schemas.opengis.net/context/1.0.0/context.xsd'

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -16,7 +16,7 @@ https://portal.opengeospatial.org/files/?artifact_id=8618
 
 """
 
-from six import iteritems
+from six import iteritems, text_type
 from six.moves import zip
 
 from owslib.etree import etree
@@ -63,17 +63,17 @@ class MapContext(object):
 
     def _getWindowElement(self):
         window = WMCElement('Window')
-        window.attrib['width'] = str(self._map.size[0])
-        window.attrib['height'] = str(self._map.size[1])
+        window.attrib['width'] = text_type(self._map.size[0])
+        window.attrib['height'] = text_type(self._map.size[1])
         return window
 
     def _getBoundingBoxElement(self):
         bbox = WMCElement('BoundingBox')
-        bbox.attrib['SRS'] = str(self._map.srs.split()[0])
-        bbox.attrib['minx'] = str(self._map.bounds[0])
-        bbox.attrib['miny'] = str(self._map.bounds[1])
-        bbox.attrib['maxx'] = str(self._map.bounds[2])
-        bbox.attrib['maxy'] = str(self._map.bounds[3])
+        bbox.attrib['SRS'] = text_type(self._map.srs.split()[0])
+        bbox.attrib['minx'] = text_type(self._map.bounds[0])
+        bbox.attrib['miny'] = text_type(self._map.bounds[1])
+        bbox.attrib['maxx'] = text_type(self._map.bounds[2])
+        bbox.attrib['maxy'] = text_type(self._map.bounds[3])
         return bbox
 
     def _getLayerListElement(self):
@@ -87,8 +87,7 @@ class MapContext(object):
             # Layer
             layer = WMCElement('Layer')
             layer.attrib['queryable'] = '0'
-            layer.attrib['hidden'] = str(
-                int(name not in self._map.visible_layers))
+            layer.attrib['hidden'] = text_type(int(name not in self._map.visible_layers))
 
             # Layer styles
             if layer_infos and layer_infos.get(title):

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -28,7 +28,7 @@ def WMCElement(tag):
     return etree.Element("{%s}" % context_ns_uri + tag)
 
 
-class MapContext:
+class MapContext(object):
 
     """ Map Context abstraction
 

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -15,14 +15,12 @@ API for Web Map Service (WMS) methods and metadata.
 Currently supports only version 1.1.1 of the WMS protocol.
 """
 
-import cgi
-import urllib2
-from urllib import urlencode
 import warnings
-from etree import etree
-from .util import openURL, testXMLValue, extract_xml_list
-from fgdc import Metadata
-from iso import MD_Metadata
+
+from owslib.etree import etree
+from owslib.util import openURL, testXMLValue, extract_xml_list, urlencode, urlopen, parse_qsl
+from owslib.fgdc import Metadata
+from owslib.iso import MD_Metadata
 
 
 class ServiceException(Exception):
@@ -482,7 +480,7 @@ class ContentMetadata(object):
 
             if metadataUrl['url'] is not None and parse_remote_metadata:  # download URL
                 try:
-                    content = urllib2.urlopen(metadataUrl['url'], timeout=timeout)
+                    content = urlopen(metadataUrl['url'], timeout=timeout)
                     doc = etree.parse(content)
                     if metadataUrl['type'] is not None:
                         if metadataUrl['type'] == 'FGDC':
@@ -612,7 +610,7 @@ class WMSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -56,7 +56,7 @@ class WebMapService(object):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -24,7 +24,9 @@ from .util import openURL, testXMLValue, extract_xml_list
 from fgdc import Metadata
 from iso import MD_Metadata
 
+
 class ServiceException(Exception):
+
     """WMS ServiceException
 
     Attributes:
@@ -35,7 +37,7 @@ class ServiceException(Exception):
     def __init__(self, message, xml):
         self.message = message
         self.xml = xml
-        
+
     def __str__(self):
         return repr(self.message)
 
@@ -45,43 +47,43 @@ class CapabilitiesError(Exception):
 
 
 class WebMapService(object):
+
     """Abstraction for OGC Web Map Service (WMS).
 
     Implements IWebMapService.
     """
-    
-    def __getitem__(self,name):
+
+    def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
 
-    
-    def __init__(self, url, version='1.1.1', xml=None, 
-                username=None, password=None, parse_remote_metadata=False
-                ):
+    def __init__(self, url, version='1.1.1', xml=None,
+                 username=None, password=None, parse_remote_metadata=False
+                 ):
         """Initialize."""
         self.url = url
         self.username = username
         self.password = password
         self.version = version
         self._capabilities = None
-        
+
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(
-                self.version, url=self.url, un=self.username, pw=self.password
-                )
+            self.version, url=self.url, un=self.username, pw=self.password
+        )
         if xml:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url)
 
         # avoid building capabilities metadata if the response is a ServiceExceptionReport
-        se = self._capabilities.find('ServiceException') 
-        if se is not None: 
-            err_message = str(se.text).strip() 
-            raise ServiceException(err_message, xml) 
+        se = self._capabilities.find('ServiceException')
+        if se is not None:
+            err_message = str(se.text).strip()
+            raise ServiceException(err_message, xml)
 
         # build metadata objects
         self._buildMetadata(parse_remote_metadata)
@@ -90,61 +92,61 @@ class WebMapService(object):
         if not self._capabilities:
             reader = WMSCapabilitiesReader(
                 self.version, url=self.url, un=self.username, pw=self.password
-                )
+            )
             self._capabilities = ServiceMetadata(reader.read(self.url))
         return self._capabilities
 
     def _buildMetadata(self, parse_remote_metadata=False):
         ''' set up capabilities metadata objects '''
-        
-        #serviceIdentification metadata
-        serviceelem=self._capabilities.find('Service')
-        self.identification=ServiceIdentification(serviceelem, self.version)   
-        
-        #serviceProvider metadata
-        self.provider=ServiceProvider(serviceelem)   
-            
-        #serviceOperations metadata 
-        self.operations=[]
+
+        # serviceIdentification metadata
+        serviceelem = self._capabilities.find('Service')
+        self.identification = ServiceIdentification(serviceelem, self.version)
+
+        # serviceProvider metadata
+        self.provider = ServiceProvider(serviceelem)
+
+        # serviceOperations metadata
+        self.operations = []
         for elem in self._capabilities.find('Capability/Request')[:]:
             self.operations.append(OperationMetadata(elem))
-          
-        #serviceContents metadata: our assumption is that services use a top-level 
-        #layer as a metadata organizer, nothing more.
-        self.contents={}
+
+        # serviceContents metadata: our assumption is that services use a top-level
+        # layer as a metadata organizer, nothing more.
+        self.contents = {}
         caps = self._capabilities.find('Capability')
-        
-        #recursively gather content metadata for all layer elements.
-        #To the WebMapService.contents store only metadata of named layers.
+
+        # recursively gather content metadata for all layer elements.
+        # To the WebMapService.contents store only metadata of named layers.
         def gather_layers(parent_elem, parent_metadata):
             for index, elem in enumerate(parent_elem.findall('Layer')):
-                cm = ContentMetadata(elem, parent=parent_metadata, index=index+1, parse_remote_metadata=parse_remote_metadata)
+                cm = ContentMetadata(elem, parent=parent_metadata, index=index + 1, parse_remote_metadata=parse_remote_metadata)
                 if cm.id:
                     if cm.id in self.contents:
                         warnings.warn('Content metadata for layer "%s" already exists. Using child layer' % cm.id)
                     self.contents[cm.id] = cm
                 gather_layers(elem, cm)
         gather_layers(caps, None)
-        
-        #exceptions
-        self.exceptions = [f.text for f \
-                in self._capabilities.findall('Capability/Exception/Format')]
-            
+
+        # exceptions
+        self.exceptions = [f.text for f
+                           in self._capabilities.findall('Capability/Exception/Format')]
+
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
-    
+
     def getcapabilities(self):
-        """Request and return capabilities document from the WMS as a 
+        """Request and return capabilities document from the WMS as a
         file-like object.
         NOTE: this is effectively redundant now"""
-        
+
         reader = WMSCapabilitiesReader(
             self.version, url=self.url, un=self.username, pw=self.password
-            )
+        )
         u = self._open(reader.capabilities_url(self.url))
         # check for service exceptions, and return
         if u.info().gettype() == 'application/vnd.ogc.se_xml':
@@ -162,7 +164,7 @@ class WebMapService(object):
                **kwargs
                ):
         """Request and return an image from the WMS as a file-like object.
-        
+
         Parameters
         ----------
         layers : list
@@ -186,7 +188,7 @@ class WebMapService(object):
             Optional. HTTP DCP method name: Get or Post.
         **kwargs : extra arguments
             anything else e.g. vendor specific parameters
-        
+
         Example
         -------
             >>> wms = WebMapService('http://giswebservices.massgis.state.ma.us/geoserver/wms', version='1.1.1')
@@ -201,10 +203,10 @@ class WebMapService(object):
             >>> out.write(img.read())
             >>> out.close()
 
-        """        
+        """
         base_url = self.getOperationByName('GetMap').methods[method]['url']
         request = {'version': self.version, 'request': 'GetMap'}
-        
+
         # check layers and styles
         assert len(layers) > 0
         request['layers'] = ','.join(layers)
@@ -217,24 +219,24 @@ class WebMapService(object):
         # size
         request['width'] = str(size[0])
         request['height'] = str(size[1])
-        
+
         request['srs'] = str(srs)
         request['bbox'] = ','.join([repr(x) for x in bbox])
         request['format'] = str(format)
         request['transparent'] = str(transparent).upper()
         request['bgcolor'] = '0x' + bgcolor[1:7]
         request['exceptions'] = str(exceptions)
-        
+
         if time is not None:
             request['time'] = str(time)
-        
+
         if kwargs:
             for kw in kwargs:
-                request[kw]=kwargs[kw]
+                request[kw] = kwargs[kw]
 
         data = urlencode(request)
-        
-        u = openURL(base_url, data, method, username = self.username, password = self.password)
+
+        u = openURL(base_url, data, method, username=self.username, password=self.password)
 
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
@@ -243,7 +245,7 @@ class WebMapService(object):
             err_message = unicode(se_tree.find('ServiceException').text).strip()
             raise ServiceException(err_message, se_xml)
         return u
-        
+
     def getServiceXML(self):
         xml = None
         if self._capabilities is not None:
@@ -253,18 +255,20 @@ class WebMapService(object):
     def getfeatureinfo(self):
         raise NotImplementedError
 
-    def getOperationByName(self, name): 
+    def getOperationByName(self, name):
         """Return a named content item."""
         for item in self.operations:
             if item.name == name:
                 return item
         raise KeyError, "No operation named %s" % name
-    
+
+
 class ServiceIdentification(object):
+
     ''' Implements IServiceIdentificationMetadata '''
-    
+
     def __init__(self, infoset, version):
-        self._root=infoset
+        self._root = infoset
         self.type = testXMLValue(self._root.find('Name'))
         self.version = version
         self.title = testXMLValue(self._root.find('Title'))
@@ -273,25 +277,28 @@ class ServiceIdentification(object):
         self.accessconstraints = testXMLValue(self._root.find('AccessConstraints'))
         self.fees = testXMLValue(self._root.find('Fees'))
 
+
 class ServiceProvider(object):
+
     ''' Implements IServiceProviderMetatdata '''
+
     def __init__(self, infoset):
-        self._root=infoset
-        name=self._root.find('ContactInformation/ContactPersonPrimary/ContactOrganization')
+        self._root = infoset
+        name = self._root.find('ContactInformation/ContactPersonPrimary/ContactOrganization')
         if name is not None:
-            self.name=name.text
+            self.name = name.text
         else:
-            self.name=None
-        self.url=self._root.find('OnlineResource').attrib.get('{http://www.w3.org/1999/xlink}href', '')
-        #contact metadata
+            self.name = None
+        self.url = self._root.find('OnlineResource').attrib.get('{http://www.w3.org/1999/xlink}href', '')
+        # contact metadata
         contact = self._root.find('ContactInformation')
-        ## sometimes there is a contact block that is empty, so make
-        ## sure there are children to parse
+        # sometimes there is a contact block that is empty, so make
+        # sure there are children to parse
         if contact is not None and contact[:] != []:
             self.contact = ContactMetadata(contact)
         else:
             self.contact = None
-            
+
     def getContentByName(self, name):
         """Return a named content item."""
         for item in self.contents:
@@ -305,23 +312,26 @@ class ServiceProvider(object):
             if item.name == name:
                 return item
         raise KeyError, "No operation named %s" % name
-        
+
+
 class ContentMetadata:
+
     """
     Abstraction for WMS layer metadata.
 
     Implements IContentMetadata.
     """
+
     def __init__(self, elem, parent=None, index=0, parse_remote_metadata=False, timeout=30):
         if elem.tag != 'Layer':
             raise ValueError('%s should be a Layer' % (elem,))
-        
+
         self.parent = parent
         if parent:
             self.index = "%s.%d" % (parent.index, index)
         else:
             self.index = str(index)
-        
+
         self.id = self.name = testXMLValue(elem.find('Name'))
 
         # layer attributes
@@ -339,31 +349,31 @@ class ContentMetadata:
             self.title = title.strip()
 
         self.abstract = testXMLValue(elem.find('Abstract'))
-        
+
         # bboxes
         b = elem.find('BoundingBox')
         self.boundingBox = None
         if b is not None:
-            try: #sometimes the SRS attribute is (wrongly) not provided
-                srs=b.attrib['SRS']
+            try:  # sometimes the SRS attribute is (wrongly) not provided
+                srs = b.attrib['SRS']
             except KeyError:
-                srs=None
+                srs = None
             self.boundingBox = (
                 float(b.attrib['minx']),
                 float(b.attrib['miny']),
                 float(b.attrib['maxx']),
                 float(b.attrib['maxy']),
                 srs,
-                )
+            )
         elif self.parent:
             if hasattr(self.parent, 'boundingBox'):
                 self.boundingBox = self.parent.boundingBox
 
-        # ScaleHint 
-        sh = elem.find('ScaleHint') 
-        self.scaleHint = None 
-        if sh is not None: 
-            self.scaleHint = {'min': sh.attrib['min'], 'max': sh.attrib['max']} 
+        # ScaleHint
+        sh = elem.find('ScaleHint')
+        self.scaleHint = None
+        if sh is not None:
+            self.scaleHint = {'min': sh.attrib['min'], 'max': sh.attrib['max']}
 
         attribution = elem.find('Attribution')
         if attribution is not None:
@@ -371,11 +381,11 @@ class ContentMetadata:
             title = attribution.find('Title')
             url = attribution.find('OnlineResource')
             logo = attribution.find('LogoURL')
-            if title is not None: 
+            if title is not None:
                 self.attribution['title'] = title.text
             if url is not None:
                 self.attribution['url'] = url.attrib['{http://www.w3.org/1999/xlink}href']
-            if logo is not None: 
+            if logo is not None:
                 self.attribution['logo_size'] = (int(logo.attrib['width']), int(logo.attrib['height']))
                 self.attribution['logo_url'] = logo.find('OnlineResource').attrib['{http://www.w3.org/1999/xlink}href']
 
@@ -391,51 +401,51 @@ class ContentMetadata:
             self.boundingBoxWGS84 = self.parent.boundingBoxWGS84
         else:
             self.boundingBoxWGS84 = None
-            
-        #SRS options
+
+        # SRS options
         self.crsOptions = []
-            
-        #Copy any parent SRS options (they are inheritable properties)
+
+        # Copy any parent SRS options (they are inheritable properties)
         if self.parent:
             self.crsOptions = list(self.parent.crsOptions)
 
-        #Look for SRS option attached to this layer
+        # Look for SRS option attached to this layer
         if elem.find('SRS') is not None:
-            ## some servers found in the wild use a single SRS
-            ## tag containing a whitespace separated list of SRIDs
-            ## instead of several SRS tags. hence the inner loop
+            # some servers found in the wild use a single SRS
+            # tag containing a whitespace separated list of SRIDs
+            # instead of several SRS tags. hence the inner loop
             for srslist in map(lambda x: x.text, elem.findall('SRS')):
                 if srslist:
                     for srs in srslist.split():
                         self.crsOptions.append(srs)
-                        
-        #Get rid of duplicate entries
+
+        # Get rid of duplicate entries
         self.crsOptions = list(set(self.crsOptions))
 
-        #Set self.crsOptions to None if the layer (and parents) had no SRS options
+        # Set self.crsOptions to None if the layer (and parents) had no SRS options
         if len(self.crsOptions) == 0:
             #raise ValueError('%s no SRS available!?' % (elem,))
-            #Comment by D Lowe.
-            #Do not raise ValueError as it is possible that a layer is purely a parent layer and does not have SRS specified. Instead set crsOptions to None
+            # Comment by D Lowe.
+            # Do not raise ValueError as it is possible that a layer is purely a parent layer and does not have SRS specified. Instead set crsOptions to None
             # Comment by Jachym:
             # Do not set it to None, but to [], which will make the code
             # work further. Fixed by anthonybaxter
-            self.crsOptions=[]
-            
-        #Styles
+            self.crsOptions = []
+
+        # Styles
         self.styles = {}
-        
-        #Copy any parent styles (they are inheritable properties)
+
+        # Copy any parent styles (they are inheritable properties)
         if self.parent:
             self.styles = self.parent.styles.copy()
- 
-        #Get the styles for this layer (items with the same name are replaced)
+
+        # Get the styles for this layer (items with the same name are replaced)
         for s in elem.findall('Style'):
             name = s.find('Name')
             title = s.find('Title')
             if name is None or title is None:
                 raise ValueError('%s missing name or title' % (s,))
-            style = { 'title' : title.text }
+            style = {'title': title.text}
             # legend url
             legend = s.find('LegendURL/OnlineResource')
             if legend is not None:
@@ -446,22 +456,22 @@ class ContentMetadata:
         self.keywords = [f.text for f in elem.findall('KeywordList/Keyword')]
 
         # timepositions - times for which data is available.
-        self.timepositions=None
+        self.timepositions = None
         self.defaulttimeposition = None
         for extent in elem.findall('Extent'):
-            if extent.attrib.get("name").lower() =='time':
+            if extent.attrib.get("name").lower() == 'time':
                 if extent.text:
-                    self.timepositions=extent.text.split(',')
+                    self.timepositions = extent.text.split(',')
                     self.defaulttimeposition = extent.attrib.get("default")
                     break
-                
+
         # Elevations - available vertical levels
-        self.elevations=None
+        self.elevations = None
         for extent in elem.findall('Extent'):
-            if extent.attrib.get("name").lower() =='elevation':
+            if extent.attrib.get("name").lower() == 'elevation':
                 if extent.text:
-                    self.elevations=extent.text.split(',')
-                    break                
+                    self.elevations = extent.text.split(',')
+                    break
 
         # MetadataURLs
         self.metadataUrls = []
@@ -494,7 +504,7 @@ class ContentMetadata:
                 'url': m.find('OnlineResource').attrib['{http://www.w3.org/1999/xlink}href']
             }
             self.dataUrls.append(dataUrl)
-                
+
         self.layers = []
         for child in elem.findall('Layer'):
             self.layers.append(ContentMetadata(child, self))
@@ -504,10 +514,12 @@ class ContentMetadata:
 
 
 class OperationMetadata:
+
     """Abstraction for WMS OperationMetadata.
-    
+
     Implements IOperationMetadata.
     """
+
     def __init__(self, elem):
         """."""
         self.name = elem.tag
@@ -519,50 +531,63 @@ class OperationMetadata:
             methods.append((verb.tag, {'url': url}))
         self.methods = dict(methods)
 
+
 class ContactMetadata:
+
     """Abstraction for contact details advertised in GetCapabilities.
     """
+
     def __init__(self, elem):
         name = elem.find('ContactPersonPrimary/ContactPerson')
         if name is not None:
-            self.name=name.text
+            self.name = name.text
         else:
-            self.name=None
+            self.name = None
         email = elem.find('ContactElectronicMailAddress')
         if email is not None:
-            self.email=email.text
+            self.email = email.text
         else:
-            self.email=None
+            self.email = None
         self.address = self.city = self.region = None
         self.postcode = self.country = None
 
         address = elem.find('ContactAddress')
         if address is not None:
             street = address.find('Address')
-            if street is not None: self.address = street.text
+            if street is not None:
+                self.address = street.text
 
             city = address.find('City')
-            if city is not None: self.city = city.text
+            if city is not None:
+                self.city = city.text
 
             region = address.find('StateOrProvince')
-            if region is not None: self.region = region.text
+            if region is not None:
+                self.region = region.text
 
             postcode = address.find('PostCode')
-            if postcode is not None: self.postcode = postcode.text
+            if postcode is not None:
+                self.postcode = postcode.text
 
             country = address.find('Country')
-            if country is not None: self.country = country.text
+            if country is not None:
+                self.country = country.text
 
         organization = elem.find('ContactPersonPrimary/ContactOrganization')
-        if organization is not None: self.organization = organization.text
-        else:self.organization = None
+        if organization is not None:
+            self.organization = organization.text
+        else:
+            self.organization = None
 
         position = elem.find('ContactPosition')
-        if position is not None: self.position = position.text
-        else: self.position = None
+        if position is not None:
+            self.position = position.text
+        else:
+            self.position = None
 
-      
+
 class WMSCapabilitiesReader:
+
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
@@ -574,15 +599,15 @@ class WMSCapabilitiesReader:
         self.username = un
         self.password = pw
 
-        #if self.username and self.password:
-            ## Provide login information in order to use the WMS server
-            ## Create an OpenerDirector with support for Basic HTTP 
-            ## Authentication...
-            #passman = HTTPPasswordMgrWithDefaultRealm()
-            #passman.add_password(None, self.url, self.username, self.password)
-            #auth_handler = HTTPBasicAuthHandler(passman)
-            #opener = build_opener(auth_handler)
-            #self._open = opener.open
+        # if self.username and self.password:
+        # Provide login information in order to use the WMS server
+        # Create an OpenerDirector with support for Basic HTTP
+        # Authentication...
+        #passman = HTTPPasswordMgrWithDefaultRealm()
+        #passman.add_password(None, self.url, self.username, self.password)
+        #auth_handler = HTTPBasicAuthHandler(passman)
+        #opener = build_opener(auth_handler)
+        #self._open = opener.open
 
     def capabilities_url(self, service_url):
         """Return a capabilities url
@@ -612,9 +637,9 @@ class WMSCapabilitiesReader:
         """
         getcaprequest = self.capabilities_url(service_url)
 
-        #now split it up again to use the generic openURL function...
-        spliturl=getcaprequest.split('?')
-        u = openURL(spliturl[0], spliturl[1], method='Get', username = self.username, password = self.password)
+        # now split it up again to use the generic openURL function...
+        spliturl = getcaprequest.split('?')
+        u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -17,8 +17,11 @@ Currently supports only version 1.1.1 of the WMS protocol.
 
 import warnings
 
+from six.moves.urllib.parse import urlencode, parse_qsl
+from six.moves.urllib.request import urlopen
+
 from owslib.etree import etree
-from owslib.util import openURL, testXMLValue, extract_xml_list, urlencode, urlopen, parse_qsl
+from owslib.util import openURL, testXMLValue, extract_xml_list
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata
 

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -58,11 +58,10 @@ class WebMapService(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, version='1.1.1', xml=None,
-                 username=None, password=None, parse_remote_metadata=False
-                 ):
+                 username=None, password=None, parse_remote_metadata=False):
         """Initialize."""
         self.url = url
         self.username = username
@@ -161,8 +160,7 @@ class WebMapService(object):
                bgcolor='#FFFFFF',
                exceptions='application/vnd.ogc.se_xml',
                method='Get',
-               **kwargs
-               ):
+               **kwargs):
         """Request and return an image from the WMS as a file-like object.
 
         Parameters
@@ -260,7 +258,7 @@ class WebMapService(object):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class ServiceIdentification(object):
@@ -304,17 +302,17 @@ class ServiceProvider(object):
         for item in self.contents:
             if item.name == name:
                 return item
-        raise KeyError, "No content named %s" % name
+        raise KeyError('No content named %s' % name)
 
     def getOperationByName(self, name):
         """Return a named content item."""
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
-class ContentMetadata:
+class ContentMetadata(object):
 
     """
     Abstraction for WMS layer metadata.
@@ -414,7 +412,7 @@ class ContentMetadata:
             # some servers found in the wild use a single SRS
             # tag containing a whitespace separated list of SRIDs
             # instead of several SRS tags. hence the inner loop
-            for srslist in map(lambda x: x.text, elem.findall('SRS')):
+            for srslist in [x.text for x in elem.findall('SRS')]:
                 if srslist:
                     for srs in srslist.split():
                         self.crsOptions.append(srs)
@@ -491,7 +489,7 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] == 'TC211':
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception as err:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)
@@ -513,7 +511,7 @@ class ContentMetadata:
         return 'Layer Name: %s Title: %s' % (self.name, self.title)
 
 
-class OperationMetadata:
+class OperationMetadata(object):
 
     """Abstraction for WMS OperationMetadata.
 
@@ -532,7 +530,7 @@ class OperationMetadata:
         self.methods = dict(methods)
 
 
-class ContactMetadata:
+class ContactMetadata(object):
 
     """Abstraction for contact details advertised in GetCapabilities.
     """
@@ -586,7 +584,7 @@ class ContactMetadata:
             self.position = None
 
 
-class WMSCapabilitiesReader:
+class WMSCapabilitiesReader(object):
 
     """Read and parse capabilities document into a lxml.etree infoset
     """

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -17,6 +17,7 @@ Currently supports only version 1.1.1 of the WMS protocol.
 
 import warnings
 
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode, parse_qsl
 from six.moves.urllib.request import urlopen
 
@@ -82,7 +83,7 @@ class WebMapService(object):
         # avoid building capabilities metadata if the response is a ServiceExceptionReport
         se = self._capabilities.find('ServiceException')
         if se is not None:
-            err_message = str(se.text).strip()
+            err_message = text_type(se.text).strip()
             raise ServiceException(err_message, xml)
 
         # build metadata objects
@@ -152,7 +153,7 @@ class WebMapService(object):
         if u.info().gettype() == 'application/vnd.ogc.se_xml':
             se_xml = u.read()
             se_tree = etree.fromstring(se_xml)
-            err_message = str(se_tree.find('ServiceException').text).strip()
+            err_message = text_type(se_tree.find('ServiceException').text).strip()
             raise ServiceException(err_message, se_xml)
         return u
 
@@ -199,7 +200,7 @@ class WebMapService(object):
                                  format='image/jpeg',\
                                  transparent=True)
             >>> out = open('example.jpg.jpg', 'wb')
-            >>> out.write(img.read())
+            >>> written_bytes = out.write(img.read())
             >>> out.close()
 
         """
@@ -216,18 +217,18 @@ class WebMapService(object):
             request['styles'] = ''
 
         # size
-        request['width'] = str(size[0])
-        request['height'] = str(size[1])
+        request['width'] = text_type(size[0])
+        request['height'] = text_type(size[1])
 
-        request['srs'] = str(srs)
+        request['srs'] = text_type(srs)
         request['bbox'] = ','.join([repr(x) for x in bbox])
-        request['format'] = str(format)
-        request['transparent'] = str(transparent).upper()
+        request['format'] = text_type(format)
+        request['transparent'] = text_type(transparent).upper()
         request['bgcolor'] = '0x' + bgcolor[1:7]
-        request['exceptions'] = str(exceptions)
+        request['exceptions'] = text_type(exceptions)
 
         if time is not None:
-            request['time'] = str(time)
+            request['time'] = text_type(time)
 
         if kwargs:
             for kw in kwargs:
@@ -241,7 +242,7 @@ class WebMapService(object):
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
             se_xml = u.read()
             se_tree = etree.fromstring(se_xml)
-            err_message = unicode(se_tree.find('ServiceException').text).strip()
+            err_message = text_type(se_tree.find('ServiceException').text).strip()
             raise ServiceException(err_message, se_xml)
         return u
 
@@ -329,7 +330,7 @@ class ContentMetadata(object):
         if parent:
             self.index = "%s.%d" % (parent.index, index)
         else:
-            self.index = str(index)
+            self.index = text_type(index)
 
         self.id = self.name = testXMLValue(elem.find('Name'))
 
@@ -646,6 +647,6 @@ class WMSCapabilitiesReader(object):
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -69,11 +69,10 @@ class WebMapTileService(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError('No content named %s' % name)
 
     def __init__(self, url, version='1.0.0', xml=None,
-                 username=None, password=None, parse_remote_metadata=False
-                 ):
+                 username=None, password=None, parse_remote_metadata=False):
         """Initialize."""
         self.url = url
         self.username = username
@@ -233,7 +232,7 @@ class WebMapTileService(object):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError('No operation named %s' % name)
 
 
 class TileMatrixSet(object):
@@ -245,7 +244,7 @@ class TileMatrixSet(object):
             raise ValueError('%s should be a TileMatrixSet' % (elem,))
         self.identifier = testXMLValue(elem.find('{http://www.opengis.net/ows/1.1}Identifier')).strip()
         self.crs = testXMLValue(elem.find('{http://www.opengis.net/ows/1.1}SupportedCRS')).strip()
-        if (self.crs == None) or (self.identifier == None):
+        if (self.crs is None) or (self.identifier is None):
             raise ValueError('%s incomplete TileMatrixSet' % (elem,))
         self.tilematrix = {}
         for tilematrix in elem.findall('{http://www.opengis.net/wmts/1.0}TileMatrix'):
@@ -287,7 +286,7 @@ class TileMatrix(object):
         self.matrixheight = int(mh)
 
 
-class Theme:
+class Theme(object):
 
     """
     Abstraction for a WMTS theme
@@ -315,7 +314,7 @@ class Theme:
                 self.layerRefs.append(layerRef.text)
 
 
-class ContentMetadata:
+class ContentMetadata(object):
 
     """
     Abstraction for WMTS layer metadata.
@@ -388,7 +387,7 @@ class ContentMetadata:
         return 'Layer Name: %s Title: %s' % (self.name, self.title)
 
 
-class OperationsMetadata:
+class OperationsMetadata(object):
 
     """Abstraction for WMTS OperationsMetadata.
 
@@ -415,7 +414,7 @@ class OperationsMetadata:
         self.methods = dict(methods)
 
 
-class WMTSCapabilitiesReader:
+class WMTSCapabilitiesReader(object):
 
     """Read and parse capabilities document into a lxml.etree infoset
     """

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -35,7 +35,9 @@ from fgdc import Metadata
 from iso import MD_Metadata
 from ows import ServiceProvider, ServiceIdentification, OperationsMetadata
 
+
 class ServiceException(Exception):
+
     """WMTS ServiceException
 
     Attributes:
@@ -56,22 +58,22 @@ class CapabilitiesError(Exception):
 
 
 class WebMapTileService(object):
+
     """Abstraction for OGC Web Map Tile Service (WMTS).
 
     Implements IWebMapService.
     """
 
-    def __getitem__(self,name):
+    def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError, "No content named %s" % name
 
-
     def __init__(self, url, version='1.0.0', xml=None,
-                username=None, password=None, parse_remote_metadata=False
-                ):
+                 username=None, password=None, parse_remote_metadata=False
+                 ):
         """Initialize."""
         self.url = url
         self.username = username
@@ -81,8 +83,8 @@ class WebMapTileService(object):
 
         # Authentication handled by Reader
         reader = WMTSCapabilitiesReader(
-                self.version, url=self.url, un=self.username, pw=self.password
-                )
+            self.version, url=self.url, un=self.username, pw=self.password
+        )
 
         if xml:  # read from stored xml
             self._capabilities = reader.readString(xml)
@@ -103,34 +105,34 @@ class WebMapTileService(object):
         if not self._capabilities:
             reader = WMTSCapabilitiesReader(
                 self.version, url=self.url, un=self.username, pw=self.password
-                )
+            )
             self._capabilities = ServiceMetadata(reader.read(self.url))
         return self._capabilities
 
     def _buildMetadata(self, parse_remote_metadata=False):
         ''' set up capabilities metadata objects '''
 
-        #serviceIdentification metadata
-        serviceident=self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceIdentification')
-        self.identification=ServiceIdentification(serviceident)
+        # serviceIdentification metadata
+        serviceident = self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceIdentification')
+        self.identification = ServiceIdentification(serviceident)
 
-        #serviceProvider metadata
-        serviceprov=self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceProvider')
-        self.provider=ServiceProvider(serviceprov)
+        # serviceProvider metadata
+        serviceprov = self._capabilities.find('{http://www.opengis.net/ows/1.1}ServiceProvider')
+        self.provider = ServiceProvider(serviceprov)
 
-        #serviceOperations metadata
-        self.operations=[]
+        # serviceOperations metadata
+        self.operations = []
         for elem in self._capabilities.find('{http://www.opengis.net/ows/1.1}OperationsMetadata')[:]:
             self.operations.append(OperationsMetadata(elem))
 
-        #serviceContents metadata: our assumption is that services use a top-level
-        #layer as a metadata organizer, nothing more.
-        self.contents={}
+        # serviceContents metadata: our assumption is that services use a top-level
+        # layer as a metadata organizer, nothing more.
+        self.contents = {}
         caps = self._capabilities.find('{http://www.opengis.net/wmts/1.0}Contents')
 
         def gather_layers(parent_elem, parent_metadata):
             for index, elem in enumerate(parent_elem.findall('{http://www.opengis.net/wmts/1.0}Layer')):
-                cm = ContentMetadata(elem, parent=parent_metadata, index=index+1, parse_remote_metadata=parse_remote_metadata)
+                cm = ContentMetadata(elem, parent=parent_metadata, index=index + 1, parse_remote_metadata=parse_remote_metadata)
                 if cm.id:
                     if cm.id in self.contents:
                         raise KeyError('Content metadata for layer "%s" already exists' % cm.id)
@@ -162,9 +164,9 @@ class WebMapTileService(object):
 
     def items(self):
         '''supports dict-like items() access'''
-        items=[]
+        items = []
         for item in self.contents:
-            items.append((item,self.contents[item]))
+            items.append((item, self.contents[item]))
         return items
 
     def buildTileRequest(self, layer=None, style=None, format=None, tilematrixset=None, tilematrix=None, row=None, column=None):
@@ -181,9 +183,9 @@ class WebMapTileService(object):
         if tilematrix is None:
             raise ValueError("tilematrix (zoom level) is mandatory (cannot be None)")
         if row is None:
-                raise ValueError("row is mandatory (cannot be None)")
+            raise ValueError("row is mandatory (cannot be None)")
         if column is None:
-                raise ValueError("column is mandatory (cannot be None)")
+            raise ValueError("column is mandatory (cannot be None)")
 
         request = list()
         request.append(('SERVICE', 'WMTS'))
@@ -200,7 +202,6 @@ class WebMapTileService(object):
         data = urlencode(request, True)
         return data
 
-
     def gettile(self, base_url=None, layer=None, style=None, format=None, tilematrixset=None, tilematrix=None, row=None, column=None):
         """Request a tile from a WMTS server
         """
@@ -208,7 +209,7 @@ class WebMapTileService(object):
 
         if base_url is None:
             base_url = self.getOperationByName('GetTile').methods['Get']['url']
-        u = openURL(base_url, data, username = self.username, password = self.password)
+        u = openURL(base_url, data, username=self.username, password=self.password)
 
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
@@ -234,8 +235,11 @@ class WebMapTileService(object):
                 return item
         raise KeyError, "No operation named %s" % name
 
+
 class TileMatrixSet(object):
+
     '''Holds one TileMatrixSet'''
+
     def __init__(self, elem):
         if elem.tag != '{http://www.opengis.net/wmts/1.0}TileMatrixSet':
             raise ValueError('%s should be a TileMatrixSet' % (elem,))
@@ -251,8 +255,11 @@ class TileMatrixSet(object):
                     raise KeyError('TileMatrix with identifier "%s" already exists' % tm.identifier)
                 self.tilematrix[tm.identifier] = tm
 
+
 class TileMatrix(object):
+
     '''Holds one TileMatrix'''
+
     def __init__(self, elem):
         if elem.tag != '{http://www.opengis.net/wmts/1.0}TileMatrix':
             raise ValueError('%s should be a TileMatrix' % (elem,))
@@ -279,10 +286,13 @@ class TileMatrix(object):
         self.matrixwidth = int(mw)
         self.matrixheight = int(mh)
 
+
 class Theme:
+
     """
     Abstraction for a WMTS theme
     """
+
     def __init__(self, elem):
         if elem.tag != '{http://www.opengis.net/wmts/1.0}Theme':
             raise ValueError('%s should be a Theme' % (elem,))
@@ -304,12 +314,15 @@ class Theme:
             if layerRef.text is not None:
                 self.layerRefs.append(layerRef.text)
 
+
 class ContentMetadata:
+
     """
     Abstraction for WMTS layer metadata.
 
     Implements IContentMetadata.
     """
+
     def __init__(self, elem, parent=None, index=0, parse_remote_metadata=False):
         if elem.tag != '{http://www.opengis.net/wmts/1.0}Layer':
             raise ValueError('%s should be a Layer' % (elem,))
@@ -337,7 +350,7 @@ class ContentMetadata:
             uc = b.find("{http://www.opengis.net/ows/1.1}UpperCorner")
             ll = [float(s) for s in lc.text.split()]
             ur = [float(s) for s in uc.text.split()]
-            self.boundingBoxWGS84 = (ll[0],ll[1],ur[0],ur[1])
+            self.boundingBoxWGS84 = (ll[0], ll[1], ur[0], ur[1])
         # TODO: there is probably some more logic here, and it should probably be shared code
 
         self.tilematrixsets = [f.text.strip() for f in elem.findall('{http://www.opengis.net/wmts/1.0}TileMatrixSetLink/{http://www.opengis.net/wmts/1.0}TileMatrixSet')]
@@ -349,7 +362,7 @@ class ContentMetadata:
                 resource[attrib] = resourceURL.attrib[attrib]
             self.resourceURLs.append(resource)
 
-        #Styles
+        # Styles
         self.styles = {}
         for s in elem.findall('{http://www.opengis.net/wmts/1.0}Style'):
             style = {}
@@ -376,10 +389,12 @@ class ContentMetadata:
 
 
 class OperationsMetadata:
+
     """Abstraction for WMTS OperationsMetadata.
 
     Implements IOperationMetadata.
     """
+
     def __init__(self, elem):
         """."""
         self.name = elem.attrib['name']
@@ -394,12 +409,14 @@ class OperationsMetadata:
                 if constraint.attrib['name'] == "GetEncoding":
                     for encoding in constraint.findall('{http://www.opengis.net/ows/1.1}AllowedValues/{http://www.opengis.net/ows/1.1}Value'):
                         encodings.append(encoding.text)
-            if len(encodings) < 1: # KVP is only a SHOULD requirement, and SFS doesn't provide it.
+            if len(encodings) < 1:  # KVP is only a SHOULD requirement, and SFS doesn't provide it.
                 encodings = ['KVP']
             methods.append(('Get', {'url': url, 'encodings': encodings}))
         self.methods = dict(methods)
 
+
 class WMTSCapabilitiesReader:
+
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
@@ -439,9 +456,9 @@ class WMTSCapabilitiesReader:
         """
         getcaprequest = self.capabilities_url(service_url)
 
-        #now split it up again to use the generic openURL function...
-        spliturl=getcaprequest.split('?')
-        u = openURL(spliturl[0], spliturl[1], method='Get', username = self.username, password = self.password)
+        # now split it up again to use the generic openURL function...
+        spliturl = getcaprequest.split('?')
+        u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -26,8 +26,10 @@ More extensive testing is needed and feedback (to bradh@frogmouth.net) would be 
 
 """
 
+from six.moves.urllib.parse import urlencode, parse_qsl
+
 from owslib.etree import etree
-from owslib.util import openURL, testXMLValue, urlencode, parse_qsl
+from owslib.util import openURL, testXMLValue
 from owslib.ows import ServiceProvider, ServiceIdentification, OperationsMetadata
 
 

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -25,7 +25,7 @@ PLEASE NOTE: the owslib wmts module should be considered in early-beta state: it
 More extensive testing is needed and feedback (to bradh@frogmouth.net) would be appreciated.
 
 """
-
+from six import text_type, binary_type
 from six.moves.urllib.parse import urlencode, parse_qsl
 
 from owslib.etree import etree
@@ -91,7 +91,7 @@ class WebMapTileService(object):
         # TODO: check if this needs a namespace
         se = self._capabilities.find('ServiceException')
         if se is not None:
-            err_message = str(se.text).strip()
+            err_message = text_type(se.text).strip()
             raise ServiceException(err_message, xml)
 
         # build metadata objects
@@ -191,8 +191,8 @@ class WebMapTileService(object):
         request.append(('STYLE', style))
         request.append(('TILEMATRIXSET', tilematrixset))
         request.append(('TILEMATRIX', tilematrix))
-        request.append(('TILEROW', str(row)))
-        request.append(('TILECOL', str(column)))
+        request.append(('TILEROW', text_type(row)))
+        request.append(('TILECOL', text_type(column)))
         request.append(('FORMAT', format))
 
         data = urlencode(request, True)
@@ -211,7 +211,7 @@ class WebMapTileService(object):
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
             se_xml = u.read()
             se_tree = etree.fromstring(se_xml)
-            err_message = unicode(se_tree.find('ServiceException').text).strip()
+            err_message = text_type(se_tree.find('ServiceException').text).strip()
             raise ServiceException(err_message, se_xml)
         return u
 
@@ -327,7 +327,7 @@ class ContentMetadata(object):
         if parent:
             self.index = "%s.%d" % (parent.index, index)
         else:
-            self.index = str(index)
+            self.index = text_type(index)
 
         self.id = self.name = testXMLValue(elem.find('{http://www.opengis.net/ows/1.1}Identifier'))
         # title is mandatory property
@@ -462,6 +462,6 @@ class WMTSCapabilitiesReader(object):
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, (text_type, binary_type)):
+            raise ValueError('String must be of type string, not %s' % type(st))
         return etree.fromstring(st)

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -63,7 +63,7 @@ class WebMapTileService(object):
 
     def __getitem__(self, name):
         ''' check contents dictionary to allow dict like access to service layers'''
-        if name in self.__getattribute__('contents').keys():
+        if name in self.__getattribute__('contents'):
             return self.__getattribute__('contents')[name]
         else:
             raise KeyError('No content named %s' % name)
@@ -171,7 +171,7 @@ class WebMapTileService(object):
         if (layer is None):
             raise ValueError("layer is mandatory (cannot be None)")
         if style is None:
-            style = self[layer].styles.keys()[0]
+            style = list(self[layer].styles.keys())[0]
         if format is None:
             format = self[layer].formats[0]
         if tilematrixset is None:

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -26,14 +26,9 @@ More extensive testing is needed and feedback (to bradh@frogmouth.net) would be 
 
 """
 
-import urlparse
-import urllib2
-from urllib import urlencode
-from etree import etree
-from .util import openURL, testXMLValue
-from fgdc import Metadata
-from iso import MD_Metadata
-from ows import ServiceProvider, ServiceIdentification, OperationsMetadata
+from owslib.etree import etree
+from owslib.util import openURL, testXMLValue, urlencode, parse_qsl
+from owslib.ows import ServiceProvider, ServiceIdentification, OperationsMetadata
 
 
 class ServiceException(Exception):
@@ -432,7 +427,7 @@ class WMTSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = urlparse.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -86,6 +86,8 @@ Also, the directory tests/ contains several examples of well-formed "Execute" re
 
 from time import sleep
 
+from six import text_type, binary_type
+
 from owslib.etree import etree
 from owslib.ows import DEFAULT_OWS_NAMESPACE, ServiceIdentification, ServiceProvider, OperationsMetadata
 from owslib.util import (testXMLValue, build_get_url, dump, getTypedValue,
@@ -384,8 +386,8 @@ class WPSReader(object):
         Method to read a WPS GetCapabilities document from an XML string.
         """
 
-        if not isinstance(string, str):
-            raise ValueError("Input must be of type string, not %s" % type(string))
+        if not isinstance(string, (text_type, binary_type)):
+            raise ValueError('Input must be of type string, not %s' % type(string))
         return etree.fromstring(string)
 
 
@@ -525,7 +527,7 @@ class WPSExecution(object):
             #     <wps:LiteralData>dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml</wps:LiteralData>
             #   </wps:Data>
             # </wps:Input>
-            if isinstance(val, str):
+            if isinstance(val, (text_type, binary_type)):
                 dataElement = etree.SubElement(inputElement, nspath_eval('wps:Data', namespaces))
                 literalDataElement = etree.SubElement(dataElement, nspath_eval('wps:LiteralData', namespaces))
                 literalDataElement.text = val
@@ -561,7 +563,7 @@ class WPSExecution(object):
             responseFormElement = etree.SubElement(root, nspath_eval('wps:ResponseForm', namespaces))
             responseDocumentElement = etree.SubElement(responseFormElement, nspath_eval('wps:ResponseDocument', namespaces),
                                                        attrib={'storeExecuteResponse': 'true', 'status': 'true'})
-            if isinstance(output, str):
+            if isinstance(output, (text_type, binary_type)):
                 self._add_output(responseDocumentElement, output, asReference=True)
             elif isinstance(output, list):
                 for (identifier, as_reference) in output:
@@ -572,7 +574,7 @@ class WPSExecution(object):
 
     def _add_output(self, element, identifier, asReference=False):
         outputElement = etree.SubElement(element, nspath_eval('wps:Output', namespaces),
-                                         attrib={'asReference': str(asReference).lower()})
+                                         attrib={'asReference': text_type(asReference).lower()})
         outputIdentifierElement = etree.SubElement(outputElement, nspath_eval('ows:Identifier', namespaces)).text = identifier
 
     # wait for 60 seconds by default

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -84,13 +84,14 @@ Also, the directory tests/ contains several examples of well-formed "Execute" re
 
 """
 
+from time import sleep
+
 from owslib.etree import etree
 from owslib.ows import DEFAULT_OWS_NAMESPACE, ServiceIdentification, ServiceProvider, OperationsMetadata
-from time import sleep
 from owslib.util import (testXMLValue, build_get_url, dump, getTypedValue,
                          getNamespace, xml2string, nspath, openURL, nspath_eval)
-from xml.dom.minidom import parseString
 from owslib.namespaces import Namespaces
+
 
 # namespace definition
 n = Namespaces()

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1396,7 +1396,7 @@ def printInputOutput(value, indent=''):
         print('%s Allowed Value: %s' % (indent, printValue(val)))
     for val in value.supportedValues:
         print('%s Supported Value: %s' % (indent, printValue(val)))
-    print('%s Default Value: %s ' % (indent, printValue(value.defaultValue)))
+    print('%s Default Value: %s' % (indent, printValue(value.defaultValue)))
 
     # Input fields
     if isinstance(value, Input):

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -20,25 +20,25 @@ More extensive testing is needed and feedback is appreciated.
 Usage
 -----
 
-The module can be used to execute three types of requests versus a remote WPS endpoint: 
+The module can be used to execute three types of requests versus a remote WPS endpoint:
 
-a) "GetCapabilities" 
+a) "GetCapabilities"
     - use the method wps.getcapabilities(xml=None)
     - the optional keyword argument "xml" may be used to avoid a real live request, and instead read the WPS capabilities document from a cached XML file
-    
+
 b) "DescribeProcess"
     - use the method wps.describeprocess(identifier, xml=None)
     - identifier is the process identifier, retrieved from the list obtained from a previous "GetCapabilities" invocation
     - the optional keyword argument "xml" may be used to avoid a real live request, and instead read the WPS process description document from a cached XML file
-    
+
 c) "Execute"
-    - use the method wps.execute(identifier, inputs, output=None, request=None, response=None), 
-      which submits the job to the remote WPS server and returns a WPSExecution object that can be used to periodically check the job status until completion 
+    - use the method wps.execute(identifier, inputs, output=None, request=None, response=None),
+      which submits the job to the remote WPS server and returns a WPSExecution object that can be used to periodically check the job status until completion
       (or error)
-    
-    - the optional keyword argument "request" may be used to avoid re-building the request XML from input arguments, and instead submit a request from a 
+
+    - the optional keyword argument "request" may be used to avoid re-building the request XML from input arguments, and instead submit a request from a
       pre-made XML file
-    
+
     - alternatively, an "Execute" request can be built from input arguments by supplying the "identifier", "inputs" and "output" arguments to the execute() method.
         - "identifier" is the mandatory process identifier
         - "inputs" is a dictionary of (key,value) pairs where:
@@ -48,31 +48,31 @@ c) "Execute"
                   - "WFSFeatureCollection" can be used in conjunction with "WFSQuery" to define a FEATURE_COLLECTION retrieved from a live WFS server.
                   - "GMLMultiPolygonFeatureCollection" can be used to define one or more polygons of (latitude, longitude) points.
           - "output" is an optional output identifier to be included in the ResponseForm section of the request.
-          
+
     - the optional keyword argument "response" mey be used to avoid submitting a real live request, and instead reading the WPS execution response document
       from a cached XML file (for debugging or testing purposes)
     - the convenience module function monitorExecution() can be used to periodically check the status of a remote running job, and eventually download the output
       either to a named file, or to a file specified by the server.
-      
-      
+
+
 Examples
 --------
 
-The files examples/wps-usgs-script.py, examples/wps-pml-script-1.py and examples/wps-pml-script-2.py contain real-world usage examples 
-that submits a "GetCapabilities", "DescribeProcess" and "Execute" requests to the live USGS and PML servers. To run: 
+The files examples/wps-usgs-script.py, examples/wps-pml-script-1.py and examples/wps-pml-script-2.py contain real-world usage examples
+that submits a "GetCapabilities", "DescribeProcess" and "Execute" requests to the live USGS and PML servers. To run:
     cd examples
     python wps-usgs-script.py
     python wps-pml-script-1.py
     python wps-pml-script-2.py
-    
+
 The file wps-client.py contains a command-line client that can be used to submit a "GetCapabilities", "DescribeProcess" or "Execute"
 request to an arbitratry WPS server. For example, you can run it as follows:
     cd examples
     To prints out usage and example invocations: wps-client -help
-    To execute a (fake) WPS invocation: 
+    To execute a (fake) WPS invocation:
         wps-client.py -v -u http://cida.usgs.gov/climate/gdp/process/WebProcessingService -r GetCapabilities -x ../tests/USGSCapabilities.xml
-    
-The directory tests/ includes several doctest-style files wps_*.txt that show how to interactively submit a 
+
+The directory tests/ includes several doctest-style files wps_*.txt that show how to interactively submit a
 "GetCapabilities", "DescribeProcess" or "Execute" request, without making a live request but rather parsing the response of cached XML response documents. To run:
     cd tests
     python -m doctest wps_*.txt
@@ -87,8 +87,8 @@ Also, the directory tests/ contains several examples of well-formed "Execute" re
 from owslib.etree import etree
 from owslib.ows import DEFAULT_OWS_NAMESPACE, ServiceIdentification, ServiceProvider, OperationsMetadata
 from time import sleep
-from owslib.util import (testXMLValue, build_get_url, dump, getTypedValue, 
-                  getNamespace, xml2string, nspath, openURL, nspath_eval)
+from owslib.util import (testXMLValue, build_get_url, dump, getTypedValue,
+                         getNamespace, xml2string, nspath, openURL, nspath_eval)
 from xml.dom.minidom import parseString
 from owslib.namespaces import Namespaces
 
@@ -108,86 +108,93 @@ DRAW_SCHEMA_LOCATION = 'http://cida.usgs.gov/climate/derivative/xsd/draw.xsd'
 WPS_DEFAULT_SCHEMA_LOCATION = 'http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd'
 WPS_DEFAULT_VERSION = '1.0.0'
 
+
 def get_namespaces():
-    ns = n.get_namespaces(["ogc","wfs","wps","gml","xsi","xlink"])
-    ns[None]  = n.get_namespace("wps")
+    ns = n.get_namespaces(["ogc", "wfs", "wps", "gml", "xsi", "xlink"])
+    ns[None] = n.get_namespace("wps")
     ns["ows"] = DEFAULT_OWS_NAMESPACE
     return ns
 namespaces = get_namespaces()
 
+
 class IWebProcessingService():
+
     """
     Abstract interface for an OGC Web Processing Service (WPS).
     """
-    
+
     url = property("""URL for the remote WPS server (string).""")
-    
+
     def getcapabilities(**kw):
         """
         Makes a GetCapabilities request to the remote WPS server,
         returns an XML document wrapped in a python file-like object.
         """
-    
+
     def describeprocess(**kw):
         """
         Makes a DescribeProcess request to the remote WPS server,
         returns a Process object containing all the process metadata.
         """
-        
+
     def execute(**kw):
         """
         Submits an Execute request to the remote WPS server,
         returns a WPSExecution object, which can be used to monitor the status of the job, and ultimately retrieve the result.
         """
 
+
 class IComplexData():
+
     """
     Abstract interface representing complex input object for a WPS request.
     """
-    
+
     def getXml(self):
         """
-        Method that returns the object data as an XML snippet, 
+        Method that returns the object data as an XML snippet,
         to be inserted into the WPS request document sent to the server.
-        """ 
-    
+        """
+
+
 class WebProcessingService(object):
+
     """
     Class that contains client-side functionality for invoking an OGC Web Processing Service (WPS).
-    
+
     Implements IWebProcessingService.
     """
-    
+
     def __init__(self, url, version=WPS_DEFAULT_VERSION, username=None, password=None, verbose=False, skip_caps=False):
         """
         Initialization method resets the object status.
-        By default it will execute a GetCapabilities invocation to the remote service, 
+        By default it will execute a GetCapabilities invocation to the remote service,
         which can be skipped by using skip_caps=True.
         """
-        
+
         # fields passed in from object initializer
         self.url = url
         self.username = username
         self.password = password
         self.version = version
         self.verbose = verbose
-                
+
         # fields populated by method invocations
         self._capabilities = None
         self.identification = None
         self.provider = None
-        self.operations=[]
-        self.processes=[]
+        self.operations = []
+        self.processes = []
 
         if not skip_caps:
             self.getcapabilities()
-        
+
     def getcapabilities(self, xml=None):
         """
         Method that requests a capabilities document from the remote WPS server and populates this object's metadata.
         keyword argument xml: local XML GetCapabilities document, prevents actual HTTP invocation.
         """
-        
+
         # read capabilities document
         reader = WPSCapabilitiesReader(version=self.version, verbose=self.verbose)
         if xml:
@@ -195,19 +202,19 @@ class WebProcessingService(object):
             self._capabilities = reader.readFromString(xml)
         else:
             self._capabilities = reader.readFromUrl(self.url, username=self.username, password=self.password)
-            
-        if self.verbose==True:
+
+        if self.verbose == True:
             print xml2string(etree.tostring(self._capabilities))
 
         # populate the capabilities metadata obects from the XML tree
         self._parseCapabilitiesMetadata(self._capabilities)
-        
+
     def describeprocess(self, identifier, xml=None):
         """
         Requests a process document from a WPS service and populates the process metadata.
         Returns the process object.
         """
-        
+
         # read capabilities document
         reader = WPSDescribeProcessReader(version=self.version, verbose=self.verbose)
         if xml:
@@ -216,96 +223,94 @@ class WebProcessingService(object):
         else:
             # read from server
             rootElement = reader.readFromUrl(self.url, identifier)
-            
-        if self.verbose==True:
+
+        if self.verbose == True:
             print xml2string(etree.tostring(rootElement))
 
         # build metadata objects
         return self._parseProcessMetadata(rootElement)
-        
+
     def execute(self, identifier, inputs, output=None, request=None, response=None):
         """
-        Submits a WPS process execution request. 
+        Submits a WPS process execution request.
         Returns a WPSExecution object, which can be used to monitor the status of the job, and ultimately retrieve the result.
-        
+
         identifier: the requested process identifier
         inputs: list of process inputs as (key, value) tuples (where value is either a string for LiteralData, or an object for ComplexData)
         output: optional identifier for process output reference (if not provided, output will be embedded in the response)
         request: optional pre-built XML request document, prevents building of request from other arguments
         response: optional pre-built XML response document, prevents submission of request to live WPS server
         """
-        
+
         # instantiate a WPSExecution object
         print 'Executing WPS request...'
         execution = WPSExecution(version=self.version, url=self.url, username=self.username, password=self.password, verbose=self.verbose)
 
-        # build XML request from parameters 
+        # build XML request from parameters
         if request is None:
-           requestElement = execution.buildRequest(identifier, inputs, output)
-           request = etree.tostring( requestElement )   
-        if self.verbose==True:
-               print request
-        
+            requestElement = execution.buildRequest(identifier, inputs, output)
+            request = etree.tostring(requestElement)
+        if self.verbose == True:
+            print request
+
         # submit the request to the live server
-        if response is None:   
+        if response is None:
             response = execution.submitRequest(request)
         else:
             response = etree.fromstring(response)
-            
-        if self.verbose==True:
+
+        if self.verbose == True:
             print etree.tostring(response)
-            
+
         # parse response
         execution.parseResponse(response)
-                        
+
         return execution
-    
-        
+
     def _parseProcessMetadata(self, rootElement):
         """
         Method to parse a <ProcessDescriptions> XML element and returned the constructed Process object
         """
-        
-        processDescriptionElement = rootElement.find( 'ProcessDescription' )
+
+        processDescriptionElement = rootElement.find('ProcessDescription')
         process = Process(processDescriptionElement, verbose=self.verbose)
-    
+
         # override existing processes in object metadata, if existing already
         found = False
         for n, p in enumerate(self.processes):
-            if p.identifier==process.identifier:
-                self.processes[n]=process
+            if p.identifier == process.identifier:
+                self.processes[n] = process
                 found = True
         # otherwise add it
         if not found:
             self.processes.append(process)
-            
+
         return process
-                
-        
-    def _parseCapabilitiesMetadata(self, root):         
+
+    def _parseCapabilitiesMetadata(self, root):
         ''' Sets up capabilities metadata objects '''
-        
+
         # use the WPS namespace defined in the document root
         wpsns = getNamespace(root)
-        
+
         # loop over children WITHOUT requiring a specific namespace
         for element in root:
-            
+
             # thie element's namespace
             ns = getNamespace(element)
-            
+
             # <ows:ServiceIdentification> metadata
             if element.tag.endswith('ServiceIdentification'):
-                self.identification=ServiceIdentification(element, namespace=ns)
-                if self.verbose==True:
+                self.identification = ServiceIdentification(element, namespace=ns)
+                if self.verbose == True:
                     dump(self.identification)
-                    
+
             # <ows:ServiceProvider> metadata
             elif element.tag.endswith('ServiceProvider'):
-                self.provider=ServiceProvider(element, namespace=ns)  
-                if self.verbose==True:
+                self.provider = ServiceProvider(element, namespace=ns)
+                if self.verbose == True:
                     dump(self.provider)
-                    
+
             # <ns0:OperationsMetadata xmlns:ns0="http://www.opengeospatial.net/ows">
             #   <ns0:Operation name="GetCapabilities">
             #     <ns0:DCP>
@@ -317,11 +322,11 @@ class WebProcessingService(object):
             #  ........
             # </ns0:OperationsMetadata>
             elif element.tag.endswith('OperationsMetadata'):
-                for child in element.findall( nspath('Operation', ns=ns) ):
-                    self.operations.append( OperationsMetadata(child, namespace=ns) )
-                    if self.verbose==True:
+                for child in element.findall(nspath('Operation', ns=ns)):
+                    self.operations.append(OperationsMetadata(child, namespace=ns))
+                    if self.verbose == True:
                         dump(self.operations[-1])
-               
+
             # <wps:ProcessOfferings>
             #   <wps:Process ns0:processVersion="1.0.0">
             #     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">gov.usgs.cida.gdp.wps.algorithm.filemanagement.ReceiveFiles</ows:Identifier>
@@ -330,23 +335,23 @@ class WebProcessingService(object):
             #   ......
             # </wps:ProcessOfferings>
             elif element.tag.endswith('ProcessOfferings'):
-                for child in element.findall( nspath('Process', ns=ns) ):
+                for child in element.findall(nspath('Process', ns=ns)):
                     p = Process(child, verbose=self.verbose)
                     self.processes.append(p)
-                    if self.verbose==True:
+                    if self.verbose == True:
                         dump(self.processes[-1])
 
-                   
-        
+
 class WPSReader(object):
+
     """
     Superclass for reading a WPS document into a lxml.etree infoset.
     """
 
-    def __init__(self, version=WPS_DEFAULT_VERSION, verbose=False):        
+    def __init__(self, version=WPS_DEFAULT_VERSION, verbose=False):
         self.version = version
         self.verbose = verbose
-                
+
     def _readFromUrl(self, url, data, method='Get', username=None, password=None):
         """
         Method to get and parse a WPS document, returning an elementtree instance.
@@ -354,111 +359,117 @@ class WPSReader(object):
         data: GET: dictionary of HTTP (key, value) parameter pairs, POST: XML document to post
         username, password: optional user credentials
         """
-        
+
         if method == 'Get':
             # full HTTP request url
             request_url = build_get_url(url, data)
-            if self.verbose==True:
+            if self.verbose == True:
                 print request_url
-    
+
             # split URL into base url and query string to use utility function
-            spliturl=request_url.split('?')
+            spliturl = request_url.split('?')
             u = openURL(spliturl[0], spliturl[1], method='Get', username=username, password=password)
             return etree.fromstring(u.read())
-        
+
         elif method == 'Post':
-            u = openURL(url, data, method='Post', username = username, password = password)
+            u = openURL(url, data, method='Post', username=username, password=password)
             return etree.fromstring(u.read())
-            
+
         else:
             raise Exception("Unrecognized HTTP method: %s" % method)
-                
-        
+
     def readFromString(self, string):
         """
         Method to read a WPS GetCapabilities document from an XML string.
         """
-        
+
         if not isinstance(string, str):
             raise ValueError("Input must be of type string, not %s" % type(string))
-        return etree.fromstring(string)    
+        return etree.fromstring(string)
+
 
 class WPSCapabilitiesReader(WPSReader):
+
     """
     Utility class that reads and parses a WPS GetCapabilities document into a lxml.etree infoset.
     """
-    
+
     def __init__(self, version=WPS_DEFAULT_VERSION, verbose=False):
         # superclass initializer
-        super(WPSCapabilitiesReader,self).__init__(version=version, verbose=verbose)
-        
+        super(WPSCapabilitiesReader, self).__init__(version=version, verbose=verbose)
+
     def readFromUrl(self, url, username=None, password=None):
         """
         Method to get and parse a WPS capabilities document, returning an elementtree instance.
         url: WPS service base url, to which is appended the HTTP parameters: service, version, and request.
         username, password: optional user credentials
         """
-        return self._readFromUrl(url, 
-                                 {'service':'WPS', 'request':'GetCapabilities', 'version':self.version}, 
+        return self._readFromUrl(url,
+                                 {'service': 'WPS', 'request': 'GetCapabilities', 'version': self.version},
                                  username=username, password=password)
-            
+
+
 class WPSDescribeProcessReader(WPSReader):
+
     """
     Class that reads and parses a WPS DescribeProcess document into a etree infoset
     """
 
     def __init__(self, version=WPS_DEFAULT_VERSION, verbose=False):
         # superclass initializer
-        super(WPSDescribeProcessReader,self).__init__(version=version, verbose=verbose)
+        super(WPSDescribeProcessReader, self).__init__(version=version, verbose=verbose)
 
-                
     def readFromUrl(self, url, identifier, username=None, password=None):
         """
         Reads a WPS DescribeProcess document from a remote service and returns the XML etree object
         url: WPS service base url, to which is appended the HTTP parameters: 'service', 'version', and 'request', and 'identifier'.
         """
-        
-        return self._readFromUrl(url, 
-                                 {'service':'WPS', 'request':'DescribeProcess', 'version':self.version, 'identifier':identifier}, 
+
+        return self._readFromUrl(url,
+                                 {'service': 'WPS', 'request': 'DescribeProcess', 'version': self.version, 'identifier': identifier},
                                  username=username, password=password)
-        
+
+
 class WPSExecuteReader(WPSReader):
+
     """
     Class that reads and parses a WPS Execute response document into a etree infoset
     """
+
     def __init__(self, verbose=False):
         # superclass initializer
-        super(WPSExecuteReader,self).__init__(verbose=verbose)
-        
-    def readFromUrl(self, url, data={}, method='Get', username=None, password=None):
-         """
-         Reads a WPS status document from a remote service and returns the XML etree object.
-         url: the URL to submit the GET/POST request to.
-         """
-         
-         return self._readFromUrl(url, data, method, username=username, password=password)
+        super(WPSExecuteReader, self).__init__(verbose=verbose)
 
-    
+    def readFromUrl(self, url, data={}, method='Get', username=None, password=None):
+        """
+        Reads a WPS status document from a remote service and returns the XML etree object.
+        url: the URL to submit the GET/POST request to.
+        """
+
+        return self._readFromUrl(url, data, method, username=username, password=password)
+
+
 class WPSExecution():
+
     """
     Class that represents a single WPS process executed on a remote WPS service.
     """
-    
+
     def __init__(self, version=WPS_DEFAULT_VERSION, url=None, username=None, password=None, verbose=False):
-        
+
         # initialize fields
         self.url = url
         self.version = version
         self.username = username
         self.password = password
         self.verbose = verbose
-        
+
         # request document
         self.request = None
-        
+
         # last response document
         self.response = None
-        
+
         # status fields retrieved from the response documents
         self.process = None
         self.serviceInstance = None
@@ -467,10 +478,9 @@ class WPSExecution():
         self.statusMessage = None
         self.errors = []
         self.statusLocation = None
-        self.dataInputs=[]
-        self.processOutputs=[]
-        
-        
+        self.dataInputs = []
+        self.processOutputs = []
+
     def buildRequest(self, identifier, inputs=[], output=None):
         """
         Method to build a WPS process request.
@@ -481,32 +491,32 @@ class WPSExecution():
               and the object must contain a 'getXml()' method that returns an XML infoset to be included in the WPS request
         output: optional identifier if process output is to be returned as a hyperlink reference
         """
-        
-        #<wps:Execute xmlns:wps="http://www.opengis.net/wps/1.0.0" 
-        #             xmlns:ows="http://www.opengis.net/ows/1.1" 
-        #             xmlns:xlink="http://www.w3.org/1999/xlink" 
-        #             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-        #             service="WPS" 
-        #             version="1.0.0" 
-        #             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">       
+
+        #<wps:Execute xmlns:wps="http://www.opengis.net/wps/1.0.0"
+        #             xmlns:ows="http://www.opengis.net/ows/1.1"
+        #             xmlns:xlink="http://www.w3.org/1999/xlink"
+        #             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        #             service="WPS"
+        #             version="1.0.0"
+        #             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_request.xsd">
         root = etree.Element(nspath_eval('wps:Execute', namespaces))
         root.set('service', 'WPS')
         root.set('version', WPS_DEFAULT_VERSION)
-        root.set(nspath_eval('xsi:schemaLocation', namespaces), '%s %s' % (namespaces['wps'], WPS_DEFAULT_SCHEMA_LOCATION) )
-        
+        root.set(nspath_eval('xsi:schemaLocation', namespaces), '%s %s' % (namespaces['wps'], WPS_DEFAULT_SCHEMA_LOCATION))
+
         # <ows:Identifier>gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm</ows:Identifier>
         identifierElement = etree.SubElement(root, nspath_eval('ows:Identifier', namespaces))
         identifierElement.text = identifier
-        
+
         # <wps:DataInputs>
         dataInputsElement = etree.SubElement(root, nspath_eval('wps:DataInputs', namespaces))
-        
-        for (key,val) in inputs:
+
+        for (key, val) in inputs:
 
             inputElement = etree.SubElement(dataInputsElement, nspath_eval('wps:Input', namespaces))
             identifierElement = etree.SubElement(inputElement, nspath_eval('ows:Identifier', namespaces))
             identifierElement.text = key
-            
+
             # Literal data
             # <wps:Input>
             #   <ows:Identifier>DATASET_URI</ows:Identifier>
@@ -518,7 +528,7 @@ class WPSExecution():
                 dataElement = etree.SubElement(inputElement, nspath_eval('wps:Data', namespaces))
                 literalDataElement = etree.SubElement(dataElement, nspath_eval('wps:LiteralData', namespaces))
                 literalDataElement.text = val
-                
+
             # Complex data
             # <wps:Input>
             #   <ows:Identifier>FEATURE_COLLECTION</ows:Identifier>
@@ -537,8 +547,8 @@ class WPSExecution():
             #   </wps:Reference>
             # </wps:Input>
             else:
-                inputElement.append( val.getXml() )
-        
+                inputElement.append(val.getXml())
+
         # <wps:ResponseForm>
         #   <wps:ResponseDocument storeExecuteResponse="true" status="true">
         #     <wps:Output asReference="true">
@@ -548,34 +558,33 @@ class WPSExecution():
         # </wps:ResponseForm>
         if output is not None:
             responseFormElement = etree.SubElement(root, nspath_eval('wps:ResponseForm', namespaces))
-            responseDocumentElement = etree.SubElement(responseFormElement, nspath_eval('wps:ResponseDocument', namespaces), 
-                                                       attrib={'storeExecuteResponse':'true', 'status':'true'} )
+            responseDocumentElement = etree.SubElement(responseFormElement, nspath_eval('wps:ResponseDocument', namespaces),
+                                                       attrib={'storeExecuteResponse': 'true', 'status': 'true'})
             if isinstance(output, str):
                 self._add_output(responseDocumentElement, output, asReference=True)
             elif isinstance(output, list):
-                for (identifier,as_reference) in output:
+                for (identifier, as_reference) in output:
                     self._add_output(responseDocumentElement, identifier, asReference=as_reference)
             else:
                 raise Exception('output parameter is neither string nor list. output=%s' % output)
         return root
 
     def _add_output(self, element, identifier, asReference=False):
-        outputElement = etree.SubElement(element, nspath_eval('wps:Output', namespaces), 
-                                                       attrib={'asReference':str(asReference).lower()} )
+        outputElement = etree.SubElement(element, nspath_eval('wps:Output', namespaces),
+                                         attrib={'asReference': str(asReference).lower()})
         outputIdentifierElement = etree.SubElement(outputElement, nspath_eval('ows:Identifier', namespaces)).text = identifier
-                  
-                
+
     # wait for 60 seconds by default
     def checkStatus(self, url=None, response=None, sleepSecs=60):
         """
         Method to check the status of a job execution.
         In the process, this method will upadte the object 'response' attribute.
-        
+
         url: optional 'statusLocation' URL retrieved from a previous WPS Execute response document.
              If not provided, the current 'statusLocation' URL will be used.
         sleepSecs: number of seconds to sleep before returning control to the caller.
         """
-                    
+
         reader = WPSExecuteReader(verbose=self.verbose)
         if response is None:
             # override status location
@@ -585,123 +594,122 @@ class WPSExecution():
             response = reader.readFromUrl(self.statusLocation, username=self.username, password=self.password)
         else:
             response = reader.readFromString(response)
-                
+
         # store latest response
         self.response = etree.tostring(response)
-        if self.verbose==True:
+        if self.verbose == True:
             print self.response
 
         self.parseResponse(response)
-                    
+
         # sleep given number of seconds
-        if self.isComplete()==False:
+        if self.isComplete() == False:
             print 'Sleeping %d seconds...' % sleepSecs
             sleep(sleepSecs)
 
-        
     def getStatus(self):
         return self.status
-        
+
     def isComplete(self):
-        if (self.status=='ProcessSucceeded' or self.status=='ProcessFailed' or self.status=='Exception'):
+        if (self.status == 'ProcessSucceeded' or self.status == 'ProcessFailed' or self.status == 'Exception'):
             return True
-        elif (self.status=='ProcessStarted'):
+        elif (self.status == 'ProcessStarted'):
             return False
-        elif (self.status=='ProcessAccepted' or self.status=='ProcessPaused'):
+        elif (self.status == 'ProcessAccepted' or self.status == 'ProcessPaused'):
             return False
         else:
             raise Exception('Unknown process execution status: %s' % self.status)
-        
+
     def isSucceded(self):
-         if self.status=='ProcessSucceeded':
-             return True
-         else:
-             return False
-        
+        if self.status == 'ProcessSucceeded':
+            return True
+        else:
+            return False
+
     def isNotComplete(self):
         return not self.isComplete()
-        
+
     def getOutput(self, filepath=None):
         """
-        Method to write the outputs of a WPS process to a file: 
+        Method to write the outputs of a WPS process to a file:
         either retrieves the referenced files from the server, or writes out the content of response embedded output.
-        
-        filepath: optional path to the output file, otherwise a file will be created in the local directory with the name assigned by the server, 
+
+        filepath: optional path to the output file, otherwise a file will be created in the local directory with the name assigned by the server,
                   or default name 'wps.out' for embedded output.
         """
-        
+
         if self.isSucceded():
             content = ''
             for output in self.processOutputs:
-                
+
                 output_content = output.retrieveData(self.username, self.password)
-                
+
                 # ExecuteResponse contains reference to server-side output
                 if output_content is not "":
                     content = content + output_content
                     if filepath is None:
                         filepath = output.fileName
-                    
-                # ExecuteResponse contain embedded output   
-                if len(output.data)>0:
+
+                # ExecuteResponse contain embedded output
+                if len(output.data) > 0:
                     if filepath is None:
                         filepath = 'wps.out'
                     for data in output.data:
                         content = content + data
-                    
+
             # write out content
             if content is not '':
                 out = open(filepath, 'wb')
                 out.write(content)
                 out.close()
-                print 'Output written to file: %s' %filepath
-            
+                print 'Output written to file: %s' % filepath
+
         else:
             raise Exception("Execution not successfully completed: status=%s" % self.status)
-    
+
     def submitRequest(self, request):
         """
         Submits a WPS Execute document to a remote service, returns the XML response document from the server.
         This method will save the request document and the first returned response document.
-        
+
         request: the XML request document to be submitted as POST to the server.
-        """ 
-        
+        """
+
         self.request = request
         reader = WPSExecuteReader(verbose=self.verbose)
         response = reader.readFromUrl(self.url, request, method='Post', username=self.username, password=self.password)
         self.response = response
         return response
- 
-        '''       
+
+        '''
         if response is None:
             # override status location
             if url is not None:
                 self.statusLocation = url
-            
+
         else:
             response = reader.readFromString(response)
 
-        
+
         '''
-    
+
     def parseResponse(self, response):
         """
         Method to parse a WPS response document
         """
-    
+
         rootTag = response.tag.split('}')[1]
         # <ns0:ExecuteResponse>
         if rootTag == 'ExecuteResponse':
             self._parseExecuteResponse(response)
-                    
+
         # <ows:ExceptionReport>
         elif rootTag == 'ExceptionReport':
             self._parseExceptionReport(response)
-            
+
         else:
             print 'Unknown Response'
-            
+
         # print status, errors
         print 'Execution status=%s' % self.status
         print 'Percent completed=%s' % self.percentCompleted
@@ -709,7 +717,6 @@ class WPSExecution():
         for error in self.errors:
             dump(error)
 
-            
     def _parseExceptionReport(self, root):
         """
         Method to parse a WPS ExceptionReport document and populate this object's metadata.
@@ -717,22 +724,21 @@ class WPSExecution():
         # set exception status, unless set already
         if self.status is None:
             self.status = "Exception"
-            
-        for exceptionEl in root.findall( nspath('Exception', ns=namespaces['ows']) ):
-            self.errors.append( WPSException(exceptionEl) )
 
+        for exceptionEl in root.findall(nspath('Exception', ns=namespaces['ows'])):
+            self.errors.append(WPSException(exceptionEl))
 
-    def _parseExecuteResponse(self, root):      
+    def _parseExecuteResponse(self, root):
         """
         Method to parse a WPS ExecuteResponse response document and populate this object's metadata.
         """
-        
+
         # retrieve WPS namespace directly from root element
         wpsns = getNamespace(root)
 
-        self.serviceInstance = root.get( 'serviceInstance' )
-        self.statusLocation = root.get( 'statusLocation' )
-        
+        self.serviceInstance = root.get('serviceInstance')
+        self.statusLocation = root.get('statusLocation')
+
         # <ns0:Status creationTime="2011-11-09T14:19:50Z">
         #  <ns0:ProcessSucceeded>PyWPS Process v.net.path successfully calculated</ns0:ProcessSucceeded>
         # </ns0:Status>
@@ -746,7 +752,7 @@ class WPSExecution():
         #   </ows:ExceptionReport>
         #  </ns0:ProcessFailed>
         # </ns0:Status>
-        statusEl = root.find( nspath('Status/*', ns=wpsns) )
+        statusEl = root.find(nspath('Status/*', ns=wpsns))
         self.status = statusEl.tag.split('}')[1]
         # get progress info
         try:
@@ -762,78 +768,82 @@ class WPSExecution():
                 self._parseExceptionReport(element)
 
         self.process = Process(root.find(nspath('Process', ns=wpsns)), verbose=self.verbose)
-        
+
         #<wps:DataInputs xmlns:wps="http://www.opengis.net/wps/1.0.0"
         #                xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
-        for inputElement in root.findall( nspath('DataInputs/Input', ns=wpsns) ):
-            self.dataInputs.append( Input(inputElement) )
-            if self.verbose==True:
+        for inputElement in root.findall(nspath('DataInputs/Input', ns=wpsns)):
+            self.dataInputs.append(Input(inputElement))
+            if self.verbose == True:
                 dump(self.dataInputs[-1])
-        
+
         # <ns:ProcessOutputs>
-        # xmlns:ns="http://www.opengis.net/wps/1.0.0" 
-        for outputElement in root.findall( nspath('ProcessOutputs/Output', ns=wpsns)  ):
-            self.processOutputs.append( Output(outputElement) )
-            if self.verbose==True:
+        # xmlns:ns="http://www.opengis.net/wps/1.0.0"
+        for outputElement in root.findall(nspath('ProcessOutputs/Output', ns=wpsns)):
+            self.processOutputs.append(Output(outputElement))
+            if self.verbose == True:
                 dump(self.processOutputs[-1])
-            
+
+
 class ComplexData(object):
+
     """
     Class that represents a ComplexData element in a WPS document
     """
-    
+
     def __init__(self, mimeType=None, encoding=None, schema=None):
         self.mimeType = mimeType
         self.encoding = encoding
         self.schema = schema
 
+
 class InputOutput(object):
+
     """
     Superclass of a WPS input or output data object.
     """
-    
+
     def __init__(self, element):
-                
+
         # loop over sub-elements without requiring a specific namespace
         for subElement in element:
-            
+
             # <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">SUMMARIZE_TIMESTEP</ows:Identifier>
             if subElement.tag.endswith('Identifier'):
-                self.identifier = testXMLValue( subElement )
+                self.identifier = testXMLValue(subElement)
 
             # <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">Summarize Timestep</ows:Title>
             elif subElement.tag.endswith('Title'):
-                self.title = testXMLValue( subElement )
-        
+                self.title = testXMLValue(subElement)
+
             # <ows:Abstract xmlns:ows="http://www.opengis.net/ows/1.1">If selected, processing output will include columns with summarized statistics for all feature attribute values for each timestep</ows:Abstract>
             elif subElement.tag.endswith('Abstract'):
-                self.abstract = testXMLValue( subElement )
-                
+                self.abstract = testXMLValue(subElement)
+
         self.allowedValues = []
         self.supportedValues = []
         self.defaultValue = None
         self.dataType = None
-        
+
     def _parseData(self, element):
         """
         Method to parse a "Data" element
         """
-        
+
         # <ns0:Data>
         #        <ns0:ComplexData mimeType="text/plain">
-        #             7504912.93758151 -764109.175074507,7750849.82379226 -22141.8611641468,8561828.42371234 -897195.923493867,7724946.16844165 -602984.014261927 
+        #             7504912.93758151 -764109.175074507,7750849.82379226 -22141.8611641468,8561828.42371234 -897195.923493867,7724946.16844165 -602984.014261927
         #        </ns0:ComplexData>
         # </ns0:Data>
         #nspath('Data', ns=WPS_NAMESPACE)
-        complexDataElement = element.find( nspath('ComplexData', ns=getNamespace(element)) )
+        complexDataElement = element.find(nspath('ComplexData', ns=getNamespace(element)))
         if complexDataElement is not None:
             self.dataType = "ComplexData"
-        
+
     def _parseLiteralData(self, element, literalElementName):
         """
         Method to parse the LiteralData element.
         """
-        
+
         # <LiteralData>
         #    <ows:DataType ows:reference="xs:string" xmlns:ows="http://www.opengis.net/ows/1.1" />
         #    <ows:AllowedValues xmlns:ows="http://www.opengis.net/ows/1.1">
@@ -843,32 +853,31 @@ class InputOutput(object):
         #    </ows:AllowedValues>
         #    <DefaultValue>COMMA</DefaultValue>
         # </LiteralData>
-        
+
         # <LiteralData>
         #     <ows:DataType ows:reference="xs:anyURI" xmlns:ows="http://www.opengis.net/ows/1.1" />
         #     <ows:AnyValue xmlns:ows="http://www.opengis.net/ows/1.1" />
         # </LiteralData>
-        literalDataElement = element.find( literalElementName )
+        literalDataElement = element.find(literalElementName)
         if literalDataElement is not None:
             self.dataType = 'LiteralData'
             for subElement in literalDataElement:
                 subns = getNamespace(subElement)
                 if subElement.tag.endswith('DataType'):
-                    self.dataType = subElement.get( nspath("reference", ns=subns) ).split(':')[1]
+                    self.dataType = subElement.get(nspath("reference", ns=subns)).split(':')[1]
                 elif subElement.tag.endswith('AllowedValues'):
-                    for value in subElement.findall( nspath('Value', ns=subns) ):
-                        self.allowedValues.append( getTypedValue(self.dataType, value.text) )
+                    for value in subElement.findall(nspath('Value', ns=subns)):
+                        self.allowedValues.append(getTypedValue(self.dataType, value.text))
                 elif subElement.tag.endswith('DefaultValue'):
                     self.defaultValue = getTypedValue(self.dataType, subElement.text)
                 elif subElement.tag.endswith('AnyValue'):
-                    self.allowedValues.append( getTypedValue(self.dataType, 'AnyValue') )
-                    
+                    self.allowedValues.append(getTypedValue(self.dataType, 'AnyValue'))
 
     def _parseComplexData(self, element, complexDataElementName):
         """
         Method to parse a ComplexData or ComplexOutput element.
         """
-        
+
         # <ComplexData>
         #     <Default>
         #         <Format>
@@ -898,100 +907,102 @@ class InputOutput(object):
         #         <Schema>NONE</Schema>
         #     </SupportedComplexData>
         # </ComplexOutput>
-        
-        complexDataElement = element.find( complexDataElementName )
+
+        complexDataElement = element.find(complexDataElementName)
         if complexDataElement is not None:
             self.dataType = "ComplexData"
-            
-            for supportedComlexDataElement in complexDataElement.findall( 'SupportedComplexData' ):
-                self.supportedValues.append( ComplexData( mimeType=testXMLValue( supportedComlexDataElement.find( 'Format' ) ),
-                                                          encoding=testXMLValue( supportedComlexDataElement.find( 'Encoding' ) ),
-                                                          schema=testXMLValue( supportedComlexDataElement.find( 'Schema' ) ) 
-                                                         ) 
-                )
-                
-            for formatElement in complexDataElement.findall( 'Supported/Format'):
-                self.supportedValues.append( ComplexData( mimeType=testXMLValue( formatElement.find( 'MimeType' ) ),
-                                                          encoding=testXMLValue( formatElement.find( 'Encoding' ) ),
-                                                          schema=testXMLValue( formatElement.find( 'Schema' ) ) 
-                                                         ) 
-                )
-               
-            defaultFormatElement = complexDataElement.find( 'Default/Format' ) 
+
+            for supportedComlexDataElement in complexDataElement.findall('SupportedComplexData'):
+                self.supportedValues.append(ComplexData(mimeType=testXMLValue(supportedComlexDataElement.find('Format')),
+                                                        encoding=testXMLValue(supportedComlexDataElement.find('Encoding')),
+                                                        schema=testXMLValue(supportedComlexDataElement.find('Schema'))
+                                                        )
+                                            )
+
+            for formatElement in complexDataElement.findall('Supported/Format'):
+                self.supportedValues.append(ComplexData(mimeType=testXMLValue(formatElement.find('MimeType')),
+                                                        encoding=testXMLValue(formatElement.find('Encoding')),
+                                                        schema=testXMLValue(formatElement.find('Schema'))
+                                                        )
+                                            )
+
+            defaultFormatElement = complexDataElement.find('Default/Format')
             if defaultFormatElement is not None:
-                self.defaultValue = ComplexData( mimeType=testXMLValue( defaultFormatElement.find( 'MimeType' ) ),
-                                                 encoding=testXMLValue( defaultFormatElement.find( 'Encoding' ) ),
-                                                 schema=testXMLValue( defaultFormatElement.find( 'Schema' ) ) 
-                                               ) 
+                self.defaultValue = ComplexData(mimeType=testXMLValue(defaultFormatElement.find('MimeType')),
+                                                encoding=testXMLValue(defaultFormatElement.find('Encoding')),
+                                                schema=testXMLValue(defaultFormatElement.find('Schema'))
+                                                )
 
 
 class Input(InputOutput):
+
     """
     Class that represents a WPS process input.
     """
-    
+
     def __init__(self, inputElement):
-        
+
         # superclass initializer
-        super(Input,self).__init__(inputElement)
-        
+        super(Input, self).__init__(inputElement)
+
         # <Input maxOccurs="1" minOccurs="0">
         # OR
         # <MinimumOccurs>1</MinimumOccurs>
         self.minOccurs = -1
         if inputElement.get("minOccurs") is not None:
-            self.minOccurs = int( inputElement.get("minOccurs") )
+            self.minOccurs = int(inputElement.get("minOccurs"))
         if inputElement.find('MinimumOccurs') is not None:
-            self.minOccurs = int( testXMLValue( inputElement.find('MinimumOccurs') ) )  
+            self.minOccurs = int(testXMLValue(inputElement.find('MinimumOccurs')))
         self.maxOccurs = -1
         if inputElement.get("maxOccurs") is not None:
-            self.maxOccurs = int( inputElement.get("maxOccurs") )
+            self.maxOccurs = int(inputElement.get("maxOccurs"))
         if inputElement.find('MaximumOccurs') is not None:
-            self.maxOccurs = int( testXMLValue( inputElement.find('MaximumOccurs') ) )       
-        
+            self.maxOccurs = int(testXMLValue(inputElement.find('MaximumOccurs')))
+
         # <LiteralData>
         self._parseLiteralData(inputElement, 'LiteralData')
-                
+
         # <ComplexData>
         self._parseComplexData(inputElement, 'ComplexData')
-                
-    
+
+
 class Output(InputOutput):
+
     """
     Class that represents a WPS process output.
     """
-    
+
     def __init__(self, outputElement):
-    
+
         # superclass initializer
-        super(Output,self).__init__(outputElement)
-        
+        super(Output, self).__init__(outputElement)
+
         self.reference = None
         self.mimeType = None
         self.data = []
         self.fileName = None
         self.filePath = None
-        
+
         # extract wps namespace from outputElement itself
         wpsns = getNamespace(outputElement)
-        
+
         # <ns:Reference encoding="UTF-8" mimeType="text/csv"
         #     href="http://cida.usgs.gov/climate/gdp/process/RetrieveResultServlet?id=1318528582026OUTPUT.601bb3d0-547f-4eab-8642-7c7d2834459e" />
-        referenceElement = outputElement.find( nspath('Reference', ns=wpsns) )
+        referenceElement = outputElement.find(nspath('Reference', ns=wpsns))
         if referenceElement is not None:
             self.reference = referenceElement.get('href')
             self.mimeType = referenceElement.get('mimeType')
-       
+
         # <LiteralOutput>
         self._parseLiteralData(outputElement, 'LiteralOutput')
-        
+
         # <ComplexData> or <ComplexOutput>
         self._parseComplexData(outputElement, 'ComplexOutput')
-        
-        # <Data>   
+
+        # <Data>
         # <ns0:Data>
         #        <ns0:ComplexData mimeType="text/plain">
-        #             7504912.93758151 -764109.175074507,7750849.82379226 -22141.8611641468,8561828.42371234 -897195.923493867,7724946.16844165 -602984.014261927 
+        #             7504912.93758151 -764109.175074507,7750849.82379226 -22141.8611641468,8561828.42371234 -897195.923493867,7724946.16844165 -602984.014261927
         #        </ns0:ComplexData>
         # </ns0:Data>
         # OR:
@@ -1003,7 +1014,7 @@ class Output(InputOutput):
         #                     <gml:coord><gml:X>-960123.1421801626</gml:X><gml:Y>4665723.56559387</gml:Y></gml:coord>
         #                     <gml:coord><gml:X>-101288.6510608822</gml:X><gml:Y>5108200.011823481</gml:Y></gml:coord>
         #                 </gml:Box>
-        #            </gml:boundedBy>                         
+        #            </gml:boundedBy>
         #            <gml:featureMember xmlns:gml="http://www.opengis.net/gml">
         #                <ns3:output fid="F0">
         #                    <ns3:geometryProperty><gml:LineString><gml:coordinates>-960123.142180162365548,4665723.565593870356679,0 -960123.142180162365548,4665723.565593870356679,0 -960123.142180162598379,4665723.565593870356679,0 -960123.142180162598379,4665723.565593870356679,0 -711230.141176006174646,4710278.48552671354264,0 -711230.141176006174646,4710278.48552671354264,0 -623656.677859728806652,4848552.374973464757204,0 -623656.677859728806652,4848552.374973464757204,0 -410100.337491964863148,4923834.82589447684586,0 -410100.337491964863148,4923834.82589447684586,0 -101288.651060882242746,5108200.011823480948806,0 -101288.651060882242746,5108200.011823480948806,0 -101288.651060882257298,5108200.011823480948806,0 -101288.651060882257298,5108200.011823480948806,0</gml:coordinates></gml:LineString></ns3:geometryProperty>
@@ -1020,69 +1031,68 @@ class Output(InputOutput):
         #        </ns3:FeatureCollection>
         #     </ns0:ComplexData>
         # </ns0:Data>
-        dataElement = outputElement.find( nspath('Data', ns=wpsns) )    
+        dataElement = outputElement.find(nspath('Data', ns=wpsns))
         if dataElement is not None:
-            complexDataElement = dataElement.find( nspath('ComplexData', ns=wpsns) )
+            complexDataElement = dataElement.find(nspath('ComplexData', ns=wpsns))
             if complexDataElement is not None:
                 self.dataType = "ComplexData"
                 self.mimeType = complexDataElement.get('mimeType')
-                #print etree.tostring(complexDataElement)
+                # print etree.tostring(complexDataElement)
                 if complexDataElement.text is not None and complexDataElement.text.strip() is not '':
                     self.data.append(complexDataElement.text.strip())
                 for child in complexDataElement:
                     self.data.append(etree.tostring(child))
-            literalDataElement = dataElement.find( nspath('LiteralData', ns=wpsns) )
+            literalDataElement = dataElement.find(nspath('LiteralData', ns=wpsns))
             if literalDataElement is not None:
                 self.dataType = literalDataElement.get('dataType')
                 if literalDataElement.text is not None and literalDataElement.text.strip() is not '':
                     self.data.append(literalDataElement.text.strip())
-                    
+
     def retrieveData(self, username=None, password=None):
         """
-        Method to retrieve data from server-side reference: 
+        Method to retrieve data from server-side reference:
         returns "" if the reference is not known.
-        
-        username, password: credentials to access the remote WPS server 
+
+        username, password: credentials to access the remote WPS server
         """
-        
+
         url = self.reference
-        if url is None: 
+        if url is None:
             return ""
-        
+
         # a) 'http://cida.usgs.gov/climate/gdp/process/RetrieveResultServlet?id=1318528582026OUTPUT.601bb3d0-547f-4eab-8642-7c7d2834459e'
         # b) 'http://rsg.pml.ac.uk/wps/wpsoutputs/outputImage-11294Bd6l2a.tif'
         print 'Output URL=%s' % url
         if '?' in url:
-            spliturl=url.split('?')
-            u = openURL(spliturl[0], spliturl[1], method='Get', username = username, password = password)
+            spliturl = url.split('?')
+            u = openURL(spliturl[0], spliturl[1], method='Get', username=username, password=password)
             # extract output filepath from URL query string
             self.fileName = spliturl[1].split('=')[1]
         else:
-            u = openURL(url, '', method='Get', username = username, password = password)
+            u = openURL(url, '', method='Get', username=username, password=password)
             # extract output filepath from base URL
             self.fileName = url.split('/')[-1]
-                
-        return u.read()      
 
-                    
+        return u.read()
+
     def writeToDisk(self, path=None, username=None, password=None):
         """
-        Method to write an output of a WPS process to disk: 
+        Method to write an output of a WPS process to disk:
         it either retrieves the referenced file from the server, or write out the content of response embedded output.
-        
+
         filepath: optional path to the output file, otherwise a file will be created in the local directory with the name assigned by the server,
         username, password: credentials to access the remote WPS server
-        """ 
-        
-        # Check if ExecuteResponse contains reference to server-side output    
+        """
+
+        # Check if ExecuteResponse contains reference to server-side output
         content = self.retrieveData(username, password)
-         
-        # ExecuteResponse contain embedded output   
-        if content is "" and len(self.data)>0:
+
+        # ExecuteResponse contain embedded output
+        if content is "" and len(self.data) > 0:
             self.fileName = self.identifier
             for data in self.data:
                 content = content + data
-                    
+
         # write out content
         if content is not "":
             if self.fileName == "":
@@ -1091,102 +1101,108 @@ class Output(InputOutput):
             out = open(self.filePath, 'wb')
             out.write(content)
             out.close()
-            print 'Output written to file: %s' %self.filePath
-                
-                    
+            print 'Output written to file: %s' % self.filePath
+
+
 class WPSException:
+
     """
     Class representing an exception raised by a WPS.
     """
-    
+
     def __init__(self, root):
         self.code = root.attrib.get("exceptionCode", None)
         self.locator = root.attrib.get("locator", None)
-        textEl = root.find( nspath('ExceptionText', ns=getNamespace(root)) )
+        textEl = root.find(nspath('ExceptionText', ns=getNamespace(root)))
         if textEl is not None:
             self.text = textEl.text
         else:
             self.text = ""
 
+
 class Process(object):
+
     """
     Class that represents a WPS process.
     """
-    
+
     def __init__(self, elem, verbose=False):
         """ Initialization method extracts all available metadata from an XML document (passed in as etree object) """
-        
-        # <ns0:ProcessDescriptions service="WPS" version="1.0.0" 
-        #                          xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd" 
+
+        # <ns0:ProcessDescriptions service="WPS" version="1.0.0"
+        #                          xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd"
         #                          xml:lang="en-US" xmlns:ns0="http://www.opengis.net/wps/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         # OR:
         # <ns0:Process ns0:processVersion="1.0.0">
         self._root = elem
         self.verbose = verbose
-        
+
         wpsns = getNamespace(elem)
-        
+
         # <ProcessDescription statusSupported="true" storeSupported="true" ns0:processVersion="1.0.0">
-        self.processVersion = elem.get( nspath('processVersion', ns=wpsns) )
-        self.statusSupported = bool( elem.get( "statusSupported" ) )
-        self.storeSupported = bool( elem.get( "storeSupported" ) )
-        
+        self.processVersion = elem.get(nspath('processVersion', ns=wpsns))
+        self.statusSupported = bool(elem.get("statusSupported"))
+        self.storeSupported = bool(elem.get("storeSupported"))
+
         for child in elem:
-            
+
             # this element's namespace
             ns = getNamespace(child)
-            
+
             # <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm</ows:Identifier>
             if child.tag.endswith('Identifier'):
-                self.identifier = testXMLValue( child )
-        
+                self.identifier = testXMLValue(child)
+
             # <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">Feature Weighted Grid Statistics</ows:Title>
             elif child.tag.endswith('Title'):
-                self.title =  testXMLValue( child )
-        
+                self.title = testXMLValue(child)
+
             # <ows:Abstract xmlns:ows="http://www.opengis.net/ows/1.1">This algorithm generates area weighted statistics of a gridded dataset for a set of vector polygon features. Using the bounding-box that encloses the feature data and the time range, if provided, a subset of the gridded dataset is requested from the remote gridded data server. Polygon representations are generated for cells in the retrieved grid. The polygon grid-cell representations are then projected to the feature data coordinate reference system. The grid-cells are used to calculate per grid-cell feature coverage fractions. Area-weighted statistics are then calculated for each feature using the grid values and fractions as weights. If the gridded dataset has a time range the last step is repeated for each time step within the time range or all time steps if a time range was not supplied.</ows:Abstract>
             elif child.tag.endswith('Abstract'):
-                self.abstract = testXMLValue( child )
-        
-        if self.verbose==True:
+                self.abstract = testXMLValue(child)
+
+        if self.verbose == True:
             dump(self)
-        
+
         # <DataInputs>
         self.dataInputs = []
-        for inputElement in elem.findall( 'DataInputs/Input' ):
-            self.dataInputs.append( Input(inputElement) )
-            if self.verbose==True:
+        for inputElement in elem.findall('DataInputs/Input'):
+            self.dataInputs.append(Input(inputElement))
+            if self.verbose == True:
                 dump(self.dataInputs[-1], prefix='\tInput: ')
-        
+
         # <ProcessOutputs>
         self.processOutputs = []
-        for outputElement in elem.findall( 'ProcessOutputs/Output' ):
-            self.processOutputs.append( Output(outputElement) )
-            if self.verbose==True:
-                dump(self.processOutputs[-1],  prefix='\tOutput: ')
-     
-    
+        for outputElement in elem.findall('ProcessOutputs/Output'):
+            self.processOutputs.append(Output(outputElement))
+            if self.verbose == True:
+                dump(self.processOutputs[-1], prefix='\tOutput: ')
+
+
 class FeatureCollection():
+
     '''
     Base class to represent a Feature Collection used as input to a WPS request.
     The method getXml() is invoked by the WPS execute() method to build the WPS request.
     All subclasses must implement the getXml() method to provide their specific XML.
-    
+
     Implements IComplexData.
     '''
-    
+
     def __init__(self):
         pass
-    
+
     def getXml(self):
         raise NotImplementedError
-    
+
+
 class WFSFeatureCollection(FeatureCollection):
+
     '''
     FeatureCollection specified by a WFS query.
     All subclasses must implement the getQuery() method to provide the specific query portion of the XML.
     '''
-    
+
     def __init__(self, wfsUrl, wfsQuery):
         '''
         wfsUrl: the WFS service URL
@@ -1195,7 +1211,7 @@ class WFSFeatureCollection(FeatureCollection):
         '''
         self.url = wfsUrl
         self.query = wfsQuery
-    
+
     #    <wps:Reference xlink:href="http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs">
     #      <wps:Body>
     #        <wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" service="WFS" version="1.1.0" outputFormat="text/xml; subtype=gml/3.1.1" xsi:schemaLocation="http://www.opengis.net/wfs ../wfs/1.1.0/WFS.xsd">
@@ -1204,15 +1220,15 @@ class WFSFeatureCollection(FeatureCollection):
     #      </wps:Body>
     #   </wps:Reference>
     def getXml(self):
-        
-        root = etree.Element(nspath_eval('wps:Reference', namespaces), attrib = { nspath_eval("xlink:href",namespaces) : self.url} )
+
+        root = etree.Element(nspath_eval('wps:Reference', namespaces), attrib={nspath_eval("xlink:href", namespaces): self.url})
         bodyElement = etree.SubElement(root, nspath_eval('wps:Body', namespaces))
         getFeatureElement = etree.SubElement(bodyElement, nspath_eval('wfs:GetFeature', namespaces),
-                                             attrib = { "service":"WFS",
-                                                        "version":"1.1.0",
-                                                        "outputFormat":"text/xml; subtype=gml/3.1.1",
-                                                        nspath_eval("xsi:schemaLocation",namespaces):"%s %s" % (namespaces['wfs'], '../wfs/1.1.0/WFS.xsd')})
-        
+                                             attrib={"service": "WFS",
+                                                     "version": "1.1.0",
+                                                     "outputFormat": "text/xml; subtype=gml/3.1.1",
+                                                     nspath_eval("xsi:schemaLocation", namespaces): "%s %s" % (namespaces['wfs'], '../wfs/1.1.0/WFS.xsd')})
+
         #            <wfs:Query typeName="sample:CONUS_States">
         #                <wfs:PropertyName>the_geom</wfs:PropertyName>
         #                <wfs:PropertyName>STATE</wfs:PropertyName>
@@ -1220,24 +1236,26 @@ class WFSFeatureCollection(FeatureCollection):
         #                    <ogc:GmlObjectId gml:id="CONUS_States.508"/>
         #                </ogc:Filter>
         #            </wfs:Query>
-        getFeatureElement.append( self.query.getXml() )
-        
+        getFeatureElement.append(self.query.getXml())
+
         return root
-    
+
+
 class WFSQuery():
+
     '''
     Class representing a WFS query, for insertion into a WFSFeatureCollection instance.
-    
+
     Implements IComplexData.
     '''
-    
+
     def __init__(self, typeName, propertyNames=[], filters=[]):
         self.typeName = typeName
         self.propertyNames = propertyNames
         self.filters = filters
-        
+
     def getXml(self):
-        
+
         #            <wfs:Query typeName="sample:CONUS_States">
         #                <wfs:PropertyName>the_geom</wfs:PropertyName>
         #                <wfs:PropertyName>STATE</wfs:PropertyName>
@@ -1245,23 +1263,25 @@ class WFSQuery():
         #                    <ogc:GmlObjectId gml:id="CONUS_States.508"/>
         #                </ogc:Filter>
         #            </wfs:Query>
-   
-        queryElement = etree.Element(nspath_eval('wfs:Query', namespaces), attrib = { "typeName":self.typeName })
+
+        queryElement = etree.Element(nspath_eval('wfs:Query', namespaces), attrib={"typeName": self.typeName})
         for propertyName in self.propertyNames:
             propertyNameElement = etree.SubElement(queryElement, nspath_eval('wfs:PropertyName', namespaces))
             propertyNameElement.text = propertyName
-        if len(self.filters)>0:
+        if len(self.filters) > 0:
             filterElement = etree.SubElement(queryElement, nspath_eval('ogc:Filter', namespaces))
             for filter in self.filters:
-                gmlObjectIdElement = etree.SubElement(filterElement, nspath_eval('ogc:GmlObjectId', namespaces), 
-                                                      attrib={nspath_eval('gml:id', namespaces):filter})
+                gmlObjectIdElement = etree.SubElement(filterElement, nspath_eval('ogc:GmlObjectId', namespaces),
+                                                      attrib={nspath_eval('gml:id', namespaces): filter})
         return queryElement
-        
+
+
 class GMLMultiPolygonFeatureCollection(FeatureCollection):
+
     '''
     Class that represents a FeatureCollection defined as a GML multi-polygon.
     '''
-    
+
     def __init__(self, polygons):
         '''
         Initializer accepts an array of polygons, where each polygon is an array of (lat,lon) tuples.
@@ -1269,7 +1289,7 @@ class GMLMultiPolygonFeatureCollection(FeatureCollection):
                               [(-92.8184, 39.5273), (-92.8184, 37.418), (-91.2363, 37.418), (-91.2363, 39.5273), (-92.8184, 39.5273)] ]
         '''
         self.polygons = polygons
-    
+
     def getXml(self):
         '''
             <wps:Data>
@@ -1303,63 +1323,66 @@ class GMLMultiPolygonFeatureCollection(FeatureCollection):
         '''
         dataElement = etree.Element(nspath_eval('wps:Data', namespaces))
         complexDataElement = etree.SubElement(dataElement, nspath_eval('wps:ComplexData', namespaces),
-                                              attrib={"mimeType":"text/xml", "encoding":"UTF-8", "schema":GML_SCHEMA_LOCATION} )
+                                              attrib={"mimeType": "text/xml", "encoding": "UTF-8", "schema": GML_SCHEMA_LOCATION})
         featureMembersElement = etree.SubElement(complexDataElement, nspath_eval('gml:featureMembers', namespaces),
-                                                 attrib={ nspath_eval("xsi:schemaLocation",namespaces):"%s %s" % (DRAW_NAMESPACE, DRAW_SCHEMA_LOCATION)})
-        boxElement = etree.SubElement(featureMembersElement, nspath_eval('gml:box', namespaces), attrib={ nspath_eval("gml:id",namespaces):"box.1" })
+                                                 attrib={nspath_eval("xsi:schemaLocation", namespaces): "%s %s" % (DRAW_NAMESPACE, DRAW_SCHEMA_LOCATION)})
+        boxElement = etree.SubElement(featureMembersElement, nspath_eval('gml:box', namespaces), attrib={nspath_eval("gml:id", namespaces): "box.1"})
         geomElement = etree.SubElement(boxElement, nspath_eval('gml:the_geom', namespaces))
         multiPolygonElement = etree.SubElement(geomElement, nspath_eval('gml:MultiPolygon', namespaces),
-                                               attrib={"srsDimension":"2", "srsName":"http://www.opengis.net/gml/srs/epsg.xml#4326"} )
+                                               attrib={"srsDimension": "2", "srsName": "http://www.opengis.net/gml/srs/epsg.xml#4326"})
         for polygon in self.polygons:
             polygonMemberElement = etree.SubElement(multiPolygonElement, nspath_eval('gml:polygonMember', namespaces))
             polygonElement = etree.SubElement(polygonMemberElement, nspath_eval('gml:Polygon', namespaces))
             exteriorElement = etree.SubElement(polygonElement, nspath_eval('gml:exterior', namespaces))
             linearRingElement = etree.SubElement(exteriorElement, nspath_eval('gml:LinearRing', namespaces))
             posListElement = etree.SubElement(linearRingElement, nspath_eval('gml:posList', namespaces))
-            posListElement.text =  ' '.join(["%s %s" % (x, y) for x, y in polygon[:] ])
-        
+            posListElement.text = ' '.join(["%s %s" % (x, y) for x, y in polygon[:]])
+
         idElement = etree.SubElement(boxElement, nspath_eval('gml:ID', namespaces))
         idElement.text = "0"
         return dataElement
-    
+
+
 def monitorExecution(execution, sleepSecs=3, download=False, filepath=None):
     '''
     Convenience method to monitor the status of a WPS execution till it completes (succesfully or not),
     and write the output to file after a succesfull job completion.
-    
+
     execution: WPSExecution instance
     sleepSecs: number of seconds to sleep in between check status invocations
     download: True to download the output when the process terminates, False otherwise
     filepath: optional path to output file (if downloaded=True), otherwise filepath will be inferred from response document
-    
+
     '''
-    
-    while execution.isComplete()==False:
+
+    while execution.isComplete() == False:
         execution.checkStatus(sleepSecs=sleepSecs)
         print 'Execution status: %s' % execution.status
-        
+
     if execution.isSucceded():
         if download:
             execution.getOutput(filepath=filepath)
         else:
-            for output in execution.processOutputs:               
+            for output in execution.processOutputs:
                 if output.reference is not None:
                     print 'Output URL=%s' % output.reference
     else:
         for ex in execution.errors:
             print 'Error: code=%s, locator=%s, text=%s' % (ex.code, ex.locator, ex.text)
 
+
 def printValue(value):
     '''
     Utility method to format a value for printing.
     '''
-    
+
     # ComplexData type
     if isinstance(value, ComplexData):
         return "mimeType=%s, encoding=%s, schema=%s" % (value.mimeType, value.encoding, value.schema)
     # other type
     else:
         return value
+
 
 def printInputOutput(value, indent=''):
     '''
@@ -1373,11 +1396,11 @@ def printInputOutput(value, indent=''):
     for val in value.supportedValues:
         print '%s Supported Value: %s' % (indent, printValue(val))
     print '%s Default Value: %s ' % (indent, printValue(value.defaultValue))
-    
+
     # Input fields
     if isinstance(value, Input):
         print '%s minOccurs=%d, maxOccurs=%d' % (indent, value.minOccurs, value.maxOccurs)
-        
+
     # Output fields
     if isinstance(value, Output):
         print '%s reference=%s, mimeType=%s' % (indent, value.reference, value.mimeType)

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -117,7 +117,7 @@ def get_namespaces():
 namespaces = get_namespaces()
 
 
-class IWebProcessingService():
+class IWebProcessingService(object):
 
     """
     Abstract interface for an OGC Web Processing Service (WPS).
@@ -144,7 +144,7 @@ class IWebProcessingService():
         """
 
 
-class IComplexData():
+class IComplexData(object):
 
     """
     Abstract interface representing complex input object for a WPS request.
@@ -203,8 +203,8 @@ class WebProcessingService(object):
         else:
             self._capabilities = reader.readFromUrl(self.url, username=self.username, password=self.password)
 
-        if self.verbose == True:
-            print xml2string(etree.tostring(self._capabilities))
+        if self.verbose is True:
+            print(xml2string(etree.tostring(self._capabilities)))
 
         # populate the capabilities metadata obects from the XML tree
         self._parseCapabilitiesMetadata(self._capabilities)
@@ -224,8 +224,8 @@ class WebProcessingService(object):
             # read from server
             rootElement = reader.readFromUrl(self.url, identifier)
 
-        if self.verbose == True:
-            print xml2string(etree.tostring(rootElement))
+        if self.verbose is True:
+            print(xml2string(etree.tostring(rootElement)))
 
         # build metadata objects
         return self._parseProcessMetadata(rootElement)
@@ -243,15 +243,15 @@ class WebProcessingService(object):
         """
 
         # instantiate a WPSExecution object
-        print 'Executing WPS request...'
+        print('Executing WPS request...')
         execution = WPSExecution(version=self.version, url=self.url, username=self.username, password=self.password, verbose=self.verbose)
 
         # build XML request from parameters
         if request is None:
             requestElement = execution.buildRequest(identifier, inputs, output)
             request = etree.tostring(requestElement)
-        if self.verbose == True:
-            print request
+        if self.verbose is True:
+            print(request)
 
         # submit the request to the live server
         if response is None:
@@ -259,8 +259,8 @@ class WebProcessingService(object):
         else:
             response = etree.fromstring(response)
 
-        if self.verbose == True:
-            print etree.tostring(response)
+        if self.verbose is True:
+            print(etree.tostring(response))
 
         # parse response
         execution.parseResponse(response)
@@ -302,13 +302,13 @@ class WebProcessingService(object):
             # <ows:ServiceIdentification> metadata
             if element.tag.endswith('ServiceIdentification'):
                 self.identification = ServiceIdentification(element, namespace=ns)
-                if self.verbose == True:
+                if self.verbose is True:
                     dump(self.identification)
 
             # <ows:ServiceProvider> metadata
             elif element.tag.endswith('ServiceProvider'):
                 self.provider = ServiceProvider(element, namespace=ns)
-                if self.verbose == True:
+                if self.verbose is True:
                     dump(self.provider)
 
             # <ns0:OperationsMetadata xmlns:ns0="http://www.opengeospatial.net/ows">
@@ -324,7 +324,7 @@ class WebProcessingService(object):
             elif element.tag.endswith('OperationsMetadata'):
                 for child in element.findall(nspath('Operation', ns=ns)):
                     self.operations.append(OperationsMetadata(child, namespace=ns))
-                    if self.verbose == True:
+                    if self.verbose is True:
                         dump(self.operations[-1])
 
             # <wps:ProcessOfferings>
@@ -338,7 +338,7 @@ class WebProcessingService(object):
                 for child in element.findall(nspath('Process', ns=ns)):
                     p = Process(child, verbose=self.verbose)
                     self.processes.append(p)
-                    if self.verbose == True:
+                    if self.verbose is True:
                         dump(self.processes[-1])
 
 
@@ -363,8 +363,8 @@ class WPSReader(object):
         if method == 'Get':
             # full HTTP request url
             request_url = build_get_url(url, data)
-            if self.verbose == True:
-                print request_url
+            if self.verbose is True:
+                print(request_url)
 
             # split URL into base url and query string to use utility function
             spliturl = request_url.split('?')
@@ -449,7 +449,7 @@ class WPSExecuteReader(WPSReader):
         return self._readFromUrl(url, data, method, username=username, password=password)
 
 
-class WPSExecution():
+class WPSExecution(object):
 
     """
     Class that represents a single WPS process executed on a remote WPS service.
@@ -590,21 +590,21 @@ class WPSExecution():
             # override status location
             if url is not None:
                 self.statusLocation = url
-            print '\nChecking execution status... (location=%s)' % self.statusLocation
+            print('\nChecking execution status... (location=%s)' % self.statusLocation)
             response = reader.readFromUrl(self.statusLocation, username=self.username, password=self.password)
         else:
             response = reader.readFromString(response)
 
         # store latest response
         self.response = etree.tostring(response)
-        if self.verbose == True:
-            print self.response
+        if self.verbose is True:
+            print(self.response)
 
         self.parseResponse(response)
 
         # sleep given number of seconds
-        if self.isComplete() == False:
-            print 'Sleeping %d seconds...' % sleepSecs
+        if self.isComplete() is False:
+            print('Sleeping %d seconds...' % sleepSecs)
             sleep(sleepSecs)
 
     def getStatus(self):
@@ -662,7 +662,7 @@ class WPSExecution():
                 out = open(filepath, 'wb')
                 out.write(content)
                 out.close()
-                print 'Output written to file: %s' % filepath
+                print('Output written to file: %s' % filepath)
 
         else:
             raise Exception("Execution not successfully completed: status=%s" % self.status)
@@ -708,12 +708,12 @@ class WPSExecution():
             self._parseExceptionReport(response)
 
         else:
-            print 'Unknown Response'
+            print('Unknown Response')
 
         # print status, errors
-        print 'Execution status=%s' % self.status
-        print 'Percent completed=%s' % self.percentCompleted
-        print 'Status message=%s' % self.statusMessage
+        print('Execution status=%s' % self.status)
+        print('Percent completed=%s' % self.percentCompleted)
+        print('Status message=%s' % self.statusMessage)
         for error in self.errors:
             dump(error)
 
@@ -773,14 +773,14 @@ class WPSExecution():
         #                xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
         for inputElement in root.findall(nspath('DataInputs/Input', ns=wpsns)):
             self.dataInputs.append(Input(inputElement))
-            if self.verbose == True:
+            if self.verbose is True:
                 dump(self.dataInputs[-1])
 
         # <ns:ProcessOutputs>
         # xmlns:ns="http://www.opengis.net/wps/1.0.0"
         for outputElement in root.findall(nspath('ProcessOutputs/Output', ns=wpsns)):
             self.processOutputs.append(Output(outputElement))
-            if self.verbose == True:
+            if self.verbose is True:
                 dump(self.processOutputs[-1])
 
 
@@ -913,25 +913,26 @@ class InputOutput(object):
             self.dataType = "ComplexData"
 
             for supportedComlexDataElement in complexDataElement.findall('SupportedComplexData'):
-                self.supportedValues.append(ComplexData(mimeType=testXMLValue(supportedComlexDataElement.find('Format')),
-                                                        encoding=testXMLValue(supportedComlexDataElement.find('Encoding')),
-                                                        schema=testXMLValue(supportedComlexDataElement.find('Schema'))
-                                                        )
-                                            )
+                self.supportedValues.append(ComplexData(
+                    mimeType=testXMLValue(supportedComlexDataElement.find('Format')),
+                    encoding=testXMLValue(supportedComlexDataElement.find('Encoding')),
+                    schema=testXMLValue(supportedComlexDataElement.find('Schema')),
+                ))
 
             for formatElement in complexDataElement.findall('Supported/Format'):
-                self.supportedValues.append(ComplexData(mimeType=testXMLValue(formatElement.find('MimeType')),
-                                                        encoding=testXMLValue(formatElement.find('Encoding')),
-                                                        schema=testXMLValue(formatElement.find('Schema'))
-                                                        )
-                                            )
+                self.supportedValues.append(ComplexData(
+                    mimeType=testXMLValue(formatElement.find('MimeType')),
+                    encoding=testXMLValue(formatElement.find('Encoding')),
+                    schema=testXMLValue(formatElement.find('Schema')),
+                ))
 
             defaultFormatElement = complexDataElement.find('Default/Format')
             if defaultFormatElement is not None:
-                self.defaultValue = ComplexData(mimeType=testXMLValue(defaultFormatElement.find('MimeType')),
-                                                encoding=testXMLValue(defaultFormatElement.find('Encoding')),
-                                                schema=testXMLValue(defaultFormatElement.find('Schema'))
-                                                )
+                self.defaultValue = ComplexData(
+                    mimeType=testXMLValue(defaultFormatElement.find('MimeType')),
+                    encoding=testXMLValue(defaultFormatElement.find('Encoding')),
+                    schema=testXMLValue(defaultFormatElement.find('Schema')),
+                )
 
 
 class Input(InputOutput):
@@ -1062,7 +1063,7 @@ class Output(InputOutput):
 
         # a) 'http://cida.usgs.gov/climate/gdp/process/RetrieveResultServlet?id=1318528582026OUTPUT.601bb3d0-547f-4eab-8642-7c7d2834459e'
         # b) 'http://rsg.pml.ac.uk/wps/wpsoutputs/outputImage-11294Bd6l2a.tif'
-        print 'Output URL=%s' % url
+        print('Output URL=%s' % url)
         if '?' in url:
             spliturl = url.split('?')
             u = openURL(spliturl[0], spliturl[1], method='Get', username=username, password=password)
@@ -1101,10 +1102,10 @@ class Output(InputOutput):
             out = open(self.filePath, 'wb')
             out.write(content)
             out.close()
-            print 'Output written to file: %s' % self.filePath
+            print('Output written to file: %s' % self.filePath)
 
 
-class WPSException:
+class WPSException(object):
 
     """
     Class representing an exception raised by a WPS.
@@ -1161,25 +1162,25 @@ class Process(object):
             elif child.tag.endswith('Abstract'):
                 self.abstract = testXMLValue(child)
 
-        if self.verbose == True:
+        if self.verbose is True:
             dump(self)
 
         # <DataInputs>
         self.dataInputs = []
         for inputElement in elem.findall('DataInputs/Input'):
             self.dataInputs.append(Input(inputElement))
-            if self.verbose == True:
+            if self.verbose is True:
                 dump(self.dataInputs[-1], prefix='\tInput: ')
 
         # <ProcessOutputs>
         self.processOutputs = []
         for outputElement in elem.findall('ProcessOutputs/Output'):
             self.processOutputs.append(Output(outputElement))
-            if self.verbose == True:
+            if self.verbose is True:
                 dump(self.processOutputs[-1], prefix='\tOutput: ')
 
 
-class FeatureCollection():
+class FeatureCollection(object):
 
     '''
     Base class to represent a Feature Collection used as input to a WPS request.
@@ -1241,7 +1242,7 @@ class WFSFeatureCollection(FeatureCollection):
         return root
 
 
-class WFSQuery():
+class WFSQuery(object):
 
     '''
     Class representing a WFS query, for insertion into a WFSFeatureCollection instance.
@@ -1355,9 +1356,9 @@ def monitorExecution(execution, sleepSecs=3, download=False, filepath=None):
 
     '''
 
-    while execution.isComplete() == False:
+    while execution.isComplete() is False:
         execution.checkStatus(sleepSecs=sleepSecs)
-        print 'Execution status: %s' % execution.status
+        print('Execution status: %s' % execution.status)
 
     if execution.isSucceded():
         if download:
@@ -1365,10 +1366,10 @@ def monitorExecution(execution, sleepSecs=3, download=False, filepath=None):
         else:
             for output in execution.processOutputs:
                 if output.reference is not None:
-                    print 'Output URL=%s' % output.reference
+                    print('Output URL=%s' % output.reference)
     else:
         for ex in execution.errors:
-            print 'Error: code=%s, locator=%s, text=%s' % (ex.code, ex.locator, ex.text)
+            print('Error: code=%s, locator=%s, text=%s' % (ex.code, ex.locator, ex.text))
 
 
 def printValue(value):
@@ -1390,19 +1391,19 @@ def printInputOutput(value, indent=''):
     '''
 
     # InputOutput fields
-    print '%s identifier=%s, title=%s, abstract=%s, data type=%s' % (indent, value.identifier, value.title, value.abstract, value.dataType)
+    print('%s identifier=%s, title=%s, abstract=%s, data type=%s' % (indent, value.identifier, value.title, value.abstract, value.dataType))
     for val in value.allowedValues:
-        print '%s Allowed Value: %s' % (indent, printValue(val))
+        print('%s Allowed Value: %s' % (indent, printValue(val)))
     for val in value.supportedValues:
-        print '%s Supported Value: %s' % (indent, printValue(val))
-    print '%s Default Value: %s ' % (indent, printValue(value.defaultValue))
+        print('%s Supported Value: %s' % (indent, printValue(val)))
+    print('%s Default Value: %s ' % (indent, printValue(value.defaultValue)))
 
     # Input fields
     if isinstance(value, Input):
-        print '%s minOccurs=%d, maxOccurs=%d' % (indent, value.minOccurs, value.maxOccurs)
+        print('%s minOccurs=%d, maxOccurs=%d' % (indent, value.minOccurs, value.maxOccurs))
 
     # Output fields
     if isinstance(value, Output):
-        print '%s reference=%s, mimeType=%s' % (indent, value.reference, value.mimeType)
+        print('%s reference=%s, mimeType=%s' % (indent, value.reference, value.mimeType))
         for datum in value.data:
-            print '%s Data Value: %s' % (indent, printValue(datum))
+            print('%s Data Value: %s' % (indent, printValue(datum)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil>=1.5
 pytz
+six

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,14 @@ import owslib
 from setuptools.command.test import test as TestCommand
 import sys
 
+
 class PyTest(TestCommand):
+
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
+
     def run_tests(self):
         import pytest
         errno = pytest.main(self.test_args)
@@ -19,21 +22,22 @@ reqs = [line.strip() for line in open('requirements.txt')]
 if sys.version[:3] < '2.7':
     reqs += [line.strip() for line in open('requirements-2.6.txt')]
 
-setup(name              = 'OWSLib',
-      version           = owslib.__version__,
-      description       = 'OGC Web Service utility library',
-      long_description  = readme,
-      license           = 'BSD',
-      keywords          = 'gis ogc iso 19115 fgdc dif ows wfs wms sos csw wps wcs capabilities metadata wmts',
-      author            = 'Sean Gillies',
-      author_email      = 'sean.gillies@gmail.com',
-      maintainer        = 'Tom Kralidis',
-      maintainer_email  = 'tomkralidis@gmail.com',
-      url               = 'https://geopython.github.io/OWSLib',
-      install_requires  = reqs,
-      cmdclass          = {'test': PyTest},
-      packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
-      classifiers       = [
+setup(
+    name              = 'OWSLib',
+    version           = owslib.__version__,
+    description       = 'OGC Web Service utility library',
+    long_description  = readme,
+    license           = 'BSD',
+    keywords          = 'gis ogc iso 19115 fgdc dif ows wfs wms sos csw wps wcs capabilities metadata wmts',
+    author            = 'Sean Gillies',
+    author_email      = 'sean.gillies@gmail.com',
+    maintainer        = 'Tom Kralidis',
+    maintainer_email  = 'tomkralidis@gmail.com',
+    url               = 'https://geopython.github.io/OWSLib',
+    install_requires  = reqs,
+    cmdclass          = {'test': PyTest},
+    packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
+    classifiers       = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
@@ -41,6 +45,5 @@ setup(name              = 'OWSLib',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: GIS',
-        ],
+    ],
 )
-

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     url               = 'https://geopython.github.io/OWSLib',
     install_requires  = reqs,
     cmdclass          = {'test': PyTest},
-    packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
+    packages          = find_packages(exclude=['docs', 'etc', 'examples', 'tests']),
     classifiers       = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tests/doctests/crs.txt
+++ b/tests/doctests/crs.txt
@@ -1,25 +1,25 @@
     >>> from owslib import crs
-    >>> c=crs.Crs('EPSG:4326')
+    >>> c = crs.Crs('EPSG:4326')
     >>> c.code
     4326
-    >>> c=crs.Crs('urn:ogc:def:crs:EPSG::4326')
+    >>> c = crs.Crs('urn:ogc:def:crs:EPSG::4326')
     >>> c.authority
     'EPSG'
     >>> c.axisorder
     'yx'
-    >>> c=crs.Crs('http://www.opengis.net/gml/epsg.xml#4326')
+    >>> c = crs.Crs('http://www.opengis.net/gml/epsg.xml#4326')
     >>> c.code
     4326
     >>> c.axisorder
     'yx'
-    >>> c=crs.Crs('urn:x-ogc:def:crs:EPSG:6.11:2192')
+    >>> c = crs.Crs('urn:x-ogc:def:crs:EPSG:6.11:2192')
     >>> c.axisorder
     'xy'
     >>> c.code
     2192
     >>> c.version
     '6.11'
-    >>> c=crs.Crs('http://www.opengis.net/def/crs/EPSG/0/4326')
+    >>> c = crs.Crs('http://www.opengis.net/def/crs/EPSG/0/4326')
     >>> c.authority
     'EPSG'
     >>> c.code

--- a/tests/doctests/csw_conterra.txt
+++ b/tests/doctests/csw_conterra.txt
@@ -1,10 +1,10 @@
     >>> from owslib.csw import CatalogueServiceWeb as cs
-    >>> c=cs('https://gateway.ceh.ac.uk/soapServices/CSWStartup')
+    >>> c = cs('https://gateway.ceh.ac.uk/soapServices/CSWStartup')
     >>> c.version
     '2.0.2'
-    
-    #no longer inspire, files name is probably misleading at this point
-    >>> #c.identification.title
+
+    # no longer inspire, files name is probably misleading at this point
+    >>>  #c.identification.title
     #'INSPIRE Geoportal Discovery Service'
     >>> c.identification.title
     'Centre for Ecology and Hydrology Information Gateway CSW Service'

--- a/tests/doctests/csw_gdp.txt
+++ b/tests/doctests/csw_gdp.txt
@@ -1,11 +1,11 @@
 Imports
 
-    >>> from owslib import fes    
-    >>> from owslib.dif import namespaces 
+    >>> from owslib import fes
+    >>> from owslib.dif import namespaces
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> from owslib.etree import etree
 
-    >>> c=cs('http://geodiscover.cgdi.ca/wes/serviceManagerCSW/csw',timeout=30)
+    >>> c = cs('http://geodiscover.cgdi.ca/wes/serviceManagerCSW/csw', timeout=30)
     >>> c.identification.title
     'Compusult CSW'
     >>> c.identification.version
@@ -19,7 +19,7 @@ Imports
     >>> c.response
     '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator=""><ows:ExceptionText>Internal Error</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
 
-    >>> prop = fes.PropertyIsLike("csw:AnyText", "birds")
+    >>> prop = fes.PropertyIsLike('csw:AnyText', 'birds')
     >>> c.getrecords2([prop])
     >>> c.results['matches']
     100
@@ -31,11 +31,11 @@ Imports
     '272 Categorized Initiatives: Initiatives are referenced to a Category, Sub-Category and Subject Term index, through the cititzen science web site at http://www.citizenscience.ca'
     >>> c.getrecordbyid(['9250AA67-F3AC-6C12-0CB9-0662231AA181'])
 
-    >>> prop = fes.PropertyIsLike("csw:AnyText", "hydrology")
+    >>> prop = fes.PropertyIsLike('csw:AnyText', 'hydrology')
     >>> c.getrecords2([prop], outputschema='http://www.isotc211.org/2005/gmd')
     >>> c.exceptionreport
 
-    >>> prop = fes.PropertyIsLike("csw:AnyText", "hydrology")
+    >>> prop = fes.PropertyIsLike('csw:AnyText', 'hydrology')
     >>> c.getrecords2([prop], outputschema='http://www.isotc211.org/2005/gmd', maxrecords=2)
     >>> c.results['returned']
     2
@@ -48,14 +48,14 @@ Imports
     'ISO/TC 211 Geographic Information/Geomatics'
     >>> c.records['World Glaciology Data, Geological Survey of Canada.xml'].stdver
     'ISO 19115:2003'
-    >>> c.harvest('somefile','someuri')
+    >>> c.harvest('somefile', 'someuri')
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     ExceptionReport: 'Access to Harvest denied'
     >>> c.response
     '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator="Access"><ows:ExceptionText>Access to Harvest denied</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
 
-    >>> prop = fes.PropertyIsLike("csw:AnyText", "glacial")
+    >>> prop = fes.PropertyIsLike('csw:AnyText', 'glacial')
     >>> c.getrecords2([prop], outputschema='http://www.fgdc.gov')
     >>> c.results['matches'] > 300
     True
@@ -67,13 +67,13 @@ Imports
     2
     >>> c.results['nextrecord']
     3
-    >>> sortBy=fes.SortBy([fes.SortProperty("dc:title", "ASC")])
+    >>> sortBy = fes.SortBy([fes.SortProperty('dc:title', 'ASC')])
     >>> c.getrecords2([prop], outputschema='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/', maxrecords=2, sortby=sortBy)
-    >>> xml=etree.fromstring(c.response)
-    >>> xml.findtext(".//{http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/}Entry_Title")
+    >>> xml = etree.fromstring(c.response)
+    >>> xml.findtext('.//{http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/}Entry_Title')
     'Agu Bay and Easter Cape (Surficial AS1959)'
-    >>> sortBy=fes.SortBy([fes.SortProperty("dc:title", "DESC")])
+    >>> sortBy = fes.SortBy([fes.SortProperty('dc:title', 'DESC')])
     >>> c.getrecords2([prop], outputschema='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/', maxrecords=2, sortby=sortBy)
-    >>> xml=etree.fromstring(c.response)
-    >>> xml.findtext(".//{http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/}Entry_Title")
+    >>> xml = etree.fromstring(c.response)
+    >>> xml.findtext('.//{http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/}Entry_Title')
     'Young Inlet (Surficial OF3450)'

--- a/tests/doctests/csw_gdp.txt
+++ b/tests/doctests/csw_gdp.txt
@@ -12,12 +12,12 @@ Imports
     '2.0.2'
     >>> c.provider.name
     'Compusult Ltd.'
-    >>> c.getdomain('GetRecords.outputSchema')
+    >>> c.getdomain('GetRecords.outputSchema')  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
+    ...
     ExceptionReport: 'Internal Error'
-    >>> c.response
-    '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator=""><ows:ExceptionText>Internal Error</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
+    >>> c.response.decode('utf8') == '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator=""><ows:ExceptionText>Internal Error</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
+    True
 
     >>> prop = fes.PropertyIsLike('csw:AnyText', 'birds')
     >>> c.getrecords2([prop])
@@ -48,12 +48,12 @@ Imports
     'ISO/TC 211 Geographic Information/Geomatics'
     >>> c.records['World Glaciology Data, Geological Survey of Canada.xml'].stdver
     'ISO 19115:2003'
-    >>> c.harvest('somefile', 'someuri')
+    >>> c.harvest('somefile', 'someuri')  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
+    ...
     ExceptionReport: 'Access to Harvest denied'
-    >>> c.response
-    '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator="Access"><ows:ExceptionText>Access to Harvest denied</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
+    >>> c.response.decode('utf8') == '<?xml version="1.0" encoding="ISO-8859-1"?><ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><ows:Exception exceptionCode="NoApplicableCode" locator="Access"><ows:ExceptionText>Access to Harvest denied</ows:ExceptionText></ows:Exception></ows:ExceptionReport>\r\n'
+    True
 
     >>> prop = fes.PropertyIsLike('csw:AnyText', 'glacial')
     >>> c.getrecords2([prop], outputschema='http://www.fgdc.gov')

--- a/tests/doctests/csw_geoserver.txt
+++ b/tests/doctests/csw_geoserver.txt
@@ -1,5 +1,5 @@
 >>> from owslib.csw import CatalogueServiceWeb
->>> c=CatalogueServiceWeb('http://suite.opengeo.org/geoserver/ows')
+>>> c = CatalogueServiceWeb('http://suite.opengeo.org/geoserver/ows')
 >>> c.getrecords2(typenames='gmd:MD_Metadata')
 >>> c.results.get('returned') > 0
 True

--- a/tests/doctests/csw_nlr.txt
+++ b/tests/doctests/csw_nlr.txt
@@ -13,19 +13,19 @@
 >>> c.identification.keywords
 ['CSW', 'geospatial', 'catalogue']
 
->>> c.identification.fees    
+>>> c.identification.fees
 'NONE'
 
 >>> c.identification.accessconstraints
 'NONE'
 
->>> c.identification.type             
+>>> c.identification.type
 'CSW'
 
 >>> c.identification.version
 '2.0.2'
 
->>> c.provider.name         
+>>> c.provider.name
 'National Aerospace Laboratory NLR'
 
 >>> c.provider.site
@@ -33,7 +33,7 @@ Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 AttributeError: 'ServiceProvider' object has no attribute 'site'
 
->>> c.provider.url 
+>>> c.provider.url
 'http://geomatics.nlr.nl/excat'
 
 >>> c.provider.uri

--- a/tests/doctests/csw_nlr.txt
+++ b/tests/doctests/csw_nlr.txt
@@ -30,7 +30,7 @@
 
 >>> c.provider.site
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
+...
 AttributeError: 'ServiceProvider' object has no attribute 'site'
 
 >>> c.provider.url
@@ -38,7 +38,7 @@ AttributeError: 'ServiceProvider' object has no attribute 'site'
 
 >>> c.provider.uri
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
+...
 AttributeError: 'ServiceProvider' object has no attribute 'uri'
 
 >>> c.provider.contact.name
@@ -56,14 +56,14 @@ AttributeError: 'ServiceProvider' object has no attribute 'uri'
 
 >>> c.get_operation_by_name('GetRecords-bad')
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
+...
 KeyError: 'No operation named GetRecords-bad'
 
 >>> c.describerecord()
 
->>> c.getdomain('GetRecords.outputSchema')
+>>> c.getdomain('GetRecords.outputSchema')  # doctest: +IGNORE_EXCEPTION_DETAIL
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
+...
 ExceptionReport: 'Operation not supported: GetDomain'
 
 >>> c.getrecordbyid(['DGFKRYMCWUZSCDRBWRXMIETZE'])

--- a/tests/doctests/csw_uuid_constrain.txt
+++ b/tests/doctests/csw_uuid_constrain.txt
@@ -3,23 +3,23 @@ Imports
     >>> from xml.dom import minidom as md
     >>> from owslib import fes, csw
     >>> from tests.utils import compare_xml
-    
+
 Initialize CSW client
 
     # connect to CSW, explore it's properties
     #endpoint = 'http://data.nodc.noaa.gov/geoportal/csw'  # NODC Geoportal: collection level
-    #endpoint = 'http://geodiscover.cgdi.ca/wes/serviceManagerCSW/csw'  # NRCAN 
-    #endpoint = 'http://geoport.whoi.edu/gi-cat/services/cswiso' # USGS Woods Hole GI_CAT
-    #endpoint = 'http://cida.usgs.gov/gdp/geonetwork/srv/en/csw' # USGS CIDA Geonetwork
-    #endpoint = 'http://www.nodc.noaa.gov/geoportal/csw'   # NODC Geoportal: granule level
+    #endpoint = 'http://geodiscover.cgdi.ca/wes/serviceManagerCSW/csw'  # NRCAN
+    #endpoint = 'http://geoport.whoi.edu/gi-cat/services/cswiso'  # USGS Woods Hole GI_CAT
+    #endpoint = 'http://cida.usgs.gov/gdp/geonetwork/srv/en/csw'  # USGS CIDA Geonetwork
+    #endpoint = 'http://www.nodc.noaa.gov/geoportal/csw'  # NODC Geoportal: granule level
     #endpoint = 'http://cmgds.marine.usgs.gov/geonetwork/srv/en/csw'  # USGS Coastal & Marine Program Geonetwork
-    >>> endpoint = 'http://www.ngdc.noaa.gov/geoportal/csw' # NGDC Geoportal
+    >>> endpoint = 'http://www.ngdc.noaa.gov/geoportal/csw'  # NGDC Geoportal
     >>> c = cs(endpoint, timeout=30)
 
     # define some var
     >>> AOOS = '1706F520-2647-4A33-B7BF-592FAFDE4B45'
-    >>> bbox = [-141,42,-52,84]
-    
+    >>> bbox = [-141, 42, -52, 84]
+
     # Test new function getrecords2()
     >>> uuid = fes.PropertyIsEqualTo(propertyname='sys.siteuuid', literal='{%s}' % AOOS)
     >>> timeRange = fes.PropertyIsBetween(propertyname='apiso:modified', lower='2009-02-01', upper='2012-02-01')
@@ -69,23 +69,22 @@ Initialize CSW client
     >>> c.results == {'matches': 2, 'nextrecord': 0, 'returned': 2}
     True
 
-
     ##########################################################
     # Test 5
     # construct a request by send the xml string
     ##########################################################
-    >>> sos_search='''<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+    >>> sos_search = '''<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
     ... <csw:GetRecords xmlns:xs2="http://www.w3.org/XML/Schema" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:gml="http://www.opengis.net/gml" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ows="http://www.opengis.net/ows" xmlns:fgdc="http://www.opengis.net/cat/csw/csdgm" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" outputSchema="http://www.opengis.net/cat/csw/2.0.2" outputFormat="application/xml" version="2.0.2" resultType="results" service="CSW" maxRecords="10" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
     ... <csw:Query typeNames="csw:Record">
     ... <csw:ElementSetName>full</csw:ElementSetName>
     ... <csw:Constraint version="1.1.0">
     ...   <ogc:Filter>
     ...     <ogc:And>
-    ...        <ogc:PropertyIsLike wildCard="*" escape="\" singleChar="?"> 
+    ...        <ogc:PropertyIsLike wildCard="*" escape="\" singleChar="?">
     ...          <ogc:PropertyName>apiso:ServiceType</ogc:PropertyName>
     ...          <ogc:Literal>*opendap*</ogc:Literal>
     ...        </ogc:PropertyIsLike>
-    ...     </ogc:And> 
+    ...     </ogc:And>
     ...    </ogc:Filter>
     ... </csw:Constraint>
     ...  </csw:Query>
@@ -98,7 +97,7 @@ Initialize CSW client
     True
     >>> c.results['nextrecord'] == 11
     True
-    
+
     ##########################################################
     # Test 6
     # construct a request by setting SAME constraint with Test 1
@@ -106,7 +105,7 @@ Initialize CSW client
     # it means a && b
     ##########################################################
     >>> dap_filter = fes.PropertyIsLike(propertyname='apiso:ServiceType', literal='*opendap*', escapeChar='\\', singleChar='?', wildCard='*')
-    >>> filter_list = [[uuid,dap_filter]]
+    >>> filter_list = [[uuid, dap_filter]]
     >>> c.getrecords2(filter_list)
     >>> c.results['matches'] > 0
     True
@@ -114,4 +113,3 @@ Initialize CSW client
     True
     >>> c.results['nextrecord'] == 11
     True
-    

--- a/tests/doctests/fes_ogc_filters.txt
+++ b/tests/doctests/fes_ogc_filters.txt
@@ -4,71 +4,71 @@ Imports
     >>> from tests.utils import compare_xml
 
 SortProperty
-    >>> sort = fes.SortProperty("property", "ASC")
+    >>> sort = fes.SortProperty('property', 'ASC')
     >>> should_return = '<ns0:SortProperty xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:SortOrder>ASC</ns0:SortOrder></ns0:SortProperty>'
     >>> compare_xml(should_return, sort.toXML())
     True
 
 SortBy
-    >>> sort2 = fes.SortProperty("another_property", "DESC")
-    >>> sortby = fes.SortBy([sort,sort2])
+    >>> sort2 = fes.SortProperty('another_property', 'DESC')
+    >>> sortby = fes.SortBy([sort, sort2])
     >>> should_return = '<ns0:SortBy xmlns:ns0="http://www.opengis.net/ogc"><ns0:SortProperty xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:SortOrder>ASC</ns0:SortOrder></ns0:SortProperty><ns0:SortProperty xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>another_property</ns0:PropertyName><ns0:SortOrder>DESC</ns0:SortOrder></ns0:SortProperty></ns0:SortBy>'
     >>> compare_xml(should_return, sortby.toXML())
     True
 
 PropertyIsEqualTo
-    >>> filter = fes.PropertyIsEqualTo("property", "value")
+    >>> filter = fes.PropertyIsEqualTo('property', 'value')
     >>> should_return = '<ns0:PropertyIsEqualTo xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsEqualTo>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsNotEqualTo
-    >>> filter = fes.PropertyIsNotEqualTo("property", "value")
+    >>> filter = fes.PropertyIsNotEqualTo('property', 'value')
     >>> should_return = '<ns0:PropertyIsNotEqualTo xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsNotEqualTo>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsLessThan
-    >>> filter = fes.PropertyIsLessThan("property", "value")
+    >>> filter = fes.PropertyIsLessThan('property', 'value')
     >>> should_return = '<ns0:PropertyIsLessThan xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsLessThan>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsGreaterThan
-    >>> filter = fes.PropertyIsGreaterThan("property", "value")
+    >>> filter = fes.PropertyIsGreaterThan('property', 'value')
     >>> should_return = '<ns0:PropertyIsGreaterThan xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsGreaterThan>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsLessThanOrEqualTo
-    >>> filter = fes.PropertyIsLessThanOrEqualTo("property", "value")
+    >>> filter = fes.PropertyIsLessThanOrEqualTo('property', 'value')
     >>> should_return = '<ns0:PropertyIsLessThanOrEqualTo xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsLessThanOrEqualTo>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsGreaterThanOrEqualTo
-    >>> filter = fes.PropertyIsGreaterThanOrEqualTo("property", "value")
+    >>> filter = fes.PropertyIsGreaterThanOrEqualTo('property', 'value')
     >>> should_return = '<ns0:PropertyIsGreaterThanOrEqualTo xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsGreaterThanOrEqualTo>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 PropertyIsLike
     # Defaults
-    >>> filter = fes.PropertyIsLike("property", "value")
+    >>> filter = fes.PropertyIsLike('property', 'value')
     >>> should_return = '<ns0:PropertyIsLike xmlns:ns0="http://www.opengis.net/ogc" wildCard="%" singleChar="_" escapeChar="\\"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsLike>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
     # Setting characters
-    >>> filter = fes.PropertyIsLike("property", "value", wildCard="*", singleChar="#", escapeChar="!")
+    >>> filter = fes.PropertyIsLike('property', 'value', wildCard='*', singleChar='#', escapeChar='!')
     >>> should_return = '<ns0:PropertyIsLike xmlns:ns0="http://www.opengis.net/ogc" wildCard="*" singleChar="#" escapeChar="!"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>value</ns0:Literal></ns0:PropertyIsLike>'
     >>> compare_xml(should_return, filter.toXML())
     True
 
 Or
-    >>> filter1 = fes.PropertyIsLike("property", "like")
-    >>> filter2 = fes.PropertyIsEqualTo("property", "equal")
-    >>> filter3 = fes.PropertyIsLessThan("property", "less")
+    >>> filter1 = fes.PropertyIsLike('property', 'like')
+    >>> filter2 = fes.PropertyIsEqualTo('property', 'equal')
+    >>> filter3 = fes.PropertyIsLessThan('property', 'less')
 
     >>> filter = fes.Or([filter1, filter2, filter3])
     >>> should_return = '<ns0:Or xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>like</ns0:Literal></ns0:PropertyIsLike><ns0:PropertyIsEqualTo><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>equal</ns0:Literal></ns0:PropertyIsEqualTo><ns0:PropertyIsLessThan><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>less</ns0:Literal></ns0:PropertyIsLessThan></ns0:Or>'
@@ -110,6 +110,3 @@ setConstraint
     >>> should_return = '<ns0:Filter xmlns:ns0="http://www.opengis.net/ogc"><ns0:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\"><ns0:PropertyName>property</ns0:PropertyName><ns0:Literal>like</ns0:Literal></ns0:PropertyIsLike></ns0:Filter>'
     >>> compare_xml(should_return, filter)
     True
-
-
-

--- a/tests/doctests/iso_codelist.txt
+++ b/tests/doctests/iso_codelist.txt
@@ -2,14 +2,13 @@
 Imports
 
     >>> from tests.utils import resource_file
-    >>> import urllib2
     >>> from owslib.etree import etree
     >>> from owslib.iso import CodelistCatalogue
 
 Print testing the code lists
 
-    >>> e=etree.parse(resource_file('gmxCodelists.xml'))
-    >>> c=CodelistCatalogue(e)
+    >>> e = etree.parse(resource_file('gmxCodelists.xml'))
+    >>> c = CodelistCatalogue(e)
     >>> sorted(c.getcodelistdictionaries())
     ['CI_DateTypeCode', 'CI_OnLineFunctionCode', 'CI_PresentationFormCode', 'CI_RoleCode', 'DQ_EvaluationMethodTypeCode', 'DS_AssociationTypeCode', 'DS_InitiativeTypeCode', 'MD_CellGeometryCode', 'MD_CharacterSetCode', 'MD_ClassificationCode', 'MD_CoverageContentTypeCode', 'MD_DatatypeCode', 'MD_DimensionNameTypeCode', 'MD_GeometricObjectTypeCode', 'MD_ImagingConditionCode', 'MD_KeywordTypeCode', 'MD_MaintenanceFrequencyCode', 'MD_MediumFormatCode', 'MD_MediumNameCode', 'MD_ObligationCode', 'MD_PixelOrientationCode', 'MD_ProgressCode', 'MD_RestrictionCode', 'MD_ScopeCode', 'MD_SpatialRepresentationTypeCode', 'MD_TopicCategoryCode', 'MD_TopologyLevelCode', 'MX_ScopeCode']
 

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -9,7 +9,7 @@ Correct Usage Tests
     >>> ns.get_namespace('csw')
     'http://www.opengis.net/cat/csw/2.0.2'
 
-    >>> x = ns.get_namespaces(['csw','gmd','fes'])
+    >>> x = ns.get_namespaces(['csw', 'gmd', 'fes'])
     >>> x == {'csw': 'http://www.opengis.net/cat/csw/2.0.2', 'fes': 'http://www.opengis.net/fes/2.0', 'gmd': 'http://www.isotc211.org/2005/gmd'}
     True
     >>> ns.get_namespaces()
@@ -18,13 +18,13 @@ Correct Usage Tests
     >>> ns.get_versioned_namespace('ows')
     'http://www.opengis.net/ows'
 
-    >>> ns.get_versioned_namespace('ows','1.0.0')
+    >>> ns.get_versioned_namespace('ows', '1.0.0')
     'http://www.opengis.net/ows'
 
-    >>> ns.get_versioned_namespace('ows','1.1.0')
+    >>> ns.get_versioned_namespace('ows', '1.1.0')
     'http://www.opengis.net/ows/1.1'
 
-    >>> ns.get_versioned_namespace('ows','2.0.0')
+    >>> ns.get_versioned_namespace('ows', '2.0.0')
     'http://www.opengis.net/ows/2.0'
 
     >>> ns.get_namespaces('csw')
@@ -37,7 +37,7 @@ Correct Usage Tests
     >>> ns.get_namespace('om300')
 
     # CSW 3.1.1 doesn't exist, so the below will return nothing
-    >>> ns.get_versioned_namespace('csw','3.1.1')
+    >>> ns.get_versioned_namespace('csw', '3.1.1')
 
 
 Invalid Usage Tests

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -42,12 +42,16 @@ Correct Usage Tests
 
 Invalid Usage Tests
 
-    >>> ns.get_namespace()
+    # For python 2: TypeError: get_namespace() takes exactly 2 arguments (1 given)
+    # For python 3: TypeError: get_namespace() missing 1 required positional argument: 'key'
+    >>> ns.get_namespace()  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: get_namespace() takes exactly 2 arguments (1 given)
+    TypeError: get_namespace() ...
 
-    >>> ns.get_versioned_namespace()
+    # For Python 2: TypeError: get_versioned_namespace() takes at least 2 arguments (1 given)
+    # For python 3: TypeError: get_versioned_namespace() missing 1 required positional argument: 'key'
+    >>> ns.get_versioned_namespace()  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: get_versioned_namespace() takes at least 2 arguments (1 given)
+    TypeError: get_versioned_namespace() ...

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -128,7 +128,7 @@
     >>> for service in services:
     ...     if type(service.contents) is dict:
     ...         service.identification.type
-    ...         content = service.contents[service.contents.iterkeys().next()]  # get random item from contents dictionary -has to be a nicer way to do this!
+    ...         content = service.contents[next(iter(service.contents.keys()))]  # get random item from contents dictionary -has to be a nicer way to do this!
     ...         [[attribute, hasattr(content, attribute)] for attribute in ['id', 'title', 'boundingBox', 'boundingBoxWGS84', 'crsOptions', 'styles', 'timepositions']]
     'CSW'
     [['id', False], ['title', True], ['boundingBox', False], ['boundingBoxWGS84', False], ['crsOptions', False], ['styles', False], ['timepositions', False]]

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -1,6 +1,6 @@
-#This test checks that the OWSLib service interfaces are the same across all service type:
-#Author: Dominic Lowe, 17th September 2009
-#Part of OWSLib package.
+# This test checks that the OWSLib service interfaces are the same across all service type:
+# Author: Dominic Lowe, 17th September 2009
+# Part of OWSLib package.
 
     >>> from tests.utils import resource_file
     >>> from owslib.csw import CatalogueServiceWeb
@@ -9,18 +9,18 @@
     >>> from owslib.wfs import WebFeatureService
 
 
-#TODO, we should run all these from local XML documents (as per the WMS and WFS services)
+# TODO, we should run all these from local XML documents (as per the WMS and WFS services)
 
     >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
     >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=wmsxml)
     >>> wfs = WebFeatureService('url', version='1.0', xml=wfsxml)
-    >>> wcs=WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')
-    >>> csw= CatalogueServiceWeb('http://data.nodc.noaa.gov/geoportal/csw')
+    >>> wcs = WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')
+    >>> csw = CatalogueServiceWeb('http://data.nodc.noaa.gov/geoportal/csw')
 
-#Check each service instance conforms to OWSLib interface
-    >>> csw.alias, wms.alias, wcs.alias, wfs.alias='CSW', 'WMS', 'WCS', 'WFS'
-    >>> services=[csw, wms, wcs, wfs]
+# Check each service instance conforms to OWSLib interface
+    >>> csw.alias, wms.alias, wcs.alias, wfs.alias = 'CSW', 'WMS', 'WCS', 'WFS'
+    >>> services = [csw, wms, wcs, wfs]
     >>> for service in services:
     ...     type(service)
     <class 'owslib.csw.CatalogueServiceWeb'>
@@ -28,7 +28,7 @@
     <class 'owslib.coverage.wcs100.WebCoverageService_1_0_0'>
     <class 'owslib.feature.wfs100.WebFeatureService_1_0_0'>
 
-#URL attribute
+# URL attribute
     >>> for service in services:
     ...     service.url
     'http://data.nodc.noaa.gov/geoportal/csw'
@@ -36,7 +36,7 @@
     'http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best'
     'url'
 
-#version attribute
+# Version attribute
     >>> for service in services:
     ...     service.version
     '2.0.2'
@@ -44,7 +44,7 @@
     '1.0.0'
     '1.0'
 
-#Identification object:
+# Identification object:
     >>> for service in services:
     ...     hasattr(service, 'identification')
     True
@@ -53,7 +53,7 @@
     True
 
 
-#Check all ServiceIdentification attributes
+# Check all ServiceIdentification attributes
     >>> for service in services:
     ...     service.identification.type
     ...     [[attribute, hasattr(service.identification, attribute)] for attribute in ['type', 'version', 'title', 'abstract', 'keywords', 'accessconstraints', 'fees']]
@@ -66,10 +66,10 @@
     'MapServer WFS'
     [['type', True], ['version', True], ['title', True], ['abstract', True], ['keywords', True], ['accessconstraints', True], ['fees', True]]
 
-#Check all ServiceProvider attributes
+# Check all ServiceProvider attributes
     >>> for service in services:
     ...     service.identification.type
-    ...     [[attribute, hasattr(service.provider, attribute)] for attribute in ['name','url','contact']]
+    ...     [[attribute, hasattr(service.provider, attribute)] for attribute in ['name', 'url', 'contact']]
     'CSW'
     [['name', True], ['url', True], ['contact', True]]
     'OGC:WMS'
@@ -79,11 +79,11 @@
     'MapServer WFS'
     [['name', True], ['url', True], ['contact', False]]
 
-#Check all operations implement IOperationMetadata
+# Check all operations implement IOperationMetadata
     >>> for service in services:
     ...     service.identification.type
     ...     for op in service.operations:
-    ...         [[attribute, hasattr(op, attribute)] for attribute in ['name','formatOptions','methods']]
+    ...         [[attribute, hasattr(op, attribute)] for attribute in ['name', 'formatOptions', 'methods']]
     'CSW'
     [['name', True], ['formatOptions', True], ['methods', True]]
     [['name', True], ['formatOptions', True], ['methods', True]]
@@ -104,9 +104,9 @@
     [['name', True], ['formatOptions', True], ['methods', True]]
 
 
-#Check all contents implement IContentMetadata as a dictionary
-#CSW does not work in this way so use dummy
-    >>> csw.contents={'dummy':'1'}
+# Check all contents implement IContentMetadata as a dictionary
+# CSW does not work in this way so use dummy
+    >>> csw.contents = {'dummy': '1'}
     >>> for service in services:
     ...     service.identification.type
     ...     type(service.contents)
@@ -120,17 +120,16 @@
     <type 'dict'>
 
 
-#Check any item (WCS coverage, WMS layer etc) from the contents of each service
-#Check it conforms to IContentMetadata interface
-#CSW does not conform to this
-#WCS boundingbox handling is also different (has multiple boundingboxes). TODO: needs harmonising.
-
+# Check any item (WCS coverage, WMS layer etc) from the contents of each service
+# Check it conforms to IContentMetadata interface
+# CSW does not conform to this
+# WCS boundingbox handling is also different (has multiple boundingboxes). TODO: needs harmonising.
 
     >>> for service in services:
-    ...	    if type(service.contents) is dict:
+    ...     if type(service.contents) is dict:
     ...         service.identification.type
-    ...         content=service.contents[service.contents.iterkeys().next()] #get random item from contents dictionary -has to be a nicer way to do this!
-    ...         [[attribute, hasattr(content, attribute)] for attribute in ['id','title','boundingBox', 'boundingBoxWGS84', 'crsOptions', 'styles', 'timepositions']]
+    ...         content = service.contents[service.contents.iterkeys().next()]  # get random item from contents dictionary -has to be a nicer way to do this!
+    ...         [[attribute, hasattr(content, attribute)] for attribute in ['id', 'title', 'boundingBox', 'boundingBoxWGS84', 'crsOptions', 'styles', 'timepositions']]
     'CSW'
     [['id', False], ['title', True], ['boundingBox', False], ['boundingBoxWGS84', False], ['crsOptions', False], ['styles', False], ['timepositions', False]]
     'OGC:WMS'

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -1,5 +1,5 @@
 #This test checks that the OWSLib service interfaces are the same across all service type:
-#Author: Dominic Lowe, 17th September 2009    
+#Author: Dominic Lowe, 17th September 2009
 #Part of OWSLib package.
 
     >>> from tests.utils import resource_file
@@ -11,7 +11,7 @@
 
 #TODO, we should run all these from local XML documents (as per the WMS and WFS services)
 
-    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read() 
+    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
     >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=wmsxml)
     >>> wfs = WebFeatureService('url', version='1.0', xml=wfsxml)
@@ -19,11 +19,11 @@
     >>> csw= CatalogueServiceWeb('http://data.nodc.noaa.gov/geoportal/csw')
 
 #Check each service instance conforms to OWSLib interface
-    >>> csw.alias, wms.alias, wcs.alias, wfs.alias='CSW', 'WMS', 'WCS', 'WFS' 
+    >>> csw.alias, wms.alias, wcs.alias, wfs.alias='CSW', 'WMS', 'WCS', 'WFS'
     >>> services=[csw, wms, wcs, wfs]
     >>> for service in services:
     ...     type(service)
-    <type 'instance'>
+    <class 'owslib.csw.CatalogueServiceWeb'>
     <class 'owslib.wms.WebMapService'>
     <class 'owslib.coverage.wcs100.WebCoverageService_1_0_0'>
     <class 'owslib.feature.wfs100.WebFeatureService_1_0_0'>
@@ -43,7 +43,7 @@
     '1.1.1'
     '1.0.0'
     '1.0'
-    
+
 #Identification object:
     >>> for service in services:
     ...     hasattr(service, 'identification')
@@ -56,7 +56,7 @@
 #Check all ServiceIdentification attributes
     >>> for service in services:
     ...     service.identification.type
-    ...     [[attribute, hasattr(service.identification, attribute)] for attribute in ['type', 'version', 'title', 'abstract', 'keywords', 'accessconstraints', 'fees']] 
+    ...     [[attribute, hasattr(service.identification, attribute)] for attribute in ['type', 'version', 'title', 'abstract', 'keywords', 'accessconstraints', 'fees']]
     'CSW'
     [['type', True], ['version', True], ['title', True], ['abstract', True], ['keywords', True], ['accessconstraints', True], ['fees', True]]
     'OGC:WMS'
@@ -69,7 +69,7 @@
 #Check all ServiceProvider attributes
     >>> for service in services:
     ...     service.identification.type
-    ...     [[attribute, hasattr(service.provider, attribute)] for attribute in ['name','url','contact']] 
+    ...     [[attribute, hasattr(service.provider, attribute)] for attribute in ['name','url','contact']]
     'CSW'
     [['name', True], ['url', True], ['contact', True]]
     'OGC:WMS'
@@ -83,7 +83,7 @@
     >>> for service in services:
     ...     service.identification.type
     ...     for op in service.operations:
-    ...         [[attribute, hasattr(op, attribute)] for attribute in ['name','formatOptions','methods']] 
+    ...         [[attribute, hasattr(op, attribute)] for attribute in ['name','formatOptions','methods']]
     'CSW'
     [['name', True], ['formatOptions', True], ['methods', True]]
     [['name', True], ['formatOptions', True], ['methods', True]]
@@ -125,7 +125,7 @@
 #CSW does not conform to this
 #WCS boundingbox handling is also different (has multiple boundingboxes). TODO: needs harmonising.
 
-	
+
     >>> for service in services:
     ...	    if type(service.contents) is dict:
     ...         service.identification.type

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -11,8 +11,8 @@
 
 # TODO, we should run all these from local XML documents (as per the WMS and WFS services)
 
-    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
-    >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
+    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'rb').read()
+    >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=wmsxml)
     >>> wfs = WebFeatureService('url', version='1.0', xml=wfsxml)
     >>> wcs = WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -109,15 +109,15 @@
     >>> csw.contents = {'dummy': '1'}
     >>> for service in services:
     ...     service.identification.type
-    ...     type(service.contents)
+    ...     isinstance(service.contents, dict)
     'CSW'
-    <type 'dict'>
+    True
     'OGC:WMS'
-    <type 'dict'>
+    True
     'OGC:WCS'
-    <type 'dict'>
+    True
     'MapServer WFS'
-    <type 'dict'>
+    True
 
 
 # Check any item (WCS coverage, WMS layer etc) from the contents of each service
@@ -126,7 +126,7 @@
 # WCS boundingbox handling is also different (has multiple boundingboxes). TODO: needs harmonising.
 
     >>> for service in services:
-    ...     if type(service.contents) is dict:
+    ...     if isinstance(service.contents, dict):
     ...         service.identification.type
     ...         content = service.contents[next(iter(service.contents.keys()))]  # get random item from contents dictionary -has to be a nicer way to do this!
     ...         [[attribute, hasattr(content, attribute)] for attribute in ['id', 'title', 'boundingBox', 'boundingBoxWGS84', 'crsOptions', 'styles', 'timepositions']]

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -7,7 +7,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sml_52N_network.xml'), 'r').read()
+    >>> xml = open(resource_file('sml_52N_network.xml'), 'rb').read()
     >>> root = SensorML(xml)
     >>> system = root.members[0]
 

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -16,7 +16,7 @@ Initialize
 
 Contacts
 
-    >>> system.contacts.keys()
+    >>> list(system.contacts.keys())
     ['http://mmisw.org/ont/ioos/definition/publisher']
 
     >>> publishers = system.get_contacts_by_role('http://mmisw.org/ont/ioos/definition/publisher')
@@ -59,7 +59,7 @@ Capabilities
 
 Characteristics
 
-    >>> system.characteristics.keys()
+    >>> list(system.characteristics.keys())
     []
 
 Components

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -7,7 +7,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sml_ndbc_station.xml'), 'r').read()
+    >>> xml = open(resource_file('sml_ndbc_station.xml'), 'rb').read()
     >>> root = SensorML(xml)
     >>> system = root.members[0]
 

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -65,7 +65,7 @@ Identification
 
 Classifiers
 
-    >>> system.classifiers.keys()
+    >>> list(system.classifiers.keys())
     ['Platform Type']
     >>> classi = system.get_classifiers_by_name('Platform type')
     >>> classi[0].name
@@ -80,7 +80,7 @@ Classifiers
 
 Documents
 
-    >>> system.documentation # doctest: +ELLIPSIS
+    >>> system.documentation  # doctest: +ELLIPSIS
     [<owslib.swe.sensor.sml.Documentation ...>]
 
     >>> doc = system.documentation[0].documents[0]

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -111,7 +111,7 @@ OperationsMetadata
     >>> getcap = ndbc.get_operation_by_name('GetCapabilities')
     >>> isinstance(getcap, OperationsMetadata)
     True
-    
+
     Get by name (case insensitive)
 
     >>> getcap = ndbc.get_operation_by_name('getcapabilities')
@@ -130,7 +130,6 @@ OperationsMetadata
     >>> x = getcap.methods
     >>> x == {'Post': {'url': 'http://sdf.ndbc.noaa.gov/sos/server.php'}, 'Get': {'url': 'http://sdf.ndbc.noaa.gov/sos/server.php'}}
     True
-
 
     # DescribeSensor
 
@@ -180,10 +179,10 @@ Network
 
     >>> network.name
     'urn:ioos:network:noaa.nws.ndbc:all'
-    
+
     >>> network.description
     'All stations on the NDBC SOS server'
-    
+
     >>> srs = network.srs
     >>> isinstance(srs, Crs)
     True
@@ -203,14 +202,14 @@ Network
     'urn:ogc:def:crs:EPSG::4326'
     >>> bbsrs.getcode()
     'EPSG:4326'
-    
+
     >>> bp = network.begin_position
     >>> isinstance(bp, datetime)
     True
     >>> ep = network.end_position
     >>> isinstance(ep, datetime)
     True
-    
+
     >>> network.result_model
     'om:Observation'
 
@@ -240,7 +239,6 @@ Network
 
 Station
 
-
     >>> station = contents['station-zbqn7']
     >>> station.id
     'station-zbqn7'
@@ -250,7 +248,7 @@ Station
 
     >>> station.description
     "Zeke's Basin, North Carolina"
-    
+
     >>> srs = station.srs
     >>> isinstance(srs, Crs)
     True
@@ -260,7 +258,7 @@ Station
     'EPSG:4326'
     >>> cast_tuple_int_list(station.bbox)
     [-77, 33, -77, 33]
-    
+
     >>> bbsrs = station.bbox_srs
     >>> isinstance(bbsrs, Crs)
     True

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -10,17 +10,17 @@ Imports
 
 Initialize ncSOS
 
-    >>> xml = open(resource_file('sos_ncSOS_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ncSOS_getcapabilities.xml'), 'rb').read()
     >>> ncsos = SensorObservationService(None, xml=xml)
 
 Initialize 52N
 
-    >>> xml = open(resource_file('sos_52n_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_52n_getcapabilities.xml'), 'rb').read()
     >>> f2n = SensorObservationService(None, xml=xml)
 
 Initialize NDBC
 
-    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'rb').read()
     >>> ndbc = SensorObservationService(None, xml=xml)
 
 ServiceIdentification

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -10,7 +10,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'rb').read()
     >>> ndbc = SensorObservationService(None, xml=xml)
 
 
@@ -25,9 +25,9 @@ GetObservation
     >>> #observedProperties = [ndbc.get_operation_by_name('GetObservation').parameters['observedProperty']['values'][0]]
     >>>
     >>> eventTime = 'This is not a valid eventTime!'
-    >>> response = ndbc.get_observation(offerings=offerings, responseFormat=responseFormat, observedProperties=observedProperties, eventTime=eventTime)
+    >>> response = ndbc.get_observation(offerings=offerings, responseFormat=responseFormat, observedProperties=observedProperties, eventTime=eventTime)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
+    ...
     ExceptionReport: 'This is not a valid eventTime!'
 
     # NDBC only supports one offering and one observedProperty at a time
@@ -49,9 +49,9 @@ DescribeSensor
 
     >>> procedure = 'foobar'
     >>> outputFormat = ndbc.get_operation_by_name('DescribeSensor').parameters['outputFormat']['values'][0]
-    >>> response = ndbc.describe_sensor(procedure=procedure, outputFormat=outputFormat)
+    >>> response = ndbc.describe_sensor(procedure=procedure, outputFormat=outputFormat)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
+    ...
     ExceptionReport: 'foobar'
 
     # Valid request

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -10,7 +10,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'),'r').read()
+    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'r').read()
     >>> ndbc = SensorObservationService(None, xml=xml)
 
 
@@ -23,7 +23,8 @@ GetObservation
     >>> responseFormat = off.response_formats[0]
     >>> observedProperties = [off.observed_properties[0]]
     >>> #observedProperties = [ndbc.get_operation_by_name('GetObservation').parameters['observedProperty']['values'][0]]
-    >>> eventTime = "This is not a valid eventTime!"
+    >>>
+    >>> eventTime = 'This is not a valid eventTime!'
     >>> response = ndbc.get_observation(offerings=offerings, responseFormat=responseFormat, observedProperties=observedProperties, eventTime=eventTime)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
@@ -36,16 +37,17 @@ GetObservation
     >>> responseFormat = off.response_formats[0]
     >>> observedProperties = [off.observed_properties[0]]
     >>> #observedProperties = [ndbc.get_operation_by_name('GetObservation').parameters['observedProperty']['values'][0]]
+    >>>
     >>> eventTime = None
 
     >>> response = ndbc.get_observation(offerings=offerings, responseFormat=responseFormat, observedProperties=observedProperties, eventTime=eventTime)
-    
+
 
 DescribeSensor
 
     # Send a funky procedure
 
-    >>> procedure = "foobar"
+    >>> procedure = 'foobar'
     >>> outputFormat = ndbc.get_operation_by_name('DescribeSensor').parameters['outputFormat']['values'][0]
     >>> response = ndbc.describe_sensor(procedure=procedure, outputFormat=outputFormat)
     Traceback (most recent call last):

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -52,7 +52,6 @@ ServiceProvider
     >>> p.url
     'http://ggw.gns.cri.nz/ggwdata/'
 
-
     ServiceContact
 
     >>> sc = p.contact
@@ -100,7 +99,7 @@ OperationsMetadata
     >>> getcap = ngmp.get_operation_by_name('GetCapabilities')
     >>> isinstance(getcap, OperationsMetadata)
     True
-    
+
     Get by name (case insensitive)
     >>> getcap = ngmp.get_operation_by_name('getcapabilities')
     >>> isinstance(getcap, OperationsMetadata)
@@ -118,7 +117,6 @@ OperationsMetadata
     >>> x == {'Post': {'url': 'https://geier.gns.cri.nz/ngmp-sos/sos'}, 'Get': {'url': 'https://geier.gns.cri.nz/ngmp-sos/sos?'}}
     True
 
-
     # DescribeSensor
     >>> descsen = ngmp.get_operation_by_name('describesensor')
 
@@ -129,11 +127,9 @@ OperationsMetadata
     >>> x == {'procedureDescriptionFormat': {'values': ['http://www.opengis.net/sensorML/1.0.1']}, 'procedure': {'values': ['http://resources.smart-project.info/ggwdata/procedure/acidity_sampling', 'http://resources.smart-project.info/ggwdata/procedure/chloride_sampling', 'http://resources.smart-project.info/ggwdata/procedure/conductivity_sampling', 'http://resources.smart-project.info/ggwdata/procedure/groundwaterlevel_sensor', 'http://resources.smart-project.info/ggwdata/procedure/hydraulic_conductivity_sampling', 'http://resources.smart-project.info/ggwdata/procedure/iron_sampling', 'http://resources.smart-project.info/ggwdata/procedure/manganese_sampling', 'http://resources.smart-project.info/ggwdata/procedure/nitrate_sampling', 'http://resources.smart-project.info/ggwdata/procedure/temperature_sampling', 'http://resources.smart-project.info/ggwdata/procedure/tritium_sampling']}}
     True
 
-
     >>> x = descsen.methods
     >>> x == {'Post': {'url': 'https://geier.gns.cri.nz/ngmp-sos/sos'}, 'Get': {'url': 'https://geier.gns.cri.nz/ngmp-sos/sos?'}}
     True
-
 
     # GetObservation
     >>> getob = ngmp.get_operation_by_name('getobservation')
@@ -162,7 +158,6 @@ Contents
     >>> len(contents)
     10
 
-
     Network
     >>> network = contents['NGMP_TEMPERATURE']
     >>> network.id
@@ -170,7 +165,7 @@ Contents
 
     >>> network.procedures
     ['http://resources.smart-project.info/ggwdata/procedure/temperature_sampling']
-    
+
     >>> srs = network.bbox_srs
     >>> isinstance(srs, Crs)
     True
@@ -186,14 +181,14 @@ Contents
     # (left, bottom, right, top)
     >>> cast_tuple_int_list(network.bbox)
     [168, -46, 177, -34]
-    
+
     >>> bp = network.begin_position
     >>> isinstance(bp, datetime)
     True
     >>> ep = network.end_position
     >>> isinstance(ep, datetime)
     True
-   
+
     >>> network.observed_properties
     ['http://resources.smart-project.info/ggwdata/phenomenon/temperature']
 

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -10,7 +10,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ngmp.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ngmp.xml'), 'rb').read()
     >>> ngmp = SensorObservationService(None, xml=xml, version='2.0.0')
 
 ServiceIdentification

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -10,7 +10,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ngwd.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ngwd.xml'), 'rb').read()
     >>> ngwd = SensorObservationService(None, xml=xml, version='2.0.0')
 
 ServiceIdentification

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -10,7 +10,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ngwd.xml'),'r').read()
+    >>> xml = open(resource_file('sos_ngwd.xml'), 'r').read()
     >>> ngwd = SensorObservationService(None, xml=xml, version='2.0.0')
 
 ServiceIdentification
@@ -51,7 +51,6 @@ ServiceProvider
 
     >>> p.url
     'http://gw-info.net'
-
 
     ServiceContact
 
@@ -119,7 +118,6 @@ OperationsMetadata
     >>> x == {'Post': {'url': 'http://ngwd-bdnes.cits.nrcan.gc.ca:8080/proxy/GinService/sos/gw'}, 'Get': {'url': 'http://ngwd-bdnes.cits.nrcan.gc.ca:8080/proxy/GinService/sos/gw?'}}
     True
 
-
     # DescribeSensor
     >>> descsen = ngwd.get_operation_by_name('describesensor')
 
@@ -130,11 +128,9 @@ OperationsMetadata
     >>> x == {'procedureDescriptionFormat': {'values': ['http://www.opengis.net/sensorML/1.0.1']}, 'procedure': {'values': ['urn:ogc:object:Sensor::GIN_GroundwaterLevelProcess']}}
     True
 
-
     >>> x = descsen.methods
     >>> x == {'Post': {'url': 'http://ngwd-bdnes.cits.nrcan.gc.ca:8080/proxy/GinService/sos/gw'}, 'Get': {'url': 'http://ngwd-bdnes.cits.nrcan.gc.ca:8080/proxy/GinService/sos/gw?'}}
     True
-
 
     # GetObservation
     >>> getob = ngwd.get_operation_by_name('getobservation')
@@ -162,7 +158,6 @@ Contents
     >>> contents = ngwd.contents
     >>> len(contents)
     1
-
 
     Network
     >>> network = contents['GW_LEVEL']

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -6,30 +6,30 @@ Imports
 
 Initialize
 
-    >>> swexml  = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'r').read()
-    >>> dr      = etree.fromstring(swexml)
+    >>> swexml = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'r').read()
+    >>> dr = etree.fromstring(swexml)
     >>> if hasattr(dr, 'getroot'):
     ...     dr = dr.getroot()
     >>> swe_dr = DataRecord(dr)
 
 Test
 
-    # two fields, 'stations' and 'observationData'
+# two fields, 'stations' and 'observationData'
     >>> len(swe_dr.field)
     2
     >>> swe_dr.definition
     'http://mmisw.org/ont/ioos/definition/observationRecord'
 
-    >>> stations_field              = swe_dr.get_by_name("stations")
+    >>> stations_field = swe_dr.get_by_name('stations')
     >>> stations_field.name
     'stations'
 
     # Single station
-    >>> single_station_field        = stations_field.content.get_by_name("wmo_41001")
+    >>> single_station_field = stations_field.content.get_by_name('wmo_41001')
     >>> single_station_field.name
     'wmo_41001'
 
-    >>> single_station_dr           = single_station_field.content
+    >>> single_station_dr = single_station_field.content
     >>> single_station_dr.id
     'wmo_41001'
 
@@ -39,45 +39,43 @@ Test
     >>> single_station_dr.definition
     'http://mmisw.org/ont/ioos/definition/station'
 
-
-    >>> single_station_dr.get_by_name("stationID").content.definition
+    >>> single_station_dr.get_by_name('stationID').content.definition
     'http://mmisw.org/ont/ioos/definition/stationID'
-    >>> single_station_dr.get_by_name("stationID").content.value
+    >>> single_station_dr.get_by_name('stationID').content.value
     'urn:ioos:station:wmo:41001'
 
-    >>> vector = single_station_dr.get_by_name("platformLocation").content
+    >>> vector = single_station_dr.get_by_name('platformLocation').content
     >>> len(vector.coordinate)
     3
-    >>> int(vector.get_by_name("latitude").content.value)
+    >>> int(vector.get_by_name('latitude').content.value)
     32
-    >>> int(vector.get_by_name("longitude").content.value)
+    >>> int(vector.get_by_name('longitude').content.value)
     -75
-    >>> int(vector.get_by_name("height").content.value)
+    >>> int(vector.get_by_name('height').content.value)
     0
 
-
-    >>> data_field              = swe_dr.get_by_name("observationData")
+    >>> data_field = swe_dr.get_by_name('observationData')
     >>> data_field.name
     'observationData'
-    >>> data_et                 = data_field.content.elementType
+    >>> data_et = data_field.content.elementType
     >>> data_et.name
     'observations'
 
-    >>> data_choice             = data_et.content.get_by_name("sensor").content
+    >>> data_choice = data_et.content.get_by_name('sensor').content
 
     # 5 sensor choices for the csv block
     >>> len(data_choice.item)
     5
-    >>> sensor_dr               = data_choice.get_by_name("wmo_41001_sensor1").content
+    >>> sensor_dr = data_choice.get_by_name('wmo_41001_sensor1').content
 
-    >>> sensor_dr.get_by_name("air_temperature").content.uom
+    >>> sensor_dr.get_by_name('air_temperature').content.uom
     'Celsius'
-    >>> sensor_dr.get_by_name("wind_speed").content.uom
+    >>> sensor_dr.get_by_name('wind_speed').content.uom
     'm/s'
-    >>> sensor_dr.get_by_name("wind_to_direction").content.uom
+    >>> sensor_dr.get_by_name('wind_to_direction').content.uom
     'degrees'
 
-    >>> encoding                        = data_field.content.encoding
+    >>> encoding = data_field.content.encoding
     >>> encoding.tokenSeparator
     ','
     >>> encoding.blockSeparator

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -6,7 +6,7 @@ Imports
 
 Initialize
 
-    >>> swexml = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'r').read()
+    >>> swexml = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'rb').read()
     >>> dr = etree.fromstring(swexml)
     >>> if hasattr(dr, 'getroot'):
     ...     dr = dr.getroot()

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -59,18 +59,22 @@ The details of the TileMap are fetched on demand
     (-180.0, -90.0)
 
 You can get tiles by their x,y,z indices, the title of the tilemap, projection and mime-type
-    >>> service.gettile(10, 10, 0, title='bluemarble', srs='EPSG:4326', mimetype='image/png').geturl()
-    'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@png/0/10/10.png?'
-    >>> service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:4326', mimetype='image/jpeg').geturl()
-    'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@jpeg/1/10/10.jpeg?'
+    >>> url = service.gettile(10, 10, 0, title='bluemarble', srs='EPSG:4326', mimetype='image/png').geturl()
+    >>> url == 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@png/0/10/10.png?'
+    True
+    >>> url = service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:4326', mimetype='image/jpeg').geturl()
+    >>> url == 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@jpeg/1/10/10.jpeg?'
+    True
 
 if mimetype is ommited the tile is fetched from the first TileMap found:
-    >>> service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:900913').geturl()
-    'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg/1/10/10.jpeg?'
+    >>> url = service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:900913').geturl()
+    >>> url == 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@png/1/10/10.png?'
+    True
 
 You can also specify the Tilemap by id:
-    >>> service.gettile(10, 10, 0, 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg').geturl()
-    'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg/0/10/10.jpeg?'
+    >>> url = service.gettile(10, 10, 0, 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg').geturl()
+    >>> url == 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg/0/10/10.jpeg?'
+    True
 
 An extensive test with:
     >>> servers = [

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -22,7 +22,7 @@ Find out what a TMS has to offer. Service metadata:
     'bluemarble'
 
 you can filter the contents by profile and srs:
-    >>> len(service.items())
+    >>> len(list(service.items()))
     14
     >>> len(service.items('EPSG:900913'))
     7
@@ -36,12 +36,12 @@ you can filter the contents by profile and srs:
     ('http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@png', <owslib.tms.ContentMetadata object at ...>)
 
 The details of the TileMap are fetched on demand
-    >>> tm._tile_map == None
+    >>> tm._tile_map is None
     True
     >>> tm.title
     'bluemarble'
     >>> tm.abstract
-    >>> tm._tile_map == None
+    >>> tm._tile_map is None
     False
     >>> tm.srs
     'EPSG:4326'
@@ -58,24 +58,21 @@ The details of the TileMap are fetched on demand
     >>> tm.origin
     (-180.0, -90.0)
 
-
-
-
 You can get tiles by their x,y,z indices, the title of the tilemap, projection and mime-type
-    >>> service.gettile(10,10,0, title='bluemarble', srs='EPSG:4326', mimetype='image/png').geturl()
+    >>> service.gettile(10, 10, 0, title='bluemarble', srs='EPSG:4326', mimetype='image/png').geturl()
     'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@png/0/10/10.png?'
-    >>> service.gettile(10,10,1, title='bluemarble', srs='EPSG:4326', mimetype='image/jpeg').geturl()
+    >>> service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:4326', mimetype='image/jpeg').geturl()
     'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@jpeg/1/10/10.jpeg?'
 
 if mimetype is ommited the tile is fetched from the first TileMap found:
-    >>> service.gettile(10,10,1, title='bluemarble', srs='EPSG:900913').geturl()
+    >>> service.gettile(10, 10, 1, title='bluemarble', srs='EPSG:900913').geturl()
     'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg/1/10/10.jpeg?'
 
 You can also specify the Tilemap by id:
-    >>> service.gettile(10,10,0, 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg').geturl()
+    >>> service.gettile(10, 10, 0, 'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg').geturl()
     'http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A900913@jpeg/0/10/10.jpeg?'
 
-An extensive test  with:
+An extensive test with:
     >>> servers = [
     ...     'http://maps.opengeo.org/geowebcache/service/tms/1.0.0',
     ...     'http://demo.opengeo.org/geoserver/gwc/service/tms/1.0.0',
@@ -106,9 +103,3 @@ An extensive test  with:
 #    ...         tm.boundingBox
 #    ...         tm.origin
 #    ...         tm.type
-
-
-
-
-
-

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -22,7 +22,7 @@ Find out what a TMS has to offer. Service metadata:
     'bluemarble'
 
 you can filter the contents by profile and srs:
-    >>> len(list(service.items()))
+    >>> len(service.items())
     14
     >>> len(service.items('EPSG:900913'))
     7

--- a/tests/doctests/wcs_idee.txt
+++ b/tests/doctests/wcs_idee.txt
@@ -16,8 +16,8 @@ WCS Version 1.0.0
     'WCS UTM30N - MDT Peninsula y Baleares'
     >>> wcs.identification.service
     'IDEE-WCS-UTM30N'
-    >>> wcs.provider.name
-    u'Instituto Geogr\xe1fico Nacional'
+    >>> wcs.provider.name == u'Instituto Geogr\xe1fico Nacional'
+    True
     >>> sorted(wcs.contents.keys())
     ['MDT1000_peninsula_baleares', 'MDT1000_peninsula_baleares_aspecto', 'MDT1000_peninsula_baleares_pendientes', 'MDT25_peninsula_ZIP', 'MDT25_peninsula_aspecto', 'MDT25_peninsula_pendientes', 'MDT500_peninsula_baleares', 'MDT500_peninsula_baleares_aspecto', 'MDT500_peninsula_baleares_pendientes', 'MDT_peninsula_baleares', 'MDT_peninsula_baleares_aspecto', 'MDT_peninsula_baleares_pendientes']
     >>> cvg = wcs['MDT25_peninsula_pendientes']
@@ -33,5 +33,5 @@ WCS Version 1.0.0
     ['EPSG:23028', 'EPSG:23029', 'EPSG:23030', 'EPSG:23030', 'EPSG:23031', 'EPSG:4230', 'EPSG:4326']
     >>> output = wcs.getCoverage(identifier='MDT25_peninsula_pendientes', bbox=(600000, 4200000, 601000, 4201000), crs='EPSG:23030', format='AsciiGrid', resX=25, resY=25)
     >>> f = open(scratch_file('test_idee.grd'), 'wb')
-    >>> f.write(output.read())
+    >>> written_bytes = f.write(output.read())
     >>> f.close()

--- a/tests/doctests/wcs_idee.txt
+++ b/tests/doctests/wcs_idee.txt
@@ -7,7 +7,7 @@ WCS Version 1.0.0
     >>> from tests.utils import cast_tuple_int_list, scratch_file
     >>> from owslib.wcs import WebCoverageService
 
-    >>> wcs=WebCoverageService('http://www.idee.es/wcs/IDEE-WCS-UTM30N/wcsServlet')
+    >>> wcs = WebCoverageService('http://www.idee.es/wcs/IDEE-WCS-UTM30N/wcsServlet')
     >>> wcs.version
     '1.0.0'
     >>> wcs.url
@@ -20,7 +20,7 @@ WCS Version 1.0.0
     u'Instituto Geogr\xe1fico Nacional'
     >>> sorted(wcs.contents.keys())
     ['MDT1000_peninsula_baleares', 'MDT1000_peninsula_baleares_aspecto', 'MDT1000_peninsula_baleares_pendientes', 'MDT25_peninsula_ZIP', 'MDT25_peninsula_aspecto', 'MDT25_peninsula_pendientes', 'MDT500_peninsula_baleares', 'MDT500_peninsula_baleares_aspecto', 'MDT500_peninsula_baleares_pendientes', 'MDT_peninsula_baleares', 'MDT_peninsula_baleares_aspecto', 'MDT_peninsula_baleares_pendientes']
-    >>> cvg=wcs['MDT25_peninsula_pendientes']
+    >>> cvg = wcs['MDT25_peninsula_pendientes']
     >>> cvg.title
     'MDT25 Pendientes Peninsula'
     >>> cast_tuple_int_list(cvg.boundingBoxWGS84)
@@ -29,9 +29,9 @@ WCS Version 1.0.0
     []
     >>> sorted(cvg.supportedFormats)
     ['AsciiGrid', 'FloatGrid_Zip', 'GeoTIFF']
-    >>> sorted(map(lambda x: x.getcode(), cvg.supportedCRS))
+    >>> sorted([x.getcode() for x in cvg.supportedCRS])
     ['EPSG:23028', 'EPSG:23029', 'EPSG:23030', 'EPSG:23030', 'EPSG:23031', 'EPSG:4230', 'EPSG:4326']
-    >>> output=wcs.getCoverage(identifier='MDT25_peninsula_pendientes',bbox=(600000,4200000,601000,4201000),crs='EPSG:23030', format='AsciiGrid', resX=25, resY=25)
-    >>> f=open(scratch_file('test_idee.grd'), 'wb')
+    >>> output = wcs.getCoverage(identifier='MDT25_peninsula_pendientes', bbox=(600000, 4200000, 601000, 4201000), crs='EPSG:23030', format='AsciiGrid', resX=25, resY=25)
+    >>> f = open(scratch_file('test_idee.grd'), 'wb')
     >>> f.write(output.read())
     >>> f.close()

--- a/tests/doctests/wcs_thredds.txt
+++ b/tests/doctests/wcs_thredds.txt
@@ -91,5 +91,5 @@ Print the ids of all layers (actually just the first 3):
 # Then write this to a netcdf file.
     >>> filename = scratch_file('threddstest.nc')
     >>> f = open(filename, 'wb')
-    >>> f.write(output.read())
+    >>> written_bytes = f.write(output.read())
     >>> f.close()

--- a/tests/doctests/wcs_thredds.txt
+++ b/tests/doctests/wcs_thredds.txt
@@ -9,7 +9,7 @@ Imports
     >>> from owslib.wcs import WebCoverageService
     >>> from tests.utils import scratch_file
 
-    >>> wcs=WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')
+    >>> wcs = WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')
     >>> wcs.url
     'http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best'
     >>> wcs.version
@@ -26,34 +26,34 @@ Imports
     >>> wcs.identification.accessConstraints
     'NONE'
 
-#There is no 'ResponsibleParty' information in the NCEP/NAM capabilities document, so wcs.provider is empty.
-#but if there was you could do:
-#wcs.provider.url
-#and..
-#wcs.provider.contact.organization
-#wcs.provider.contact.email
-#wcs.provider.contact.address
-#etc... for region, city, postcode, country
+# There is no 'ResponsibleParty' information in the NCEP/NAM capabilities document, so wcs.provider is empty.
+# but if there was you could do:
+# wcs.provider.url
+# and..
+# wcs.provider.contact.organization
+# wcs.provider.contact.email
+# wcs.provider.contact.address
+# etc... for region, city, postcode, country
 
 Print the ids of all layers (actually just the first 3):
-   >>> sorted(wcs.contents.keys())
-   ['Absolute_vorticity_isobaric', 'Best_4_layer_lifted_index_layer_between_two_pressure_difference_from_ground_layer', 'Convective_Available_Potential_Energy_layer_between_two_pressure_difference_from_ground_layer', 'Convective_Available_Potential_Energy_surface', 'Convective_inhibition_layer_between_two_pressure_difference_from_ground_layer', 'Convective_inhibition_surface', 'Convective_precipitation_surface_Mixed_intervals_Accumulation', 'Geopotential_height_isobaric', 'Geopotential_height_surface', 'Geopotential_height_zeroDegC_isotherm', 'Mean_Sea_Level_Pressure_NAM_Model_Reduction_msl', 'Parcel_lifted_index_to_500_hPa_layer_between_two_pressure_difference_from_ground_layer', 'Precipitable_water_entire_atmosphere', 'Pressure_cloud_base', 'Pressure_cloud_tops', 'Pressure_maximum_wind', 'Pressure_reduced_to_MSL_msl', 'Pressure_surface', 'Pressure_tropopause', 'Relative_humidity_height_above_ground', 'Relative_humidity_isobaric', 'Relative_humidity_layer_between_two_pressure_difference_from_ground_layer', 'Relative_humidity_zeroDegC_isotherm', 'Storm_relative_helicity_layer_between_two_heights_above_ground_layer', 'Temperature_cloud_tops', 'Temperature_height_above_ground', 'Temperature_isobaric', 'Temperature_layer_between_two_pressure_difference_from_ground_layer', 'Temperature_tropopause', 'Total_precipitation_surface_Mixed_intervals_Accumulation', 'Vertical_velocity_pressure_isobaric', 'u-component_of_wind_height_above_ground', 'u-component_of_wind_isobaric', 'u-component_of_wind_layer_between_two_pressure_difference_from_ground_layer', 'u-component_of_wind_maximum_wind', 'u-component_of_wind_tropopause', 'v-component_of_wind_height_above_ground', 'v-component_of_wind_isobaric', 'v-component_of_wind_layer_between_two_pressure_difference_from_ground_layer', 'v-component_of_wind_maximum_wind', 'v-component_of_wind_tropopause']
+    >>> sorted(wcs.contents.keys())
+    ['Absolute_vorticity_isobaric', 'Best_4_layer_lifted_index_layer_between_two_pressure_difference_from_ground_layer', 'Convective_Available_Potential_Energy_layer_between_two_pressure_difference_from_ground_layer', 'Convective_Available_Potential_Energy_surface', 'Convective_inhibition_layer_between_two_pressure_difference_from_ground_layer', 'Convective_inhibition_surface', 'Convective_precipitation_surface_Mixed_intervals_Accumulation', 'Geopotential_height_isobaric', 'Geopotential_height_surface', 'Geopotential_height_zeroDegC_isotherm', 'Mean_Sea_Level_Pressure_NAM_Model_Reduction_msl', 'Parcel_lifted_index_to_500_hPa_layer_between_two_pressure_difference_from_ground_layer', 'Precipitable_water_entire_atmosphere', 'Pressure_cloud_base', 'Pressure_cloud_tops', 'Pressure_maximum_wind', 'Pressure_reduced_to_MSL_msl', 'Pressure_surface', 'Pressure_tropopause', 'Relative_humidity_height_above_ground', 'Relative_humidity_isobaric', 'Relative_humidity_layer_between_two_pressure_difference_from_ground_layer', 'Relative_humidity_zeroDegC_isotherm', 'Storm_relative_helicity_layer_between_two_heights_above_ground_layer', 'Temperature_cloud_tops', 'Temperature_height_above_ground', 'Temperature_isobaric', 'Temperature_layer_between_two_pressure_difference_from_ground_layer', 'Temperature_tropopause', 'Total_precipitation_surface_Mixed_intervals_Accumulation', 'Vertical_velocity_pressure_isobaric', 'u-component_of_wind_height_above_ground', 'u-component_of_wind_isobaric', 'u-component_of_wind_layer_between_two_pressure_difference_from_ground_layer', 'u-component_of_wind_maximum_wind', 'u-component_of_wind_tropopause', 'v-component_of_wind_height_above_ground', 'v-component_of_wind_isobaric', 'v-component_of_wind_layer_between_two_pressure_difference_from_ground_layer', 'v-component_of_wind_maximum_wind', 'v-component_of_wind_tropopause']
 
 
-#To further interrogate a single "coverage" get the coverageMetadata object
-#You can either do:
-    >>> cvg= wcs.contents['Temperature_tropopause'] #to get it from the dictonary
+# To further interrogate a single "coverage" get the coverageMetadata object
+# You can either do:
+    >>> cvg = wcs.contents['Temperature_tropopause']  # to get it from the dictonary
 
-#or even simpler you can do:
-    >>> cvg=wcs['Temperature_tropopause']
+# or even simpler you can do:
+    >>> cvg = wcs['Temperature_tropopause']
 
     >>> cvg.boundingBoxWGS84
     (-153.58891112103777, 11.747698396806157, -48.598408556239576, 57.484319872365305)
 
-    >>> len(cvg.timepositions)>1 #The old test kept failing as the response timepositions kept changign on the server
+    >>> len(cvg.timepositions) > 1  # The old test kept failing as the response timepositions kept changign on the server
     True
 
-    >>> filter(None, map(lambda x: x.getcode(), cvg.supportedCRS))
+    >>> [c for c in [x.getcode() for x in cvg.supportedCRS] if c]
     ['EPSG:9802']
 
     >>> cvg.supportedFormats
@@ -78,18 +78,18 @@ Print the ids of all layers (actually just the first 3):
     [['81.27100405485734', '0.0'], ['0.0', '81.27100086212158']]
 
 
-#Now we have enough information to build a getCoverage request:
-    >>> covID='Temperature_tropopause'
-    >>> timeRange=['2009-01-08T06:00:00',  '2009-01-08T12:00:00']  #Okay, you should be able to select a range of times, but the server doesn't seem to like it.
-    >>> timeRange=[cvg.timepositions[10]] #So for now I'll just  choose one timestep (from cvg.timepositions)
-    >>> bb=(-140, -15, 30, 55) # chosen from cvg.boundingBoxWGS84
-    >>> formatType='NetCDF3' # chosen from cvg.supportedFormats
+# Now we have enough information to build a getCoverage request:
+    >>> covID = 'Temperature_tropopause'
+    >>> timeRange = ['2009-01-08T06:00:00', '2009-01-08T12:00:00']  # Okay, you should be able to select a range of times, but the server doesn't seem to like it.
+    >>> timeRange = [cvg.timepositions[10]]  # So for now I'll just  choose one timestep (from cvg.timepositions)
+    >>> bb = (-140, -15, 30, 55)  # chosen from cvg.boundingBoxWGS84
+    >>> formatType = 'NetCDF3'  # chosen from cvg.supportedFormats
 
-#Make the actual getCoverage request.
-    >>> output=wcs.getCoverage(identifier=covID,time=timeRange,bbox=bb, format=formatType)
+# Make the actual getCoverage request.
+    >>> output = wcs.getCoverage(identifier=covID, time=timeRange, bbox=bb, format=formatType)
 
-#Then write this to a netcdf file.
+# Then write this to a netcdf file.
     >>> filename = scratch_file('threddstest.nc')
-    >>> f=open(filename, 'wb')
+    >>> f = open(filename, 'wb')
     >>> f.write(output.read())
     >>> f.close()

--- a/tests/doctests/wfs1_generic.txt
+++ b/tests/doctests/wfs1_generic.txt
@@ -3,7 +3,7 @@ Imports and initialize
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 
-    >>> getcapsin = open(resource_file('wfs_HSRS_GetCapabilities_1_1_0.xml')).read()
+    >>> getcapsin = open(resource_file('wfs_HSRS_GetCapabilities_1_1_0.xml'), 'rb').read()
     >>> wfs = WebFeatureService('http://gis.bnhelp.cz/ows/crwfs', xml=getcapsin, version='1.1.0')
 
 Test the capabilities info
@@ -27,8 +27,8 @@ Test the capabilities info
     'http://www.hsrs.cz'
     >>> wfs.provider.contact.email
     >>> wfs.provider.contact.phone
-    >>> wfs.provider.contact.name
-    u'Stanislav Hol\xfd'
+    >>> wfs.provider.contact.name == u'Stanislav Hol\xfd'
+    True
     >>> wfs.provider.contact.organization
     >>> wfs.provider.contact.city
     >>> wfs.provider.contact.region
@@ -59,21 +59,21 @@ WFS 1.0.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
     >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
-    >>> json.dumps(json.loads(feature.read()))
+    >>> json.dumps(json.loads(feature.read().decode('utf8')))
     '{...}'
 
 WFS 1.1.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.1.0')
     >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
-    >>> json.dumps(json.loads(feature.read()))
+    >>> json.dumps(json.loads(feature.read().decode('utf8')))
     '{...}'
 
 WFS 2.0.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='2.0.0')
     >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
-    >>> json.dumps(json.loads(feature.read()))
+    >>> json.dumps(json.loads(feature.read().decode('utf8')))
     '{...}'
 
 
@@ -82,7 +82,7 @@ Test srsName
 WFS 1.0.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')  # doctest: +IGNORE_EXCEPTION_DETAIL
     ...
     Traceback (most recent call last):
     ...
@@ -92,13 +92,13 @@ WFS 1.0.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
     >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='urn:x-ogc:def:crs:EPSG:4326')
-    >>> json.dumps(json.loads(feature.read()))
+    >>> json.dumps(json.loads(feature.read().decode('utf8')))
     '{...}'
 
 WFS 1.1.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.1.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')  # doctest: +IGNORE_EXCEPTION_DETAIL
     ...
     Traceback (most recent call last):
     ...
@@ -107,5 +107,5 @@ WFS 1.1.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
     >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='urn:x-ogc:def:crs:EPSG:4326')
-    >>> json.dumps(json.loads(feature.read()))
+    >>> json.dumps(json.loads(feature.read().decode('utf8')))
     '{...}'

--- a/tests/doctests/wfs1_generic.txt
+++ b/tests/doctests/wfs1_generic.txt
@@ -1,10 +1,9 @@
 Imports and initialize
 
     >>> from owslib.wfs import WebFeatureService
-    >>> from urlparse import urlparse
     >>> from tests.utils import resource_file, sorted_url_query
 
-    >>> getcapsin = open(resource_file("wfs_HSRS_GetCapabilities_1_1_0.xml")).read()
+    >>> getcapsin = open(resource_file('wfs_HSRS_GetCapabilities_1_1_0.xml')).read()
     >>> wfs = WebFeatureService('http://gis.bnhelp.cz/ows/crwfs', xml=getcapsin, version='1.1.0')
 
 Test the capabilities info
@@ -47,10 +46,10 @@ Test the getfeature method
     >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['okresy'], maxfeatures=2))
     ['maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=okresy', 'version=1.1.0']
 
-    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['okresy'], maxfeatures=2, bbox=[15,49,16,51,'urn:ogc:def:crs:EPSG:4326']))
+    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['okresy'], maxfeatures=2, bbox=[15, 49, 16, 51, 'urn:ogc:def:crs:EPSG:4326']))
     ['bbox=49%2C15%2C51%2C16%2Curn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326', 'maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=okresy', 'version=1.1.0']
 
-    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['okresy'], maxfeatures=2, bbox=[-685336,-993518,-684996,-993285]))
+    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['okresy'], maxfeatures=2, bbox=[-685336, -993518, -684996, -993285]))
     ['bbox=-993518%2C-685336%2C-993285%2C-684996%2Curn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326', 'maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=okresy', 'version=1.1.0']
 
 
@@ -83,7 +82,7 @@ Test srsName
 WFS 1.0.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname="EPSG:99999999")
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')
     ...
     Traceback (most recent call last):
     ...
@@ -92,14 +91,14 @@ WFS 1.0.0
 
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname="urn:x-ogc:def:crs:EPSG:4326")
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='urn:x-ogc:def:crs:EPSG:4326')
     >>> json.dumps(json.loads(feature.read()))
     '{...}'
 
 WFS 1.1.0
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.1.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname="EPSG:99999999")
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='EPSG:99999999')
     ...
     Traceback (most recent call last):
     ...
@@ -107,6 +106,6 @@ WFS 1.1.0
 
     >>> import json
     >>> wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288', version='1.0.0')
-    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname="urn:x-ogc:def:crs:EPSG:4326")
+    >>> feature = wfs.getfeature(typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json', srsname='urn:x-ogc:def:crs:EPSG:4326')
     >>> json.dumps(json.loads(feature.read()))
     '{...}'

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -3,7 +3,7 @@ Imports and initialize
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 
-    >>> getcapsin = open(resource_file('wfs_CUZK_GetCapabilities_2_0_0.xml')).read()
+    >>> getcapsin = open(resource_file('wfs_CUZK_GetCapabilities_2_0_0.xml'), 'rb').read()
     >>> wfs = WebFeatureService('http://services.cuzk.cz/wfs/inspire-cp-wfs.asp', xml=getcapsin, version='2.0.0')
 
 Test the capabilities info

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -3,7 +3,7 @@ Imports and initialize
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 
-    >>> getcapsin = open(resource_file("wfs_CUZK_GetCapabilities_2_0_0.xml")).read()
+    >>> getcapsin = open(resource_file('wfs_CUZK_GetCapabilities_2_0_0.xml')).read()
     >>> wfs = WebFeatureService('http://services.cuzk.cz/wfs/inspire-cp-wfs.asp', xml=getcapsin, version='2.0.0')
 
 Test the capabilities info
@@ -44,8 +44,8 @@ Test the getfeature method
     >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['CP:CadastralBoundary'], maxfeatures=2))
     ['maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=CP%3ACadastralBoundary', 'version=2.0.0']
 
-    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['CP:CadastralBoundary'], maxfeatures=2, bbox=[15,49,16,51,'urn:ogc:def:crs:EPSG:4326']))
+    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['CP:CadastralBoundary'], maxfeatures=2, bbox=[15, 49, 16, 51, 'urn:ogc:def:crs:EPSG:4326']))
     ['bbox=49%2C15%2C51%2C16%2Curn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326', 'maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=CP%3ACadastralBoundary', 'version=2.0.0']
 
-    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['CP:CadastralBoundary'], maxfeatures=2, bbox=[-685336,-993518,-684996,-993285]))
+    >>> sorted_url_query(wfs.getGETGetFeatureRequest(typename=['CP:CadastralBoundary'], maxfeatures=2, bbox=[-685336, -993518, -684996, -993285]))
     ['bbox=-685336%2C-993518%2C-684996%2C-993285%2Curn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A102067', 'maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=CP%3ACadastralBoundary', 'version=2.0.0']

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -6,7 +6,7 @@ Imports
 
 Fake a request to a WFS Server using saved doc from.
 
-    >>> xml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('mapserver-wfs-cap.xml'), 'rb').read()
     >>> wfs = WebFeatureService('url', version='1.0', xml=xml)
 
 Test capabilities
@@ -99,5 +99,5 @@ Lastly, test the getcapabilities method
 
     >>> wfs = WebFeatureService('http://www.bsc-eoc.org/cgi-bin/bsc_ows.asp?', version='1.0')
     >>> xml = wfs.getcapabilities().read()
-    >>> xml.find('<WFS_Capabilities') > 0
+    >>> xml.find('<WFS_Capabilities'.encode('utf8')) > 0
     True

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -42,7 +42,7 @@ Service Provider:
     >>> wfs.provider.url
     'http://geodiscover.cgdi.ca/gdp/search?action=entrySummary&entryType=webService&entryId=3920&entryLang=en&portal=gdp'
 
-    #TODO: test contact info:
+    # TODO: test contact info:
     #>>> wfs.provider.contact.name
 
 
@@ -64,7 +64,7 @@ Test single item accessor
     >>> cast_tuple_int_list(wfs['IBA'].boundingBoxWGS84)
     [-141, 41, -52, 78]
 
-    >>> map(lambda x: x.getcode(), wfs['IBA'].crsOptions)
+    >>> [x.getcode() for x in wfs['IBA'].crsOptions]
     ['EPSG:4326']
 
     >>> wfs['IBA'].verbOptions
@@ -101,4 +101,3 @@ Lastly, test the getcapabilities method
     >>> xml = wfs.getcapabilities().read()
     >>> xml.find('<WFS_Capabilities') > 0
     True
-

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -7,12 +7,12 @@ Test the getfeature method
 
     >>> wfs = WebFeatureService('http://www.bsc-eoc.org/cgi-bin/bsc_ows.asp?', version='1.0.0')
     >>> response = wfs.getfeature(typename=['IBA'], maxfeatures=5)
-    >>> response.read().find('<wfs:FeatureCollection') > 0
+    >>> response.read().find('<wfs:FeatureCollection'.encode('utf8')) > 0
     True
 
 Handle service exception
 
-    >>> response = wfs.getfeature(typename=['totally bogus'], maxfeatures=5)
+    >>> response = wfs.getfeature(typename=['totally bogus'], maxfeatures=5)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     ServiceException: msWFSGetFeature(): WFS server error. TYPENAME 'totally bogus' doesn't exist in this server.  Please check the capabilities and reformulate your request.

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -2,7 +2,7 @@
 Imports
 
     >>> from owslib.wfs import WebFeatureService
-    
+
 Test the getfeature method
 
     >>> wfs = WebFeatureService('http://www.bsc-eoc.org/cgi-bin/bsc_ows.asp?', version='1.0.0')
@@ -16,4 +16,3 @@ Handle service exception
     Traceback (most recent call last):
     ...
     ServiceException: msWFSGetFeature(): WFS server error. TYPENAME 'totally bogus' doesn't exist in this server.  Please check the capabilities and reformulate your request.
-

--- a/tests/doctests/wfs_USDASSURGO.txt
+++ b/tests/doctests/wfs_USDASSURGO.txt
@@ -3,7 +3,7 @@
 
 >>> import unittest
 >>> from owslib.wfs import WebFeatureService
->>> wfs_filter = "<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName='EPSG:4326'><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>"
+>>> wfs_filter = '<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName="EPSG:4326"><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>'
 >>> wfs = WebFeatureService('http://SDMDataAccess.nrcs.usda.gov/Spatial/SDMWGS84Geographic.wfs', version='1.0.0')
 >>> response = wfs.getfeature(typename=('MapunitPolyExtended',), filter=wfs_filter, propertyname=None)
 >>> response.read().find('<wfs:FeatureCollection') > 0

--- a/tests/doctests/wfs_USDASSURGO.txt
+++ b/tests/doctests/wfs_USDASSURGO.txt
@@ -6,5 +6,5 @@
 >>> wfs_filter = '<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName="EPSG:4326"><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>'
 >>> wfs = WebFeatureService('http://SDMDataAccess.nrcs.usda.gov/Spatial/SDMWGS84Geographic.wfs', version='1.0.0')
 >>> response = wfs.getfeature(typename=('MapunitPolyExtended',), filter=wfs_filter, propertyname=None)
->>> response.read().find('<wfs:FeatureCollection') > 0
+>>> response.read().find('<wfs:FeatureCollection'.encode('utf8')) > 0
 True

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -5,7 +5,7 @@ Imports
 
 Test GetSiteInfo
 
-    >>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'r').read()
+    >>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'rb').read()
     >>> response = wml(f).response
 
     >>> response.site_names
@@ -27,7 +27,7 @@ Test GetSiteInfo
 
 Test GetValues
 
-    >>> f = open(resource_file('cuahsi_example_get_values_10.xml')).read()
+    >>> f = open(resource_file('cuahsi_example_get_values_10.xml'), 'rb').read()
     >>> response = wml(f).response
 
     >>> response.variable_names

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -1,42 +1,41 @@
 Imports
 
-	>>> from tests.utils import resource_file
-	>>> from owslib.waterml.wml10 import WaterML_1_0 as wml
+    >>> from tests.utils import resource_file
+    >>> from owslib.waterml.wml10 import WaterML_1_0 as wml
 
 Test GetSiteInfo
 
-	>>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'r').read()
-	>>> response = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'r').read()
+    >>> response = wml(f).response
 
-	>>> response.site_names
-	['Little Bear River at Mendon Road near Mendon, Utah']
-	>>> site = response.sites[0]
-	>>> sorted(site.variable_names)
-	['Battery voltage', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'pH, unfiltered']
-	>>> codes = site.variable_codes
-	>>> sorted(codes)
-        ['USU10', 'USU11', 'USU12', 'USU13', 'USU3', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU37', 'USU39', 'USU4', 'USU40', 'USU41', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
-	>>> var = site['USU9']
-	>>> var.unit.name
-	'nephelometric turbidity units'
-	>>> var.unit.id
-	>>> var.notes
-	{}
-	>>> var.no_data_value
-	'-9999'
+    >>> response.site_names
+    ['Little Bear River at Mendon Road near Mendon, Utah']
+    >>> site = response.sites[0]
+    >>> sorted(site.variable_names)
+    ['Battery voltage', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'pH, unfiltered']
+    >>> codes = site.variable_codes
+    >>> sorted(codes)
+    ['USU10', 'USU11', 'USU12', 'USU13', 'USU3', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU37', 'USU39', 'USU4', 'USU40', 'USU41', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
+    >>> var = site['USU9']
+    >>> var.unit.name
+    'nephelometric turbidity units'
+    >>> var.unit.id
+    >>> var.notes
+    {}
+    >>> var.no_data_value
+    '-9999'
 
 Test GetValues
 
-	>>> f = open(resource_file('cuahsi_example_get_values_10.xml')).read()
-	>>> response = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_get_values_10.xml')).read()
+    >>> response = wml(f).response
 
-	>>> response.variable_names
-	['Phosphorus, total as P']
-	>>> response.variable_codes
-	['USU39']
-	>>> series = response.get_series_by_variable('Phosphorus, total as P')
-	>>> series = series[0]
-	>>> values = series.values[0]
-	>>> values.get_date_values()
-	[(datetime.datetime(2008, 4, 14, 13, 0), '0.1192'), (datetime.datetime(2008, 4, 14, 13, 0), '0.114'), (datetime.datetime(2008, 4, 14, 14, 0), '0.1424'), (datetime.datetime(2008, 4, 14, 15, 0), '0.1814'), (datetime.datetime(2008, 4, 14, 16, 0), '0.3841'), (datetime.datetime(2008, 4, 14, 18, 0), '0.9124'), (datetime.datetime(2008, 4, 14, 20, 0), '0.0655'), (datetime.datetime(2008, 4, 14, 21, 0), '0.4342'), (datetime.datetime(2008, 4, 14, 22, 0), '0.9543'), (datetime.datetime(2008, 4, 14, 23, 0), '0.7308'), (datetime.datetime(2008, 4, 14, 23, 0), '0.7004'), (datetime.datetime(2008, 4, 15, 0, 0), '0.6097'), (datetime.datetime(2008, 4, 15, 1, 0), '0.5544'), (datetime.datetime(2008, 4, 15, 1, 0), '0.6182'), (datetime.datetime(2008, 4, 15, 1, 0), '0.5476'), (datetime.datetime(2008, 4, 15, 2, 0), '0.5728'), (datetime.datetime(2008, 4, 15, 2, 0), '0.369'), (datetime.datetime(2008, 4, 15, 2, 0), '0.3664'), (datetime.datetime(2008, 4, 15, 2, 0), '0.4767'), (datetime.datetime(2008, 4, 15, 3, 0), '0.3144'), (datetime.datetime(2008, 4, 15, 4, 0), '0.4517'), (datetime.datetime(2008, 4, 15, 5, 0), '0.3838'), (datetime.datetime(2008, 4, 15, 6, 0), '0.4702'), (datetime.datetime(2008, 4, 15, 7, 0), '0.389'), (datetime.datetime(2008, 4, 15, 8, 0), '0.4949'), (datetime.datetime(2008, 4, 15, 9, 0), '0.2778'), (datetime.datetime(2008, 4, 15, 10, 0), '0.3576'), (datetime.datetime(2008, 4, 15, 11, 0), '0.3618'), (datetime.datetime(2008, 4, 15, 12, 0), '0.2803')]
-
+    >>> response.variable_names
+    ['Phosphorus, total as P']
+    >>> response.variable_codes
+    ['USU39']
+    >>> series = response.get_series_by_variable('Phosphorus, total as P')
+    >>> series = series[0]
+    >>> values = series.values[0]
+    >>> values.get_date_values()
+    [(datetime.datetime(2008, 4, 14, 13, 0), '0.1192'), (datetime.datetime(2008, 4, 14, 13, 0), '0.114'), (datetime.datetime(2008, 4, 14, 14, 0), '0.1424'), (datetime.datetime(2008, 4, 14, 15, 0), '0.1814'), (datetime.datetime(2008, 4, 14, 16, 0), '0.3841'), (datetime.datetime(2008, 4, 14, 18, 0), '0.9124'), (datetime.datetime(2008, 4, 14, 20, 0), '0.0655'), (datetime.datetime(2008, 4, 14, 21, 0), '0.4342'), (datetime.datetime(2008, 4, 14, 22, 0), '0.9543'), (datetime.datetime(2008, 4, 14, 23, 0), '0.7308'), (datetime.datetime(2008, 4, 14, 23, 0), '0.7004'), (datetime.datetime(2008, 4, 15, 0, 0), '0.6097'), (datetime.datetime(2008, 4, 15, 1, 0), '0.5544'), (datetime.datetime(2008, 4, 15, 1, 0), '0.6182'), (datetime.datetime(2008, 4, 15, 1, 0), '0.5476'), (datetime.datetime(2008, 4, 15, 2, 0), '0.5728'), (datetime.datetime(2008, 4, 15, 2, 0), '0.369'), (datetime.datetime(2008, 4, 15, 2, 0), '0.3664'), (datetime.datetime(2008, 4, 15, 2, 0), '0.4767'), (datetime.datetime(2008, 4, 15, 3, 0), '0.3144'), (datetime.datetime(2008, 4, 15, 4, 0), '0.4517'), (datetime.datetime(2008, 4, 15, 5, 0), '0.3838'), (datetime.datetime(2008, 4, 15, 6, 0), '0.4702'), (datetime.datetime(2008, 4, 15, 7, 0), '0.389'), (datetime.datetime(2008, 4, 15, 8, 0), '0.4949'), (datetime.datetime(2008, 4, 15, 9, 0), '0.2778'), (datetime.datetime(2008, 4, 15, 10, 0), '0.3576'), (datetime.datetime(2008, 4, 15, 11, 0), '0.3618'), (datetime.datetime(2008, 4, 15, 12, 0), '0.2803')]

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -6,7 +6,7 @@ Imports
     >>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 
 An example GetSites response (from cuahsi)
-    >>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'r').read()
+    >>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'rb').read()
     >>> sites = wml(f).response
 
 Can view the queryInfo structure for information about the query
@@ -45,7 +45,7 @@ Get a site to view it in more detail
     '1345'
 
 An example GetSiteInfo response
-    >>> f = open(resource_file('cuahsi_example_siteinfo_multiple.xml')).read()
+    >>> f = open(resource_file('cuahsi_example_siteinfo_multiple.xml'), 'rb').read()
     >>> sites = wml(f).response
 
     >>> sites.query_info.criteria.method_called
@@ -107,7 +107,7 @@ Get a variable by its code
     'second'
 
 Example GetValues response
-    >>> f = open(resource_file('cuahsi_example_get_values.xml')).read()
+    >>> f = open(resource_file('cuahsi_example_get_values.xml'), 'rb').read()
     >>> series = wml(f).response
 
     >>> series.query_info.criteria.method_called
@@ -135,7 +135,7 @@ List (in tuple) the dates and their corresponding measurements
     [(datetime.datetime(2005, 8, 5, 0, 0), '34.53'), (datetime.datetime(2005, 8, 5, 0, 30), '37.12'), (datetime.datetime(2005, 8, 5, 1, 0), '35.97'), (datetime.datetime(2005, 8, 5, 1, 30), '35.78'), (datetime.datetime(2005, 8, 5, 2, 0), '35.68'), (datetime.datetime(2005, 8, 5, 2, 30), '36.08'), (datetime.datetime(2005, 8, 5, 3, 0), '37.8'), (datetime.datetime(2005, 8, 5, 3, 30), '37.93'), (datetime.datetime(2005, 8, 5, 4, 0), '38.88'), (datetime.datetime(2005, 8, 5, 4, 30), '37.34'), (datetime.datetime(2005, 8, 5, 5, 0), '35.15'), (datetime.datetime(2005, 8, 5, 5, 30), '35.96'), (datetime.datetime(2005, 8, 5, 6, 0), '35.62'), (datetime.datetime(2005, 8, 5, 6, 30), '34.72'), (datetime.datetime(2005, 8, 5, 7, 0), '34.7'), (datetime.datetime(2005, 8, 5, 7, 30), '33.54'), (datetime.datetime(2005, 8, 5, 8, 0), '34.98'), (datetime.datetime(2005, 8, 5, 8, 30), '31.65'), (datetime.datetime(2005, 8, 5, 9, 0), '32.49'), (datetime.datetime(2005, 8, 5, 9, 30), '32.78'), (datetime.datetime(2005, 8, 5, 10, 0), '30.58'), (datetime.datetime(2005, 8, 5, 10, 30), '32.8'), (datetime.datetime(2005, 8, 5, 11, 0), '31.83'), (datetime.datetime(2005, 8, 5, 11, 30), '30.71'), (datetime.datetime(2005, 8, 5, 12, 0), '30.82'), (datetime.datetime(2005, 8, 5, 12, 30), '29.72'), (datetime.datetime(2005, 8, 5, 13, 0), '27.05'), (datetime.datetime(2005, 8, 5, 13, 30), '25.5'), (datetime.datetime(2005, 8, 5, 14, 0), '24.69'), (datetime.datetime(2005, 8, 5, 14, 30), '26.03'), (datetime.datetime(2005, 8, 5, 15, 0), '25.55'), (datetime.datetime(2005, 8, 5, 15, 30), '25.96'), (datetime.datetime(2005, 8, 5, 16, 0), '24.72'), (datetime.datetime(2005, 8, 5, 16, 30), '23.36'), (datetime.datetime(2005, 8, 5, 17, 0), '24.21'), (datetime.datetime(2005, 8, 5, 17, 30), '25.61'), (datetime.datetime(2005, 8, 5, 18, 0), '24.73'), (datetime.datetime(2005, 8, 5, 18, 30), '25.73'), (datetime.datetime(2005, 8, 5, 19, 0), '24.76'), (datetime.datetime(2005, 8, 5, 19, 30), '24.96'), (datetime.datetime(2005, 8, 5, 20, 0), '25.69'), (datetime.datetime(2005, 8, 5, 20, 30), '27.34'), (datetime.datetime(2005, 8, 5, 21, 0), '27.14'), (datetime.datetime(2005, 8, 5, 21, 30), '27.7'), (datetime.datetime(2005, 8, 5, 22, 0), '28.88'), (datetime.datetime(2005, 8, 5, 22, 30), '30.44'), (datetime.datetime(2005, 8, 5, 23, 0), '32.14'), (datetime.datetime(2005, 8, 5, 23, 30), '34.02'), (datetime.datetime(2005, 8, 6, 0, 0), '33.61')]
 
 Example GetVariables response
-    >>> f = open(resource_file('cuahsi_example_get_variables.xml')).read()
+    >>> f = open(resource_file('cuahsi_example_get_variables.xml'), 'rb').read()
     >>> varis = wml(f).response
 
 Just a list of variables

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -2,154 +2,154 @@ Using WaterML 1.1 for examples
 
 Imports
 
-	>>> from tests.utils import resource_file
-	>>> from owslib.waterml.wml11 import WaterML_1_1 as wml
+    >>> from tests.utils import resource_file
+    >>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 
 An example GetSites response (from cuahsi)
-	>>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'r').read()
-	>>> sites = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'r').read()
+    >>> sites = wml(f).response
 
 Can view the queryInfo structure for information about the query
-	>>> sites.query_info.creation_time
-	datetime.datetime(2009, 6, 12, 10, 47, 54, 531250, tzinfo=tzoffset(None, -25200))
-	>>> sites.query_info.notes
-	['ALL Sites(empty request)']
-	>>> sites.query_info.criteria.method_called
-	'GetSites'
+    >>> sites.query_info.creation_time
+    datetime.datetime(2009, 6, 12, 10, 47, 54, 531250, tzinfo=tzoffset(None, -25200))
+    >>> sites.query_info.notes
+    ['ALL Sites(empty request)']
+    >>> sites.query_info.criteria.method_called
+    'GetSites'
 
 Get a list of codes for the sites returned
-	>>> codes = sites.site_codes
-	>>> sorted(codes)
-	[['10105900'], ['USU-LBR-Confluence'], ['USU-LBR-EFLower'], ['USU-LBR-EFRepeater'], ['USU-LBR-EFWeather'], ['USU-LBR-ExpFarm'], ['USU-LBR-Mendon'], ['USU-LBR-Paradise'], ['USU-LBR-ParadiseRepeater'], ['USU-LBR-SFLower'], ['USU-LBR-SFUpper'], ['USU-LBR-Wellsville']]
+    >>> codes = sites.site_codes
+    >>> sorted(codes)
+    [['10105900'], ['USU-LBR-Confluence'], ['USU-LBR-EFLower'], ['USU-LBR-EFRepeater'], ['USU-LBR-EFWeather'], ['USU-LBR-ExpFarm'], ['USU-LBR-Mendon'], ['USU-LBR-Paradise'], ['USU-LBR-ParadiseRepeater'], ['USU-LBR-SFLower'], ['USU-LBR-SFUpper'], ['USU-LBR-Wellsville']]
 
 Get the names ofthe sites
-	>>> sorted(sites.site_names)
-	['East Fork Little Bear River Radio Repeater near Avon, Utah', 'East Fork Little Bear River at Paradise Canal Diversion near Avon, Utah', 'Little Bear River Upper Weather Station near Avon, Utah', 'Little Bear River at McMurdy Hollow near Paradise, Utah', 'Little Bear River at Mendon Road near Mendon, Utah', 'Little Bear River at Paradise, Utah', 'Little Bear River below Confluence of South and East Forks near Avon, Utah', 'Little Bear River near Wellsville, Utah', 'Radio Repeater near Paradise, Utah', 'South Fork Little Bear River above Davenport Creek near Avon, Utah', 'South Fork Little Bear River below Davenport Creek near Avon, Utah', 'Utah State University Experimental Farm near Wellsville, Utah']
+    >>> sorted(sites.site_names)
+    ['East Fork Little Bear River Radio Repeater near Avon, Utah', 'East Fork Little Bear River at Paradise Canal Diversion near Avon, Utah', 'Little Bear River Upper Weather Station near Avon, Utah', 'Little Bear River at McMurdy Hollow near Paradise, Utah', 'Little Bear River at Mendon Road near Mendon, Utah', 'Little Bear River at Paradise, Utah', 'Little Bear River below Confluence of South and East Forks near Avon, Utah', 'Little Bear River near Wellsville, Utah', 'Radio Repeater near Paradise, Utah', 'South Fork Little Bear River above Davenport Creek near Avon, Utah', 'South Fork Little Bear River below Davenport Creek near Avon, Utah', 'Utah State University Experimental Farm near Wellsville, Utah']
 
 Get a site to view it in more detail
-	>>> site = sites[codes[0][0]]
-	>>> site.geo_coords
-	[('-111.946402', '41.718473')]
-	>>> site.latitudes
-	['41.718473']
-	>>> site.longitudes
-	['-111.946402']
-	>>> info = site.site_info
-	>>> info.notes
-	[]
-	>>> x = info.site_properties
-	>>> x == {'County': 'Cache', 'PosAccuracy_m': '1', 'State': 'Utah', 'Site Comments': 'Located below county road bridge at Mendon Road crossing'}
-	True
-	>>> info.altname
-	>>> info.elevation
-	'1345'
+    >>> site = sites[codes[0][0]]
+    >>> site.geo_coords
+    [('-111.946402', '41.718473')]
+    >>> site.latitudes
+    ['41.718473']
+    >>> site.longitudes
+    ['-111.946402']
+    >>> info = site.site_info
+    >>> info.notes
+    []
+    >>> x = info.site_properties
+    >>> x == {'County': 'Cache', 'PosAccuracy_m': '1', 'State': 'Utah', 'Site Comments': 'Located below county road bridge at Mendon Road crossing'}
+    True
+    >>> info.altname
+    >>> info.elevation
+    '1345'
 
 An example GetSiteInfo response
-	>>> f = open(resource_file('cuahsi_example_siteinfo_multiple.xml')).read()
-	>>> sites = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_siteinfo_multiple.xml')).read()
+    >>> sites = wml(f).response
 
-	>>> sites.query_info.criteria.method_called
-	'GetSiteInfo'
+    >>> sites.query_info.criteria.method_called
+    'GetSiteInfo'
 
 List codes and names of the sites
-	>>> codes = sites.site_codes
-	>>> sorted(codes)
-	[['USU-LBR-Mendon'], ['USU-LBR-Wellsville']]
-	>>> sorted(sites.site_names)
-	['Little Bear River at Mendon Road near Mendon, Utah', 'Little Bear River near Wellsville, Utah']
+    >>> codes = sites.site_codes
+    >>> sorted(codes)
+    [['USU-LBR-Mendon'], ['USU-LBR-Wellsville']]
+    >>> sorted(sites.site_names)
+    ['Little Bear River at Mendon Road near Mendon, Utah', 'Little Bear River near Wellsville, Utah']
 
 Get a site for a closer look
-	>>> site = sites[codes[1][0]]
-	>>> site.geo_coords
-	[('-111.917649', '41.643457')]
+    >>> site = sites[codes[1][0]]
+    >>> site.geo_coords
+    [('-111.917649', '41.643457')]
 
 Get the (first) catalog of series for the site
-	>>> catalog = site[0]
+    >>> catalog = site[0]
 
 Get a series from the catalog for a closer look
-	>>> series = catalog[3]
-	>>> series.properties
-	{}
-	>>> series.begin_date_time
-	datetime.datetime(2007, 11, 5, 14, 30)
-	>>> series.end_date_time
-	datetime.datetime(2008, 4, 5, 20, 30)
-	>>> series.method_id
-	'23'
-	>>> series.source_id
-	'2'
-	>>> series.value_count
-	'7309'
-	>>> series.value_type
-	'Field Observation'
-	>>> series.name
-	'Turbidity'
-	>>> series.organization
-	'Utah State University Utah Water Research Laboratory'
+    >>> series = catalog[3]
+    >>> series.properties
+    {}
+    >>> series.begin_date_time
+    datetime.datetime(2007, 11, 5, 14, 30)
+    >>> series.end_date_time
+    datetime.datetime(2008, 4, 5, 20, 30)
+    >>> series.method_id
+    '23'
+    >>> series.source_id
+    '2'
+    >>> series.value_count
+    '7309'
+    >>> series.value_type
+    'Field Observation'
+    >>> series.name
+    'Turbidity'
+    >>> series.organization
+    'Utah State University Utah Water Research Laboratory'
 
 List variable names and codes
-	>>> sorted(site.variable_names)
-	['Battery voltage', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'pH, unfiltered']
-	>>> sorted(site.variable_codes)
-	['USU10', 'USU13', 'USU3', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU39', 'USU4', 'USU40', 'USU41', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
+    >>> sorted(site.variable_names)
+    ['Battery voltage', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'pH, unfiltered']
+    >>> sorted(site.variable_codes)
+    ['USU10', 'USU13', 'USU3', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU39', 'USU4', 'USU40', 'USU41', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
 
 Get a variable by its code
-	>>> variable = site['USU7']
-	>>> variable.variable_name
-	'Turbidity'
-	>>> variable.properties
-	{}
-	>>> variable.speciation
-	'Not Applicable'
-	>>> variable.unit.name
-	'nephelometric turbidity units'
-	>>> variable.time_scale.unit.name
-	'second'
+    >>> variable = site['USU7']
+    >>> variable.variable_name
+    'Turbidity'
+    >>> variable.properties
+    {}
+    >>> variable.speciation
+    'Not Applicable'
+    >>> variable.unit.name
+    'nephelometric turbidity units'
+    >>> variable.time_scale.unit.name
+    'second'
 
 Example GetValues response
-	>>> f = open(resource_file('cuahsi_example_get_values.xml')).read()
-	>>> series = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_get_values.xml')).read()
+    >>> series = wml(f).response
 
-	>>> series.query_info.criteria.method_called
-	'GetValuesForASite'
+    >>> series.query_info.criteria.method_called
+    'GetValuesForASite'
 
 List the names of the series returned (usually None)
-	>>> series.series_names
-	[None, None, None, None, None, None, None, None, None, None, None, None]
+    >>> series.series_names
+    [None, None, None, None, None, None, None, None, None, None, None, None]
 
 List the variables and their codes
-	>>> sorted(series.variable_names)
-	['Battery Voltage', 'Battery voltage', 'Gage height', 'Temperature', 'Turbidity']
-	>>> codes = series.variable_codes
-	>>> sorted(codes)
-	['SDSC45', 'USU10', 'USU11', 'USU12', 'USU13', 'USU3', 'USU4', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
+    >>> sorted(series.variable_names)
+    ['Battery Voltage', 'Battery voltage', 'Gage height', 'Temperature', 'Turbidity']
+    >>> codes = series.variable_codes
+    >>> sorted(codes)
+    ['SDSC45', 'USU10', 'USU11', 'USU12', 'USU13', 'USU3', 'USU4', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
 
 Get variables by code
-	>>> var = series.get_series_by_variable(var_code='USU4')
+    >>> var = series.get_series_by_variable(var_code='USU4')
 
 Get the first values set from the first variable retrieved from the code
-	>>> vals = var[0].values[0]
+    >>> vals = var[0].values[0]
 
 List (in tuple) the dates and their corresponding measurements
-	>>> sorted(vals.get_date_values())
-	[(datetime.datetime(2005, 8, 5, 0, 0), '34.53'), (datetime.datetime(2005, 8, 5, 0, 30), '37.12'), (datetime.datetime(2005, 8, 5, 1, 0), '35.97'), (datetime.datetime(2005, 8, 5, 1, 30), '35.78'), (datetime.datetime(2005, 8, 5, 2, 0), '35.68'), (datetime.datetime(2005, 8, 5, 2, 30), '36.08'), (datetime.datetime(2005, 8, 5, 3, 0), '37.8'), (datetime.datetime(2005, 8, 5, 3, 30), '37.93'), (datetime.datetime(2005, 8, 5, 4, 0), '38.88'), (datetime.datetime(2005, 8, 5, 4, 30), '37.34'), (datetime.datetime(2005, 8, 5, 5, 0), '35.15'), (datetime.datetime(2005, 8, 5, 5, 30), '35.96'), (datetime.datetime(2005, 8, 5, 6, 0), '35.62'), (datetime.datetime(2005, 8, 5, 6, 30), '34.72'), (datetime.datetime(2005, 8, 5, 7, 0), '34.7'), (datetime.datetime(2005, 8, 5, 7, 30), '33.54'), (datetime.datetime(2005, 8, 5, 8, 0), '34.98'), (datetime.datetime(2005, 8, 5, 8, 30), '31.65'), (datetime.datetime(2005, 8, 5, 9, 0), '32.49'), (datetime.datetime(2005, 8, 5, 9, 30), '32.78'), (datetime.datetime(2005, 8, 5, 10, 0), '30.58'), (datetime.datetime(2005, 8, 5, 10, 30), '32.8'), (datetime.datetime(2005, 8, 5, 11, 0), '31.83'), (datetime.datetime(2005, 8, 5, 11, 30), '30.71'), (datetime.datetime(2005, 8, 5, 12, 0), '30.82'), (datetime.datetime(2005, 8, 5, 12, 30), '29.72'), (datetime.datetime(2005, 8, 5, 13, 0), '27.05'), (datetime.datetime(2005, 8, 5, 13, 30), '25.5'), (datetime.datetime(2005, 8, 5, 14, 0), '24.69'), (datetime.datetime(2005, 8, 5, 14, 30), '26.03'), (datetime.datetime(2005, 8, 5, 15, 0), '25.55'), (datetime.datetime(2005, 8, 5, 15, 30), '25.96'), (datetime.datetime(2005, 8, 5, 16, 0), '24.72'), (datetime.datetime(2005, 8, 5, 16, 30), '23.36'), (datetime.datetime(2005, 8, 5, 17, 0), '24.21'), (datetime.datetime(2005, 8, 5, 17, 30), '25.61'), (datetime.datetime(2005, 8, 5, 18, 0), '24.73'), (datetime.datetime(2005, 8, 5, 18, 30), '25.73'), (datetime.datetime(2005, 8, 5, 19, 0), '24.76'), (datetime.datetime(2005, 8, 5, 19, 30), '24.96'), (datetime.datetime(2005, 8, 5, 20, 0), '25.69'), (datetime.datetime(2005, 8, 5, 20, 30), '27.34'), (datetime.datetime(2005, 8, 5, 21, 0), '27.14'), (datetime.datetime(2005, 8, 5, 21, 30), '27.7'), (datetime.datetime(2005, 8, 5, 22, 0), '28.88'), (datetime.datetime(2005, 8, 5, 22, 30), '30.44'), (datetime.datetime(2005, 8, 5, 23, 0), '32.14'), (datetime.datetime(2005, 8, 5, 23, 30), '34.02'), (datetime.datetime(2005, 8, 6, 0, 0), '33.61')]
+    >>> sorted(vals.get_date_values())
+    [(datetime.datetime(2005, 8, 5, 0, 0), '34.53'), (datetime.datetime(2005, 8, 5, 0, 30), '37.12'), (datetime.datetime(2005, 8, 5, 1, 0), '35.97'), (datetime.datetime(2005, 8, 5, 1, 30), '35.78'), (datetime.datetime(2005, 8, 5, 2, 0), '35.68'), (datetime.datetime(2005, 8, 5, 2, 30), '36.08'), (datetime.datetime(2005, 8, 5, 3, 0), '37.8'), (datetime.datetime(2005, 8, 5, 3, 30), '37.93'), (datetime.datetime(2005, 8, 5, 4, 0), '38.88'), (datetime.datetime(2005, 8, 5, 4, 30), '37.34'), (datetime.datetime(2005, 8, 5, 5, 0), '35.15'), (datetime.datetime(2005, 8, 5, 5, 30), '35.96'), (datetime.datetime(2005, 8, 5, 6, 0), '35.62'), (datetime.datetime(2005, 8, 5, 6, 30), '34.72'), (datetime.datetime(2005, 8, 5, 7, 0), '34.7'), (datetime.datetime(2005, 8, 5, 7, 30), '33.54'), (datetime.datetime(2005, 8, 5, 8, 0), '34.98'), (datetime.datetime(2005, 8, 5, 8, 30), '31.65'), (datetime.datetime(2005, 8, 5, 9, 0), '32.49'), (datetime.datetime(2005, 8, 5, 9, 30), '32.78'), (datetime.datetime(2005, 8, 5, 10, 0), '30.58'), (datetime.datetime(2005, 8, 5, 10, 30), '32.8'), (datetime.datetime(2005, 8, 5, 11, 0), '31.83'), (datetime.datetime(2005, 8, 5, 11, 30), '30.71'), (datetime.datetime(2005, 8, 5, 12, 0), '30.82'), (datetime.datetime(2005, 8, 5, 12, 30), '29.72'), (datetime.datetime(2005, 8, 5, 13, 0), '27.05'), (datetime.datetime(2005, 8, 5, 13, 30), '25.5'), (datetime.datetime(2005, 8, 5, 14, 0), '24.69'), (datetime.datetime(2005, 8, 5, 14, 30), '26.03'), (datetime.datetime(2005, 8, 5, 15, 0), '25.55'), (datetime.datetime(2005, 8, 5, 15, 30), '25.96'), (datetime.datetime(2005, 8, 5, 16, 0), '24.72'), (datetime.datetime(2005, 8, 5, 16, 30), '23.36'), (datetime.datetime(2005, 8, 5, 17, 0), '24.21'), (datetime.datetime(2005, 8, 5, 17, 30), '25.61'), (datetime.datetime(2005, 8, 5, 18, 0), '24.73'), (datetime.datetime(2005, 8, 5, 18, 30), '25.73'), (datetime.datetime(2005, 8, 5, 19, 0), '24.76'), (datetime.datetime(2005, 8, 5, 19, 30), '24.96'), (datetime.datetime(2005, 8, 5, 20, 0), '25.69'), (datetime.datetime(2005, 8, 5, 20, 30), '27.34'), (datetime.datetime(2005, 8, 5, 21, 0), '27.14'), (datetime.datetime(2005, 8, 5, 21, 30), '27.7'), (datetime.datetime(2005, 8, 5, 22, 0), '28.88'), (datetime.datetime(2005, 8, 5, 22, 30), '30.44'), (datetime.datetime(2005, 8, 5, 23, 0), '32.14'), (datetime.datetime(2005, 8, 5, 23, 30), '34.02'), (datetime.datetime(2005, 8, 6, 0, 0), '33.61')]
 
 Example GetVariables response
-	>>> f = open(resource_file('cuahsi_example_get_variables.xml')).read()
-	>>> varis = wml(f).response
+    >>> f = open(resource_file('cuahsi_example_get_variables.xml')).read()
+    >>> varis = wml(f).response
 
 Just a list of variables
-	>>> codes = varis.variable_codes
-	>>> sorted(codes)
-	['SDSC45', 'USU10', 'USU11', 'USU12', 'USU13', 'USU14', 'USU15', 'USU16', 'USU17', 'USU18', 'USU19', 'USU20', 'USU21', 'USU22', 'USU23', 'USU24', 'USU25', 'USU26', 'USU27', 'USU28', 'USU29', 'USU3', 'USU30', 'USU31', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU37', 'USU38', 'USU39', 'USU4', 'USU40', 'USU41', 'USU42', 'USU43', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
-	>>> sorted(varis.variable_names)
-	['Barometric pressure', 'Battery Voltage', 'Battery voltage', 'Discharge', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Precipitation', 'Radiation, incoming shortwave', 'Relative humidity', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'Wind direction', 'Wind speed', 'pH, unfiltered']
-	>>> var = varis[codes[10]]
-	>>> var.variable_name
-	'Gage height'
-	>>> var.no_data_value
-	'-9999'
-	>>> var.properties
-	{}
-	>>> var.unit.name
-	'international foot'
+    >>> codes = varis.variable_codes
+    >>> sorted(codes)
+    ['SDSC45', 'USU10', 'USU11', 'USU12', 'USU13', 'USU14', 'USU15', 'USU16', 'USU17', 'USU18', 'USU19', 'USU20', 'USU21', 'USU22', 'USU23', 'USU24', 'USU25', 'USU26', 'USU27', 'USU28', 'USU29', 'USU3', 'USU30', 'USU31', 'USU32', 'USU33', 'USU34', 'USU35', 'USU36', 'USU37', 'USU38', 'USU39', 'USU4', 'USU40', 'USU41', 'USU42', 'USU43', 'USU5', 'USU6', 'USU7', 'USU8', 'USU9']
+    >>> sorted(varis.variable_names)
+    ['Barometric pressure', 'Battery Voltage', 'Battery voltage', 'Discharge', 'Gage height', 'Oxygen, dissolved', 'Oxygen, dissolved percent of saturation', 'Phosphorus, total as P', 'Phosphorus, total as P, filtered', 'Precipitation', 'Radiation, incoming shortwave', 'Relative humidity', 'Solids, total Suspended', 'Specific conductance, unfiltered', 'Temperature', 'Turbidity', 'Wind direction', 'Wind speed', 'pH, unfiltered']
+    >>> var = varis[codes[10]]
+    >>> var.variable_name
+    'Gage height'
+    >>> var.no_data_value
+    '-9999'
+    >>> var.properties
+    {}
+    >>> var.unit.name
+    'international foot'

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -2,14 +2,14 @@ Imports
 
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file
     >>> from owslib.wms import WebMapService
-    
+
 Fake a request to a WMS Server using saved doc from GeoServer, using a subset
 of the sample data distributed with the installer.
 http://localhost:8080/geoserver/wms?request=GetCapabilities
 
-    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'r').read() 
+    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
-    
+
 Test capabilities
 
     >>> wms.identification.type
@@ -20,10 +20,10 @@ Test capabilities
 
     >>> wms.identification.abstract
     'This is a description of your Web Map Server.'
-    
+
     >>> wms.provider.url
     'http://localhost:8080/geoserver/wms'
-    
+
     >>> wms.identification.keywords
     ['WFS', 'WMS', 'GEOSERVER']
 
@@ -35,33 +35,33 @@ Test available content layers
 
     >>> 'opengeo:poi' in wms.contents.keys()
     True
-    
-    >>> layers=[wms[layer].title for layer in wms.contents]
+
+    >>> layers = [wms[layer].title for layer in wms.contents]
     >>> 'Points of Interest' in layers
     True
-        
+
 Test single item accessor
 
     >>> wms['opengeo:poi'].title
     'Points of Interest'
-    
+
     >>> cast_tuple_int_list_srs(wms['opengeo:poi'].boundingBox)
     [-74, 40, -74, 40, 'EPSG:4326']
-    
+
     >>> cast_tuple_int_list(wms['opengeo:poi'].boundingBoxWGS84)
     [-74, 40, -74, 40]
-    
+
     >>> wms['opengeo:poi'].crsOptions
     ['EPSG:4326']
 
     >>> x = wms['opengeo:poi'].attribution
     >>> x == {'url': 'http://svn.codehaus.org/geoserver/trunk/data/release/data/', 'logo_size': (353, 112), 'logo_url': 'http://geoserver.org/s/1518/25/0.1/_/download/resources/com.atlassian.confluence.themes.geoserver%3Ageoserver/chrome/geoserver-logo.png', 'title': 'GeoServer Sample Data'}
     True
-    
+
     >>> x = wms['opengeo:poi'].styles
     >>> x == {'point': {'legend': 'http://localhost:8080/geoserver/wms?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=poi', 'title': 'A boring default style'}}
     True
-    
+
 Expect a KeyError for invalid names
 
     >>> wms['utterly bogus'].title
@@ -73,11 +73,11 @@ Test operations
 
     >>> [op.name for op in wms.operations]
     ['GetCapabilities', 'GetMap', 'GetFeatureInfo', 'DescribeLayer', 'GetLegendGraphic']
-    
+
     >>> x = wms.getOperationByName('GetMap').methods
     >>> x == {'Get': {'url': 'http://localhost:8080/geoserver/wms?SERVICE=WMS&'}}
     True
-    
+
     >>> wms.getOperationByName('GetMap').formatOptions
     ['image/png', 'application/atom xml', 'application/atom+xml', 'application/openlayers', 'application/pdf', 'application/rss xml', 'application/rss+xml', 'application/vnd.google-earth.kml', 'application/vnd.google-earth.kml xml', 'application/vnd.google-earth.kml+xml', 'application/vnd.google-earth.kmz', 'application/vnd.google-earth.kmz xml', 'application/vnd.google-earth.kmz+xml', 'atom', 'image/geotiff', 'image/geotiff8', 'image/gif', 'image/jpeg', 'image/png8', 'image/svg', 'image/svg xml', 'image/svg+xml', 'image/tiff', 'image/tiff8', 'kml', 'kmz', 'openlayers', 'rss']
 
@@ -92,4 +92,3 @@ Lastly, test the getcapabilities method
 #    >>> xml = wms.getcapabilities().read()
 #    >>> xml.find('<WMT_MS_Capabilities version="1.1.1">') > 0
 #    True
-

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -33,7 +33,7 @@ Test capabilities
 
 Test available content layers
 
-    >>> 'opengeo:poi' in wms.contents.keys()
+    >>> 'opengeo:poi' in wms.contents
     True
 
     >>> layers = [wms[layer].title for layer in wms.contents]

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -7,7 +7,7 @@ Fake a request to a WMS Server using saved doc from GeoServer, using a subset
 of the sample data distributed with the installer.
 http://localhost:8080/geoserver/wms?request=GetCapabilities
 
-    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -4,13 +4,13 @@ Imports
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> import os
-    
-Fake a request to a WMS Server using saved doc from 
+
+Fake a request to a WMS Server using saved doc from
 http://wms.jpl.nasa.gov/wms.cgi.
 
     >>> xml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
-    
+
 Test capabilities
 -----------------
 
@@ -47,9 +47,8 @@ Check contact info (some of it is missing)
     'JPL'
     >>> wms.provider.contact.position
 
-    
 Test available content layers
-    >>> type(wms.items())
+    >>> type(list(wms.items()))
     <type 'list'>
     >>> type(wms.contents)
     <type 'dict'>
@@ -62,30 +61,28 @@ NOTE: Not sure this dictionary interface is right...??
     >>> sorted([wms[layer].id for layer in wms.contents])
     ['BMNG', 'daily_afternoon', 'daily_planet', 'gdem', 'global_mosaic', 'global_mosaic_base', 'huemapped_srtm', 'modis', 'srtm_mag', 'srtmplus', 'us_colordem', 'us_elevation', 'us_landsat_wgs84', 'us_ned', 'worldwind_dem']
 
- 
 Test single item accessor
-    
+
     >>> wms['global_mosaic'].title
     'WMS Global Mosaic, pan sharpened'
 
     >>> wms['global_mosaic'].keywords
     []
-    
+
 ['GlobalMosaic', 'Imagery', 'BaseMaps', 'EarthCover', 'JPL', 'Jet Propulsion Laboratory', 'Landsat', 'WMS', 'SLD', 'Global']
 
     >>> wms['global_mosaic'].boundingBox
 
     >>> wms['global_mosaic'].boundingBoxWGS84
     (-180.0, -60.0, 180.0, 84.0)
-    
+
     >>> sorted(wms['global_mosaic'].crsOptions)
     ['AUTO:42003', 'EPSG:4326']
 
-    
     >>> x = wms['global_mosaic'].styles
     >>> x == {'pseudo_bright': {'title': 'Pseudo-color image (Uses IR and Visual bands, 542 mapping), gamma 1.5'}, 'pseudo': {'title': '(default) Pseudo-color image, pan sharpened (Uses IR and Visual bands, 542 mapping), gamma 1.5'}, 'visual': {'title': 'Real-color image, pan sharpened (Uses the visual bands, 321 mapping), gamma 1.5'}, 'pseudo_low': {'title': 'Pseudo-color image, pan sharpened (Uses IR and Visual bands, 542 mapping)'}, 'visual_low': {'title': 'Real-color image, pan sharpened (Uses the visual bands, 321 mapping)'}, 'visual_bright': {'title': 'Real-color image (Uses the visual bands, 321 mapping), gamma 1.5'}}
     True
-    
+
 Expect a KeyError for invalid names
 
     >>> wms['utterly bogus'].title
@@ -100,7 +97,7 @@ Test operations
 
     >>> wms.getOperationByName('GetMap').methods
     {'Get': {'url': 'http://wms.jpl.nasa.gov/wms.cgi?'}}
-    
+
     >>> wms.getOperationByName('GetMap').formatOptions
     ['image/jpeg', 'image/png', 'image/geotiff', 'image/tiff', 'application/vnd.google-earth.kml+xml']
 

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -48,7 +48,7 @@ Check contact info (some of it is missing)
     >>> wms.provider.contact.position
 
 Test available content layers
-    >>> type(list(wms.items()))
+    >>> type(wms.items())
     <type 'list'>
     >>> type(wms.contents)
     <type 'dict'>

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -8,7 +8,7 @@ Imports
 Fake a request to a WMS Server using saved doc from
 http://wms.jpl.nasa.gov/wms.cgi.
 
-    >>> xml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_JPLCapabilities.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -48,10 +48,10 @@ Check contact info (some of it is missing)
     >>> wms.provider.contact.position
 
 Test available content layers
-    >>> type(wms.items())
-    <type 'list'>
-    >>> type(wms.contents)
-    <type 'dict'>
+    >>> isinstance(wms.items(), list)
+    True
+    >>> isinstance(wms.contents, dict)
+    True
 
 NOTE: Not sure this dictionary interface is right...??
 

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -7,7 +7,7 @@ Imports
 Fake a request to a WMS Server using saved doc from
 http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?
 
-    >>> xml = open(resource_file('wms_mesonet-caps.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_mesonet-caps.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -4,12 +4,12 @@ Imports
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
 
-Fake a request to a WMS Server using saved doc from 
+Fake a request to a WMS Server using saved doc from
 http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?
 
     >>> xml = open(resource_file('wms_mesonet-caps.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
-    
+
 Test capabilities
 -----------------
 
@@ -34,21 +34,21 @@ Test available content layers
     >>> sorted([wms[layer].id for layer in wms.contents])
     ['nexrad-n0r-wmst', 'nexrad_base_reflect', 'time_idx']
 
- 
+
 Test single item accessor
-    
+
     >>> wms['time_idx'].title
     'NEXRAD BASE REFLECT'
 
     >>> wms['time_idx'].keywords
     []
-    
+
     >>> wms['time_idx'].boundingBox
     (-126.0, 24.0, -66.0, 50.0, 'EPSG:4326')
 
     >>> wms['time_idx'].boundingBoxWGS84
     (-126.0, 24.0, -66.0, 50.0)
-    
+
     >>> sorted(wms['time_idx'].crsOptions)
     ['EPSG:102100', 'EPSG:3857', 'EPSG:4326', 'EPSG:900913']
 

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -7,7 +7,7 @@ Imports
 Fake a request to a WMS Server using saved doc from telascience.org.
 http://wms.telascience.org/cgi-bin/ngBM_wms?
 
-    >>> xml = open(resource_file('wms_Telascience.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_Telascience.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -3,13 +3,13 @@ Imports
 
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
-    
+
 Fake a request to a WMS Server using saved doc from telascience.org.
 http://wms.telascience.org/cgi-bin/ngBM_wms?
 
-    >>> xml = open(resource_file('wms_Telascience.xml'), 'r').read() 
+    >>> xml = open(resource_file('wms_Telascience.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
-    
+
 Test capabilities
 
     >>> wms.identification.type
@@ -20,10 +20,10 @@ Test capabilities
 
     >>> wms.identification.abstract
     'Blue Marble 200409'
-    
+
     >>> wms.provider.url
     'http://wms.telascience.org/cgi-bin/ngBM_wms?'
-    
+
     >>> wms.identification.keywords
     []
 
@@ -38,29 +38,27 @@ Test available content layers
     >>> sorted(wms.contents.keys())
     ['USGS_1ft_San_Diego', 'ngBM', 'world.topo.bathy.200409']
 
-    
     >>> sorted([wms[layer].title for layer in wms.contents])
     ['BM', 'USGS 1ft San Diego', 'world.topo.bathy.200409']
 
-    
+
 Test single item accessor
 
     >>> wms['world.topo.bathy.200409'].title
     'world.topo.bathy.200409'
-    
+
     >>> wms['world.topo.bathy.200409'].boundingBox
     (-180.0, -90.0, 180.0, 90.0, 'EPSG:4326')
-    
+
     >>> wms['world.topo.bathy.200409'].boundingBoxWGS84
     (-180.0, -90.0, 180.0, 90.0)
-    
+
     >>> sorted(wms['world.topo.bathy.200409'].crsOptions)
     ['EPSG:4326', 'init=epsg:4326']
 
-    
     >>> wms['world.topo.bathy.200409'].styles
     {}
-    
+
 Expect a KeyError for invalid names
 
     >>> wms['utterly bogus'].title
@@ -72,11 +70,11 @@ Test operations
 
     >>> sorted([op.name for op in wms.operations])
     ['DescribeLayer', 'GetCapabilities', 'GetFeatureInfo', 'GetLegendGraphic', 'GetMap']
-    
+
     >>> x = wms.getOperationByName('GetMap').methods
     >>> x == {'Post': {'url': 'http://wms.telascience.org/cgi-bin/ngBM_wms?'}, 'Get': {'url': 'http://wms.telascience.org/cgi-bin/ngBM_wms?'}}
     True
-    
+
     >>> wms.getOperationByName('GetMap').formatOptions
     ['image/gif', 'image/png', 'image/jpeg', 'image/wbmp', 'image/tiff', 'image/png; mode=24bit']
 

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -4,13 +4,13 @@ Imports
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file, scratch_file
     >>> import os
-    
-Fake a request to a GeoServer WMS Server using saved doc from 
+
+Fake a request to a GeoServer WMS Server using saved doc from
 http://giswebservices.massgis.state.ma.us/geoserver/wms
 
     >>> xml = open(resource_file('wms_mass_gis-caps.xml'), 'r').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
-    
+
 Test capabilities
 -----------------
 
@@ -53,14 +53,14 @@ Check contact info (some of it is missing)
     'GIS Programmer'
 
 Test available content layers
-    >>> type(wms.items())
+    >>> type(list(wms.items()))
     <type 'list'>
     >>> type(wms.contents)
     <type 'dict'>
 
- 
+
 Test single item accessor
-    
+
     >>> wms['massgis:GISDATA.SHORELINES_ARC'].title
     'Shoreline Change'
 
@@ -72,11 +72,11 @@ Test single item accessor
 
     >>> cast_tuple_int_list(wms['massgis:GISDATA.SHORELINES_ARC'].boundingBoxWGS84)
     [-71, 41, -69, 42]
-    
+
     >>> x = wms['massgis:GISDATA.SHORELINES_ARC'].styles
     >>> x == {'GISDATA.SHORELINES_ARC::Default': {'legend': 'http://giswebservices.massgis.state.ma.us/geoserver/wms?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=GISDATA.SHORELINES_ARC', 'title': None}}
     True
-    
+
 Expect a KeyError for invalid names
 
     >>> wms['utterly bogus'].title
@@ -88,10 +88,10 @@ Test operations
 
     >>> [op.name for op in wms.operations]
     ['GetCapabilities', 'GetMap', 'GetFeatureInfo', 'DescribeLayer', 'GetLegendGraphic']
-    
+
     >>> wms.getOperationByName('GetMap').methods
     {'Get': {'url': 'http://giswebservices.massgis.state.ma.us/geoserver/wms?SERVICE=WMS&'}}
-    
+
     >>> len(wms.getOperationByName('GetMap').formatOptions)
     29
 

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -53,10 +53,10 @@ Check contact info (some of it is missing)
     'GIS Programmer'
 
 Test available content layers
-    >>> type(wms.items())
-    <type 'list'>
-    >>> type(wms.contents)
-    <type 'dict'>
+    >>> isinstance(wms.items(), list)
+    True
+    >>> isinstance(wms.contents, dict)
+    True
 
 
 Test single item accessor

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -8,7 +8,7 @@ Imports
 Fake a request to a GeoServer WMS Server using saved doc from
 http://giswebservices.massgis.state.ma.us/geoserver/wms
 
-    >>> xml = open(resource_file('wms_mass_gis-caps.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_mass_gis-caps.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
 
 Test capabilities
@@ -106,5 +106,5 @@ Lastly, test the getcapabilities and getmap methods
     >>> wms = WebMapService('http://giswebservices.massgis.state.ma.us/geoserver/wms', version='1.1.1')
     >>> img = wms.getmap(layers=['massgis:GISDATA.SHORELINES_ARC'], styles=[''], srs='EPSG:4326', bbox=(-70.8, 42, -70, 42.8), size=(300, 300), format='image/jpeg', transparent=True)
     >>> out = open(scratch_file('massgis_shoreline.jpg'), 'wb')
-    >>> out.write(img.read())
+    >>> written_bytes = out.write(img.read())
     >>> out.close()

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -53,7 +53,7 @@ Check contact info (some of it is missing)
     'GIS Programmer'
 
 Test available content layers
-    >>> type(list(wms.items()))
+    >>> type(wms.items())
     <type 'list'>
     >>> type(wms.contents)
     <type 'dict'>

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -37,5 +37,5 @@ Fetch a tile (using some defaults):
 
     >>> tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor', tilematrixset='EPSG4326_250m', tilematrix='0', row=0, column=0, format='image/jpeg')
     >>> out = open(scratch_file('nasa_modis_terra_truecolour.jpg'), 'wb')
-    >>> out.write(tile.read())
+    >>> written_bytes = out.write(tile.read())
     >>> out.close()

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -6,7 +6,7 @@ Imports
 Find out what a WMTS has to offer. Service metadata:
 
     >>> from owslib.wmts import WebMapTileService
-    >>> wmts = WebMapTileService("http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi")
+    >>> wmts = WebMapTileService('http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi')
     >>> wmts.identification.type
     'OGC WMTS'
     >>> wmts.identification.version
@@ -25,18 +25,17 @@ Service Provider:
 
     >>> wmts.provider.url
     'http://earthdata.nasa.gov/'
-    
+
 Available Layers:
 
-    >>> len(wmts.contents.keys()) > 0
+    >>> len(list(wmts.contents.keys())) > 0
     True
     >>> sorted(list(wmts.contents))[0]
     'AIRS_CO_Total_Column_Day'
 
 Fetch a tile (using some defaults):
 
-  >>> tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor', tilematrixset='EPSG4326_250m', tilematrix='0', row=0, column=0, format="image/jpeg")
-  >>> out = open(scratch_file('nasa_modis_terra_truecolour.jpg'), 'wb')
-  >>> out.write(tile.read())
-  >>> out.close()
-
+    >>> tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor', tilematrixset='EPSG4326_250m', tilematrix='0', row=0, column=0, format='image/jpeg')
+    >>> out = open(scratch_file('nasa_modis_terra_truecolour.jpg'), 'wb')
+    >>> out.write(tile.read())
+    >>> out.close()

--- a/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
+++ b/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
@@ -7,7 +7,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from
 http://map1b.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi
 
-    >>> xml = open(resource_file('eosdis-wmts-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('eosdis-wmts-cap.xml'), 'rb').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
 
 Test capabilities
@@ -175,13 +175,13 @@ Test the gettile methods
     # TODO - more checks
     >>> try:
     ...     from PIL import Image
-    ...     import cStringIO
+    ...     from six import BytesIO
     ... except:
     ...     pass
     ... else:
     ...     rq = wmts.buildTileRequest(layer='MODIS_Aqua_SurfaceReflectance_Bands121', tilematrix='0', row=0, column=0)
     ...     assert rq == 'SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=MODIS_Aqua_SurfaceReflectance_Bands121&STYLE=default&TILEMATRIXSET=EPSG4326_250m&TILEMATRIX=0&TILEROW=0&TILECOL=0&FORMAT=image%2Fjpeg'
     ...     tile000 = wmts.gettile(layer='MODIS_Aqua_SurfaceReflectance_Bands121', tilematrix='0', row=0, column=0)
-    ...     im = cStringIO.StringIO(tile000.read())
+    ...     im = BytesIO(tile000.read())
     ...     image = Image.open(im)
     ...     assert image.size == (512, 512)

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -7,7 +7,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from
 http://server.caris.com/spatialfusionserver/services/ows/wmts/World/1.0.0/WMTSCapabilities.xml
 
-    >>> xml = open(resource_file('sfs-wmts-cap-world.xml'), 'r').read()
+    >>> xml = open(resource_file('sfs-wmts-cap-world.xml'), 'rb').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
 
 Test capabilities
@@ -223,8 +223,8 @@ Test the gettile methods
     ... else:
     ...     rq = wmts.buildTileRequest(layer='World', tilematrix='0', row=0, column=0)
     ...     assert rq == 'SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=World&STYLE=default&TILEMATRIXSET=GlobalCRS84Scale&TILEMATRIX=0&TILEROW=0&TILECOL=0&FORMAT=image%2Fpng'
-    ...     import cStringIO
+    ...     from six import BytesIO
     ...     tile000 = wmts.gettile(layer='World', tilematrix='0', row=0, column=0)
-    ...     im = cStringIO.StringIO(tile000.read())
+    ...     im = BytesIO(tile000.read())
     ...     image = Image.open(im)
     ...     assert image.size == (256, 256)

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -178,7 +178,7 @@ Test single item accessor
     True
 
 Test themes
-    >>> wmts.themes.keys()
+    >>> list(wmts.themes.keys())
     ['Earth']
     >>> wmts.themes['Earth'].title
     'Earth'
@@ -188,7 +188,6 @@ Test themes
 
     >>> sorted(wmts.themes['Earth'].layerRefs)
     ['Ocean', 'World']
-
 
 
 Expect a KeyError for invalid names
@@ -229,4 +228,3 @@ Test the gettile methods
     ...     im = cStringIO.StringIO(tile000.read())
     ...     image = Image.open(im)
     ...     assert image.size == (256, 256)
-

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -3,13 +3,13 @@ Imports
 
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
-    
-Fake a request to a WMTS Server using saved doc from 
+
+Fake a request to a WMTS Server using saved doc from
 http://geonode.iwlearn.org/geoserver/gwc/service/wmts?REQUEST=GetCapabilities
 
-    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'r').read() 
+    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'r').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
-    
+
 Test capabilities
 -----------------
     >>> wmts.identification.type
@@ -33,7 +33,7 @@ Service Provider:
     'http://geonode.iwlearn.org/geoserver/gwc/service/wmts'
     >>> wmts.provider.url
     'http://geonode.iwlearn.org/geoserver/gwc/service/wmts'
-    
+
 Check contact info
     >>> wmts.provider.contact.name
     'GeoWebCache User'

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -7,7 +7,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from
 http://geonode.iwlearn.org/geoserver/gwc/service/wmts?REQUEST=GetCapabilities
 
-    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'rb').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -12,7 +12,7 @@ Initialize WPS client
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_CEDADescribeProcess.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_CEDADescribeProcess.xml'), 'rb').read()
     >>> process = wps.describeprocess('Doubleit', xml=xml)
 
 Check process description

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -8,7 +8,7 @@ Imports
 
 Initialize WPS client
 
-    >>> wps = WebProcessingService('http://ceda-wps2.badc.rl.ac.uk/wps',skip_caps=True)
+    >>> wps = WebProcessingService('http://ceda-wps2.badc.rl.ac.uk/wps', skip_caps=True)
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
@@ -27,23 +27,23 @@ Check process description
 Check process inputs
 
     >>> for input in process.dataInputs:
-    ...     print 'Process input:'
+    ...     print('Process input:')
     ...     printInputOutput(input)
-    ... 
+    ...
     Process input:
      identifier=NumberToDouble, title=NumberToDouble, abstract=NumberToDouble, data type=LiteralData
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=-1
 
 Check process outputs
 
     >>> for output in process.processOutputs:
-    ...     print 'Process output:'
+    ...     print('Process output:')
     ...     printInputOutput(output)
-    ... 
+    ...
     Process output:
      identifier=OutputXML, title=OutputXML, abstract=OutputXML, data type=ComplexData
      Supported Value: mimeType=text/XML, encoding=UTF-8, schema=NONE
-     Default Value: None 
+     Default Value: None
      reference=None, mimeType=None

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -12,7 +12,7 @@ Initialize WPS client
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_USGSDescribeProcess.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_USGSDescribeProcess.xml'), 'rb').read()
     >>> process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 
 Check process description

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -8,7 +8,7 @@ Imports
 
 Initialize WPS client
 
-    >>> wps = WebProcessingService('http://cida.usgs.gov/gdp/process/WebProcessingService',skip_caps=True)
+    >>> wps = WebProcessingService('http://cida.usgs.gov/gdp/process/WebProcessingService', skip_caps=True)
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
@@ -26,9 +26,9 @@ Check process description
 
 Check process inputs
     >>> for input in process.dataInputs:
-    ...     print 'Process input:'
+    ...     print('Process input:')
     ...     printInputOutput(input, indent='')
-    ... 
+    ...
     Process input:
      identifier=FEATURE_COLLECTION, title=Feature Collection, abstract=A feature collection encoded as a WFS request or one of the supported GML profiles., data type=ComplexData
      Supported Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/2.0.0/feature.xsd
@@ -40,44 +40,44 @@ Check process inputs
      Supported Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/3.1.0/base/feature.xsd
      Supported Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/3.1.1/base/feature.xsd
      Supported Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/3.2.1/base/feature.xsd
-     Default Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/2.0.0/feature.xsd 
+     Default Value: mimeType=text/xml, encoding=UTF-8, schema=http://schemas.opengis.net/gml/2.0.0/feature.xsd
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=DATASET_URI, title=Dataset URI, abstract=The base data web service URI for the dataset of interest., data type=anyURI
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=DATASET_ID, title=Dataset Identifier, abstract=The unique identifier for the data type or variable of interest., data type=string
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=2147483647
     Process input:
      identifier=REQUIRE_FULL_COVERAGE, title=Require Full Coverage, abstract=If turned on, the service will require that the dataset of interest fully cover the polygon analysis zone data., data type=boolean
      Allowed Value: True
-     Default Value: True 
+     Default Value: True
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=TIME_START, title=Time Start, abstract=The date to begin analysis., data type=dateTime
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=TIME_END, title=Time End, abstract=The date to end analysis., data type=dateTime
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=FEATURE_ATTRIBUTE_NAME, title=Feature Attribute Name, abstract=The attribute that will be used to label column headers in processing output., data type=string
      Allowed Value: AnyValue
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=DELIMITER, title=Delimiter, abstract=The delimiter that will be used to separate columns in the processing output., data type=string
      Allowed Value: COMMA
      Allowed Value: TAB
      Allowed Value: SPACE
-     Default Value: COMMA 
+     Default Value: COMMA
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=STATISTICS, title=Statistics, abstract=Statistics that will be returned for each feature in the processing output., data type=string
@@ -88,33 +88,33 @@ Check process inputs
      Allowed Value: STD_DEV
      Allowed Value: WEIGHT_SUM
      Allowed Value: COUNT
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=7
     Process input:
      identifier=GROUP_BY, title=Group By, abstract=If multiple features and statistics are selected, this will change whether the processing output columns are sorted according to statistics or feature attributes., data type=string
      Allowed Value: STATISTIC
      Allowed Value: FEATURE_ATTRIBUTE
-     Default Value: None 
+     Default Value: None
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=SUMMARIZE_TIMESTEP, title=Summarize Timestep, abstract=If selected, processing output will include columns with summarized statistics for all feature attribute values for each timestep, data type=boolean
      Allowed Value: True
-     Default Value: True 
+     Default Value: True
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=SUMMARIZE_FEATURE_ATTRIBUTE, title=Summarize Feature Attribute, abstract=If selected, processing output will include a final row of statistics summarizing all timesteps for each feature attribute value, data type=boolean
      Allowed Value: True
-     Default Value: True 
+     Default Value: True
      minOccurs=0, maxOccurs=1
 
 
 Check process outputs
     >>> for output in process.processOutputs:
-    ...     print 'Process output:'
+    ...     print('Process output:')
     ...     printInputOutput(output, indent='')
-    ... 
+    ...
     Process output:
      identifier=OUTPUT, title=Output File, abstract=A delimited text file containing requested process output., data type=ComplexData
      Supported Value: mimeType=text/csv, encoding=UTF-8, schema=None
-     Default Value: mimeType=text/csv, encoding=UTF-8, schema=None 
+     Default Value: mimeType=text/csv, encoding=UTF-8, schema=None
      reference=None, mimeType=None

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -39,5 +39,5 @@ Simulate end of process
 Display location of process output
     >>> for output in execution.processOutputs:
     ...     output.reference
-    ... 
+    ...
     'http://cida.usgs.gov/climate/gdp/process/RetrieveResultServlet?id=1318528582026OUTPUT.601bb3d0-547f-4eab-8642-7c7d2834459e'

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -12,8 +12,8 @@ Initialize WPS client
 
 Execute fake invocation of Execute operation using cached HTTP request and response
 
-    >>> request = open(resource_file('wps_USGSExecuteRequest1.xml'), 'r').read()
-    >>> response = open(resource_file('wps_USGSExecuteResponse1a.xml'), 'r').read()
+    >>> request = open(resource_file('wps_USGSExecuteRequest1.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_USGSExecuteResponse1a.xml'), 'rb').read()
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...
     Execution status=ProcessStarted
@@ -26,7 +26,7 @@ Execute fake invocation of Execute operation using cached HTTP request and respo
 
 Simulate end of process
 
-    >>> response = open(resource_file('wps_USGSExecuteResponse1b.xml'), 'r').read()
+    >>> response = open(resource_file('wps_USGSExecuteResponse1b.xml'), 'rb').read()
     >>> execution.checkStatus(sleepSecs=0, response=response)
     Execution status=ProcessSucceeded
     Percent completed=0

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -18,7 +18,7 @@ Submit fake invocation of Execute operation using cached HTTP request and respon
     Execution status=ProcessFailed
     Percent completed=0
     Status message=None
-     owslib.wps.WPSException : ...
+     <class 'owslib.wps.WPSException'> : ...
 
     >>> execution.isComplete()
     True
@@ -26,5 +26,5 @@ Submit fake invocation of Execute operation using cached HTTP request and respon
 Display errors
     >>> for ex in execution.errors:
     ...     ex.code, ex.locator, ex.text
-    ... 
+    ...
     (None, None, 'Attribute null not found in feature collection')

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -11,8 +11,8 @@ Initialize WPS client
     >>> wps = WebProcessingService('http://cida.usgs.gov/gdp/process/WebProcessingService')
 
 Submit fake invocation of Execute operation using cached HTTP request and response
-    >>> request = open(resource_file('wps_USGSExecuteInvalidRequest.xml'), 'r').read()
-    >>> response = open(resource_file('wps_USGSExecuteInvalidRequestResponse.xml'), 'r').read()
+    >>> request = open(resource_file('wps_USGSExecuteInvalidRequest.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_USGSExecuteInvalidRequestResponse.xml'), 'rb').read()
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...
     Execution status=ProcessFailed

--- a/tests/doctests/wps_getcapabilities_ceda.txt
+++ b/tests/doctests/wps_getcapabilities_ceda.txt
@@ -25,17 +25,16 @@ Check WPS description
 
 Check available operations
     >>> for operation in wps.operations:
-    ...     print operation.name
-    ... 
+    ...     print(operation.name)
+    ...
     GetCapabilities
     DescribeProcess
     Execute
-    
 
 Check high level process descriptions
     >>> for process in wps.processes:
     ...     process.identifier, process.title
-    ... 
+    ...
     ('CDMSSubsetVariable', 'Writes a text file and returns an output.')
     ('NCDumpIt', 'Calls ncdump on the input file path and writes it to an output file.')
     ('TestDap', 'Writes a text file and returns an output.')

--- a/tests/doctests/wps_getcapabilities_ceda.txt
+++ b/tests/doctests/wps_getcapabilities_ceda.txt
@@ -12,7 +12,7 @@ Initialize WPS client
 
 Execute fake invocation of GetCapabilities operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_CEDACapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_CEDACapabilities.xml'), 'rb').read()
     >>> wps.getcapabilities(xml=xml)
 
 Check WPS description

--- a/tests/doctests/wps_getcapabilities_usgs.txt
+++ b/tests/doctests/wps_getcapabilities_usgs.txt
@@ -25,8 +25,8 @@ Check WPS description
 
 Check available operations
     >>> for operation in wps.operations:
-    ...     print operation.name
-    ... 
+    ...     print(operation.name)
+    ...
     GetCapabilities
     DescribeProcess
     Execute

--- a/tests/doctests/wps_getcapabilities_usgs.txt
+++ b/tests/doctests/wps_getcapabilities_usgs.txt
@@ -12,7 +12,7 @@ Initialize WPS client
 
 Execute fake invocation of GetCapabilities operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_USGSCapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_USGSCapabilities.xml'), 'rb').read()
     >>> wps.getcapabilities(xml=xml)
 
 Check WPS description

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -43,6 +43,6 @@ Supply process input arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_USGSExecuteRequest2.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_USGSExecuteRequest2.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -9,41 +9,40 @@ Imports
 
 Supply process input arguments
 
-    >>> wfsUrl = "http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs"
-    >>> query = WFSQuery("sample:CONUS_States", propertyNames=['the_geom',"STATE"], filters=["CONUS_States.508","CONUS_States.469"])
+    >>> wfsUrl = 'http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs'
+    >>> query = WFSQuery('sample:CONUS_States', propertyNames=['the_geom', 'STATE'], filters=['CONUS_States.508', 'CONUS_States.469'])
     >>> featureCollection = WFSFeatureCollection(wfsUrl, query)
     >>> processid = 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm'
-    >>> inputs = [ ("FEATURE_ATTRIBUTE_NAME","STATE"),
-    ...            ("DATASET_URI", "dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml"),
-    ...            ("DATASET_ID", "ccsm3_a1b_tmax"),
-    ...            ("DATASET_ID", "ccsm3_a1b_pr"),
-    ...            ("DATASET_ID", "ccsm3_a1fi_tmax"),          
-    ...            ("TIME_START","1960-01-01T00:00:00.000Z"),
-    ...            ("TIME_END","1960-12-31T00:00:00.000Z"),
-    ...            ("REQUIRE_FULL_COVERAGE","true"),
-    ...            ("DELIMITER","COMMA"),
-    ...            ("STATISTICS","MEAN"),
-    ...            ("STATISTICS","MINIMUM"),
-    ...            ("STATISTICS","MAXIMUM"),
-    ...            ("STATISTICS","WEIGHT_SUM"),
-    ...            ("STATISTICS","VARIANCE"),
-    ...            ("STATISTICS","STD_DEV"),
-    ...            ("STATISTICS","COUNT"),
-    ...            ("GROUP_BY","STATISTIC"),
-    ...            ("SUMMARIZE_TIMESTEP","true"),
-    ...            ("SUMMARIZE_FEATURE_ATTRIBUTE","true"),
-    ...            ("FEATURE_COLLECTION", featureCollection)
+    >>> inputs = [ ('FEATURE_ATTRIBUTE_NAME','STATE'),
+    ...            ('DATASET_URI', 'dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml'),
+    ...            ('DATASET_ID', 'ccsm3_a1b_tmax'),
+    ...            ('DATASET_ID', 'ccsm3_a1b_pr'),
+    ...            ('DATASET_ID', 'ccsm3_a1fi_tmax'),
+    ...            ('TIME_START', '1960-01-01T00:00:00.000Z'),
+    ...            ('TIME_END', '1960-12-31T00:00:00.000Z'),
+    ...            ('REQUIRE_FULL_COVERAGE', 'true'),
+    ...            ('DELIMITER', 'COMMA'),
+    ...            ('STATISTICS', 'MEAN'),
+    ...            ('STATISTICS', 'MINIMUM'),
+    ...            ('STATISTICS', 'MAXIMUM'),
+    ...            ('STATISTICS', 'WEIGHT_SUM'),
+    ...            ('STATISTICS', 'VARIANCE'),
+    ...            ('STATISTICS', 'STD_DEV'),
+    ...            ('STATISTICS', 'COUNT'),
+    ...            ('GROUP_BY', 'STATISTIC'),
+    ...            ('SUMMARIZE_TIMESTEP', 'true'),
+    ...            ('SUMMARIZE_FEATURE_ATTRIBUTE', 'true'),
+    ...            ('FEATURE_COLLECTION', featureCollection),
     ...           ]
-    >>> output = "OUTPUT"
+    >>> output = 'OUTPUT'
 
     # build XML request for WPS process execution
     >>> execution = WPSExecution()
     >>> requestElement = execution.buildRequest(processid, inputs, output=output)
-    >>> request = etree.tostring( requestElement )
+    >>> request = etree.tostring(requestElement)
 
 Compare to cached XML request
 
     >>> _request = open(resource_file('wps_USGSExecuteRequest2.xml'), 'r').read()
     >>> compare_xml(request, _request)
     True
-

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -40,6 +40,6 @@ Supply process input arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -10,37 +10,36 @@ Import python modules
 Supply process input arguments
 
     >>> polygon = [(-102.8184, 39.5273), (-102.8184, 37.418), (-101.2363, 37.418), (-101.2363, 39.5273), (-102.8184, 39.5273)]
-    >>> featureCollection = GMLMultiPolygonFeatureCollection( [polygon] )
+    >>> featureCollection = GMLMultiPolygonFeatureCollection([polygon])
     >>> processid = 'gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm'
-    >>> inputs = [ ("FEATURE_ATTRIBUTE_NAME","the_geom"),
-    ...            ("DATASET_URI", "dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml"),
-    ...            ("DATASET_ID", "ccsm3_a1b_tmax"),
-    ...            ("TIME_START","1960-01-01T00:00:00.000Z"),
-    ...            ("TIME_END","1960-12-31T00:00:00.000Z"),
-    ...            ("REQUIRE_FULL_COVERAGE","true"),
-    ...            ("DELIMITER","COMMA"),
-    ...            ("STATISTICS","MEAN"),
-    ...            ("STATISTICS","MINIMUM"),
-    ...            ("STATISTICS","MAXIMUM"),
-    ...            ("STATISTICS","WEIGHT_SUM"),
-    ...            ("STATISTICS","VARIANCE"),
-    ...            ("STATISTICS","STD_DEV"),
-    ...            ("STATISTICS","COUNT"),
-    ...            ("GROUP_BY","STATISTIC"),
-    ...            ("SUMMARIZE_TIMESTEP","false"),
-    ...            ("SUMMARIZE_FEATURE_ATTRIBUTE","false"),
-    ...            ("FEATURE_COLLECTION", featureCollection)
+    >>> inputs = [ ('FEATURE_ATTRIBUTE_NAME', 'the_geom'),
+    ...            ('DATASET_URI', 'dods://igsarm-cida-thredds1.er.usgs.gov:8080/thredds/dodsC/dcp/conus_grid.w_meta.ncml'),
+    ...            ('DATASET_ID', 'ccsm3_a1b_tmax'),
+    ...            ('TIME_START', '1960-01-01T00:00:00.000Z'),
+    ...            ('TIME_END', '1960-12-31T00:00:00.000Z'),
+    ...            ('REQUIRE_FULL_COVERAGE', 'true'),
+    ...            ('DELIMITER', 'COMMA'),
+    ...            ('STATISTICS', 'MEAN'),
+    ...            ('STATISTICS', 'MINIMUM'),
+    ...            ('STATISTICS', 'MAXIMUM'),
+    ...            ('STATISTICS', 'WEIGHT_SUM'),
+    ...            ('STATISTICS', 'VARIANCE'),
+    ...            ('STATISTICS', 'STD_DEV'),
+    ...            ('STATISTICS', 'COUNT'),
+    ...            ('GROUP_BY', 'STATISTIC'),
+    ...            ('SUMMARIZE_TIMESTEP', 'false'),
+    ...            ('SUMMARIZE_FEATURE_ATTRIBUTE', 'false'),
+    ...            ('FEATURE_COLLECTION', featureCollection),
     ...           ]
-    >>> output = "OUTPUT"
+    >>> output = 'OUTPUT'
 
     # build XML request for WPS process execution
     >>> execution = WPSExecution()
     >>> requestElement = execution.buildRequest(processid, inputs, output=output)
-    >>> request = etree.tostring( requestElement )
+    >>> request = etree.tostring(requestElement)
 
 Compare to cached XML request
 
     >>> _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'r').read()
     >>> compare_xml(request, _request)
     True
-    

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -21,6 +21,6 @@ Process input/ouutput arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest4.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest4.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -9,15 +9,15 @@ Imports
 
 Process input/ouutput arguments
 
-    >>> processid = "reprojectImage"
-    >>> inputs = [ ("inputImage","http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img"),
-    ...            ("outputSRS", "EPSG:4326") ]
-    >>> output = "outputImage"
+    >>> processid = 'reprojectImage'
+    >>> inputs = [ ('inputImage', 'http://rsg.pml.ac.uk/wps/testdata/elev_srtm_30m.img'),
+    ...            ('outputSRS', 'EPSG:4326') ]
+    >>> output = 'outputImage'
 
     # build XML request for WPS process execution
     >>> execution = WPSExecution()
     >>> requestElement = execution.buildRequest(processid, inputs, output=output)
-    >>> request = etree.tostring( requestElement )
+    >>> request = etree.tostring(requestElement)
 
 Compare to cached XML request
 

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -9,15 +9,15 @@ Imports
 
 Process input/ouutput arguments
 
-    >>> processid = "reprojectCoords"
-    >>> inputs = [ ("coords","http://rsg.pml.ac.uk/wps/testdata/coords.txt"),
-    ...            ("outputSRS", "EPSG:32630"),
-    ...            ("inputSRS","EPSG:4326") ]
+    >>> processid = 'reprojectCoords'
+    >>> inputs = [ ('coords', 'http://rsg.pml.ac.uk/wps/testdata/coords.txt'),
+    ...            ('outputSRS', 'EPSG:32630'),
+    ...            ('inputSRS', 'EPSG:4326') ]
 
     # build XML request for WPS process execution
     >>> execution = WPSExecution()
     >>> requestElement = execution.buildRequest(processid, inputs)
-    >>> request = etree.tostring( requestElement )
+    >>> request = etree.tostring(requestElement)
 
 Compare to cached XML request
 

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -21,6 +21,6 @@ Process input/ouutput arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest5.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest5.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -21,6 +21,6 @@ Build XML request for WPS process execution
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -9,15 +9,15 @@ Imports
 
 Process input/ouutput arguments
 
-    >>> processid = "v.net.path"
-    >>> inputs = [ ("input","http://rsg.pml.ac.uk/wps/example/graph.gml"),
-    ...            ("file","1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481")]
+    >>> processid = 'v.net.path'
+    >>> inputs = [ ('input', 'http://rsg.pml.ac.uk/wps/example/graph.gml'),
+    ...            ('file', '1 -960123.1421801624 4665723.56559387 -101288.65106088226 5108200.011823481')]
 
 Build XML request for WPS process execution
 
     >>> execution = WPSExecution()
     >>> requestElement = execution.buildRequest(processid, inputs)
-    >>> request = etree.tostring( requestElement )
+    >>> request = etree.tostring(requestElement)
 
 Compare to cached XML request
 

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -8,7 +8,7 @@ Execute face WPS invocation
 
     >>> request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'r').read()
     >>> response = open(resource_file('wps_PMLExecuteResponse6.xml'), 'r').read()
-    >>> 
+    >>>
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...
     Execution status=ProcessSucceeded

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -6,8 +6,8 @@ Instantiate WPS
 
 Execute face WPS invocation
 
-    >>> request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'r').read()
-    >>> response = open(resource_file('wps_PMLExecuteResponse6.xml'), 'r').read()
+    >>> request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_PMLExecuteResponse6.xml'), 'rb').read()
     >>>
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,30 +2,36 @@ import os
 from owslib.etree import etree
 from urlparse import urlparse
 
+
 def resource_file(filepath):
     return os.path.join(test_directory(), 'resources', filepath)
+
 
 def test_directory():
     """Helper function to return path to the tests directory"""
     return os.path.dirname(__file__)
 
+
 def scratch_directory():
     """Helper function to return path to the tests scratch directory"""
     return os.path.join(test_directory(), 'scratch')
+
 
 def scratch_file(filename):
     """Helper function to return file path in the tests scratch directory"""
     return os.path.join(scratch_directory(), filename)
 
-def compare_xml(a,b):
+
+def compare_xml(a, b):
     if not isinstance(a, etree._Element):
         a = etree.fromstring(a)
     if not isinstance(b, etree._Element):
         b = etree.fromstring(b)
 
-    return compare_elements(a,b)
+    return compare_elements(a, b)
 
-def compare_elements(a,b):
+
+def compare_elements(a, b):
     # Tag
     if a.tag != b.tag:
         return False
@@ -45,14 +51,17 @@ def compare_elements(a,b):
 
     return True
 
+
 def cast_tuple_int_list(tup):
     """Set tuple float values to int for more predictable test results"""
     return [int(a) for a in tup]
+
 
 def cast_tuple_int_list_srs(tup):
     tup2 = cast_tuple_int_list(tup[:4])
     tup2.append(tup[-1])
     return tup2
+
 
 def sorted_url_query(url):
     return sorted(urlparse(url).query.split("&"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,13 +2,7 @@ import os
 
 from six.moves.urllib.parse import urlparse
 
-from owslib.etree import etree
-
-
-try:
-    Element = etree._Element
-except AttributeError:
-    Element = etree.Element
+from owslib.etree import etree, Element
 
 
 def resource_file(filepath):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 import os
+
+from six.moves.urllib.parse import urlparse
+
 from owslib.etree import etree
-from urlparse import urlparse
 
 
 def resource_file(filepath):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,12 @@ from six.moves.urllib.parse import urlparse
 from owslib.etree import etree
 
 
+try:
+    Element = etree._Element
+except AttributeError:
+    Element = etree.Element
+
+
 def resource_file(filepath):
     return os.path.join(test_directory(), 'resources', filepath)
 
@@ -25,9 +31,9 @@ def scratch_file(filename):
 
 
 def compare_xml(a, b):
-    if not isinstance(a, etree._Element):
+    if not isinstance(a, Element):
         a = etree.fromstring(a)
-    if not isinstance(b, etree._Element):
+    if not isinstance(b, Element):
         b = etree.fromstring(b)
 
     return compare_elements(a, b)


### PR DESCRIPTION
Look like code have many different code styles at once. I use auto tools as `autopep8` and manual checking for update code. Also it contain steps move to python 3 support.

Patches take care at most about code style and python 3 compatibility and didn't:
- line length, but now it can be too long
- double and single quotes for strings (for code used more single for docstring double)
