### PR TITLE
Better handling of AnyValue

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -813,6 +813,7 @@ class InputOutput(object):
         self.supportedValues = []
         self.defaultValue = None
         self.dataType = None
+        self.anyValue = False
         
     def _parseData(self, element):
         """
@@ -861,7 +862,7 @@ class InputOutput(object):
                 elif subElement.tag.endswith('DefaultValue'):
                     self.defaultValue = getTypedValue(self.dataType, subElement.text)
                 elif subElement.tag.endswith('AnyValue'):
-                    self.allowedValues.append( getTypedValue(self.dataType, 'AnyValue') )
+                    self.anyValue = True
                     
 
     def _parseComplexData(self, element, complexDataElementName):


### PR DESCRIPTION
This improves WPS handling of AnyValue, and fixes potential crashes.

1) AnyValue should not be added to the list of allowed values, as it is itself not an allowed value, but rather a signifier that any value is permitted.  To better distinguish these cases, I added an anyValue flag, which defaults to False, and gets set to True if the AnyValue tag is encountered.  (This is also how OpenLayers works, so the general semantics will be familiar to anyone working with that lib.)

2) If AnyValue is present and the datatype is numeric, then the current code will crash trying to convert AnyValue to a number (which cannot be done).  This patch prevents that crash.
