### PR TITLE
Added 'om' back to the list of default SOS namespaces

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -10,7 +10,7 @@ from owslib.namespaces import Namespaces
 
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["ogc","sml","gml","sos","swe","xlink"])
+    ns = n.get_namespaces(["ogc","sml","gml","om","sos","swe","xlink"])
     ns["ows"] = n.get_namespace("ows110")
     return ns
 namespaces = get_namespaces()


### PR DESCRIPTION
In a recent namespace reorganisation, it appears the "om" namespace was accidentally dropped from the default list for a SOS (its key for  SOS observations).  This has caused backward incompatibilities with some of our existing code that is built using OWSlib. 
