### PR TITLE
Reimplement AnyValue fix, including test changes

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -813,6 +813,7 @@ class InputOutput(object):
         self.supportedValues = []
         self.defaultValue = None
         self.dataType = None
+        self.anyValue = False
         
     def _parseData(self, element):
         """
@@ -861,7 +862,7 @@ class InputOutput(object):
                 elif subElement.tag.endswith('DefaultValue'):
                     self.defaultValue = getTypedValue(self.dataType, subElement.text)
                 elif subElement.tag.endswith('AnyValue'):
-                    self.allowedValues.append( getTypedValue(self.dataType, 'AnyValue') )
+                    self.anyValue = True
                     
 
     def _parseComplexData(self, element, complexDataElementName):
@@ -1370,6 +1371,8 @@ def printInputOutput(value, indent=''):
     print '%s identifier=%s, title=%s, abstract=%s, data type=%s' % (indent, value.identifier, value.title, value.abstract, value.dataType)
     for val in value.allowedValues:
         print '%s Allowed Value: %s' % (indent, printValue(val))
+    if value.anyValue:
+        print ' Any value allowed'
     for val in value.supportedValues:
         print '%s Supported Value: %s' % (indent, printValue(val))
     print '%s Default Value: %s ' % (indent, printValue(value.defaultValue))

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -32,9 +32,10 @@ Check process inputs
     ... 
     Process input:
      identifier=NumberToDouble, title=NumberToDouble, abstract=NumberToDouble, data type=LiteralData
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=1, maxOccurs=-1
+
 
 Check process outputs
 

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -44,32 +44,32 @@ Check process inputs
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=DATASET_URI, title=Dataset URI, abstract=The base data web service URI for the dataset of interest., data type=anyURI
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=DATASET_ID, title=Dataset Identifier, abstract=The unique identifier for the data type or variable of interest., data type=string
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=1, maxOccurs=2147483647
     Process input:
      identifier=REQUIRE_FULL_COVERAGE, title=Require Full Coverage, abstract=If turned on, the service will require that the dataset of interest fully cover the polygon analysis zone data., data type=boolean
-     Allowed Value: True
+     Any value allowed
      Default Value: True 
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=TIME_START, title=Time Start, abstract=The date to begin analysis., data type=dateTime
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=TIME_END, title=Time End, abstract=The date to end analysis., data type=dateTime
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=FEATURE_ATTRIBUTE_NAME, title=Feature Attribute Name, abstract=The attribute that will be used to label column headers in processing output., data type=string
-     Allowed Value: AnyValue
+     Any value allowed
      Default Value: None 
      minOccurs=1, maxOccurs=1
     Process input:
@@ -98,12 +98,12 @@ Check process inputs
      minOccurs=1, maxOccurs=1
     Process input:
      identifier=SUMMARIZE_TIMESTEP, title=Summarize Timestep, abstract=If selected, processing output will include columns with summarized statistics for all feature attribute values for each timestep, data type=boolean
-     Allowed Value: True
+     Any value allowed
      Default Value: True 
      minOccurs=0, maxOccurs=1
     Process input:
      identifier=SUMMARIZE_FEATURE_ATTRIBUTE, title=Summarize Feature Attribute, abstract=If selected, processing output will include a final row of statistics summarizing all timesteps for each feature attribute value, data type=boolean
-     Allowed Value: True
+     Any value allowed
      Default Value: True 
      minOccurs=0, maxOccurs=1
 


### PR DESCRIPTION
NOTE: Test failure does not appear related to this commit

This improves WPS handling of AnyValue, and fixes potential crashes.

1) AnyValue should not be added to the list of allowed values, as it is itself not an allowed value, but rather a signifier that any value is permitted. To better distinguish these cases, I added an anyValue flag, which defaults to False, and gets set to True if the AnyValue tag is encountered. (This is also how OpenLayers works, so the general semantics will be familiar to anyone working with that lib.)

2) If AnyValue is present and the datatype is numeric, then the current code will crash trying to convert AnyValue to a number (which cannot be done). This patch prevents that crash.

3) Includes fixes to tests to reflect these changes

Fixes the following crash:

from owslib.wps import WebProcessingService
wps = WebProcessingService("http://geoprocessing.demo.52north.org:8081/wps/WebProcessingService", version="1.0.0")
wps.describeprocess("r.los")
