### PR TITLE
quick fix to add gmi:MI_Matadata support to csw

### DIFF
--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -495,7 +495,7 @@ class CatalogueServiceWeb:
 
     def _parserecords(self, outputschema, esn):
         if outputschema == namespaces['gmd']: # iso 19139
-            for i in self._exml.findall('.//'+util.nspath_eval('gmd:MD_Metadata', namespaces)):
+            for i in self._exml.findall('.//'+util.nspath_eval('gmd:MD_Metadata', namespaces)) or self._exml.findall('.//'+util.nspath_eval('gmi:MI_Metadata', namespaces)):
                 val = i.find(util.nspath_eval('gmd:fileIdentifier/gco:CharacterString', namespaces))
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = MD_Metadata(i)

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -15,6 +15,7 @@ class Namespaces(object):
         'fgdc'  :   'http://www.opengis.net/cat/csw/csdgm',
         'gco'   :   'http://www.isotc211.org/2005/gco',
         'gmd'   :   'http://www.isotc211.org/2005/gmd',
+        'gmi'   :   'http://www.isotc211.org/2005/gmi',
         'gml'   :   'http://www.opengis.net/gml',
         'gml311':   'http://www.opengis.net/gml',
         'gml32' :   'http://www.opengis.net/gml/3.2',


### PR DESCRIPTION
ISO Metadata Standard (19115-2) container `gmi:MI_Metadata` is ignored by the parser. This patch will make the parser to look inside `gmi:MI_Metadata` as well as `gmd:MD_Metadata` for record information.
