### PR TITLE
Adds client specified timeouts to SOS 2.0

### DIFF
--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -118,6 +118,10 @@ class SensorObservationService_2_0_0(object):
 
         assert isinstance(procedure, str)
         request['procedure'] = procedure
+        
+        url_kwargs = {}
+        if 'timeout' in kwargs:
+            url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
 
         # Optional Fields
         if kwargs:
@@ -126,7 +130,7 @@ class SensorObservationService_2_0_0(object):
        
         data = urlencode(request)        
 
-        response = openURL(base_url, data, method, username=self.username, password=self.password).read()
+        response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
         tr = etree.fromstring(response)
 
         if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):
@@ -168,6 +172,10 @@ class SensorObservationService_2_0_0(object):
         # Optional Fields
         if eventTime is not None:
             request['temporalFilter'] = eventTime
+        
+        url_kwargs = {}
+        if 'timeout' in kwargs:
+            url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
 
         if kwargs:
             for kw in kwargs:
@@ -175,7 +183,7 @@ class SensorObservationService_2_0_0(object):
 
         data = urlencode(request)        
 
-        response = openURL(base_url, data, method, username=self.username, password=self.password).read()
+        response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
         try:
             tr = etree.fromstring(response)
             if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):


### PR DESCRIPTION
- SOS clients can specify in the kwargs of the methods
  a timeout which gets passed to the URL request.
