### PR TITLE
some wms servers lack a scalehint max attribute

### DIFF
--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -1,4 +1,4 @@
-# -*- coding: ISO-8859-15 -*-
+# -*- coding: iso-8859-15 -*-
 # =============================================================================
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2005 Nuxeo SARL <http://nuxeo.com>
@@ -366,7 +366,8 @@ class ContentMetadata:
         sh = elem.find('ScaleHint') 
         self.scaleHint = None 
         if sh is not None: 
-            self.scaleHint = {'min': sh.attrib['min'], 'max': sh.attrib['max']} 
+            if 'min' in sh.attrib and 'max' in sh.attrib:
+                self.scaleHint = {'min': sh.attrib['min'], 'max': sh.attrib['max']} 
 
         attribution = elem.find('Attribution')
         if attribution is not None:


### PR DESCRIPTION
I found a WMS server that lacks the max attribute in the scalehint element. According to the 1.1.1 WMS standard it's required, but I added a check for it so that it does not cause an error. 

The server that had the error is located at this url:
http://geodata1.nationaalgeoregister.nl/luchtfoto/wms

I informed them of the error, so it might get updated at some point. 
