### PR TITLE
SOS __getitem__ to use id not name

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -30,7 +30,7 @@ class SensorObservationService_1_0_0(object):
 
     def __getitem__(self,id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
-        if name in self.__getattribute__('contents').keys():
+        if id in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
             raise KeyError, "No Observational Offering with id: %s" % id
@@ -67,17 +67,17 @@ class SensorObservationService_1_0_0(object):
         raise KeyError("No operation named %s" % name)
 
     def _build_metadata(self):
-        """ 
+        """
             Set up capabilities metadata objects
         """
         # ows:ServiceIdentification metadata
         service_id_element = self._capabilities.find(nspath_eval('ows:ServiceIdentification', namespaces))
         self.identification = ows.ServiceIdentification(service_id_element)
-        
+
         # ows:ServiceProvider metadata
         service_provider_element = self._capabilities.find(nspath_eval('ows:ServiceProvider', namespaces))
         self.provider = ows.ServiceProvider(service_provider_element)
-            
+
         # ows:OperationsMetadata metadata
         self.operations=[]
         for elem in self._capabilities.findall(nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
@@ -115,7 +115,7 @@ class SensorObservationService_1_0_0(object):
 
         assert isinstance(procedure, str)
         request['procedure'] = procedure
-        
+
         url_kwargs = {}
         if 'timeout' in kwargs:
             url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
@@ -124,13 +124,13 @@ class SensorObservationService_1_0_0(object):
         if kwargs:
             for kw in kwargs:
                 request[kw]=kwargs[kw]
-       
-        data = urlencode(request)        
+
+        data = urlencode(request)
 
 
         response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
 
-            
+
 
         tr = etree.fromstring(response)
 
@@ -176,7 +176,7 @@ class SensorObservationService_1_0_0(object):
         # Optional Fields
         if eventTime is not None:
             request['eventTime'] = eventTime
-        
+
         url_kwargs = {}
         if 'timeout' in kwargs:
             url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
@@ -185,7 +185,7 @@ class SensorObservationService_1_0_0(object):
             for kw in kwargs:
                 request[kw]=kwargs[kw]
 
-        data = urlencode(request)        
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password, **kwargs).read()
         try:
@@ -193,13 +193,13 @@ class SensorObservationService_1_0_0(object):
             if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):
                 raise ows.ExceptionReport(tr)
             else:
-                return response                
+                return response
         except ows.ExceptionReport:
             raise
         except BaseException:
             return response
 
-    def get_operation_by_name(self, name): 
+    def get_operation_by_name(self, name):
         """
             Return a Operation item by name, case insensitive
         """
@@ -266,7 +266,7 @@ class SosObservationOffering(object):
 
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
-        
+
 class SosCapabilitiesReader(object):
     def __init__(self, version="1.0.0", url=None, username=None, password=None):
         self.version = version
@@ -316,4 +316,3 @@ class SosCapabilitiesReader(object):
         if not isinstance(st, str):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
-

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -32,7 +32,7 @@ class SensorObservationService_2_0_0(object):
 
     def __getitem__(self,id):
         ''' check contents dictionary to allow dict like access to service observational offerings'''
-        if name in self.__getattribute__('contents').keys():
+        if id in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
             raise KeyError, "No Observational Offering with id: %s" % id
@@ -56,8 +56,8 @@ class SensorObservationService_2_0_0(object):
 
         # Avoid building metadata if the response is an Exception
         se = self._capabilities.find(nspath_eval('ows:ExceptionReport', namespaces))
-        if se is not None: 
-            raise ows.ExceptionReport(se) 
+        if se is not None:
+            raise ows.ExceptionReport(se)
 
         # build metadata objects
         self._build_metadata()
@@ -70,17 +70,17 @@ class SensorObservationService_2_0_0(object):
         raise KeyError("No operation named %s" % name)
 
     def _build_metadata(self):
-        """ 
+        """
             Set up capabilities metadata objects
         """
         # ows:ServiceIdentification metadata
         service_id_element = self._capabilities.find(nspath_eval('ows:ServiceIdentification', namespaces))
         self.identification = ows.ServiceIdentification(service_id_element)
-        
+
         # ows:ServiceProvider metadata
         service_provider_element = self._capabilities.find(nspath_eval('ows:ServiceProvider', namespaces))
         self.provider = ows.ServiceProvider(service_provider_element)
-            
+
         # ows:OperationsMetadata metadata
         self.operations= []
         for elem in self._capabilities.findall(nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
@@ -118,7 +118,7 @@ class SensorObservationService_2_0_0(object):
 
         assert isinstance(procedure, str)
         request['procedure'] = procedure
-        
+
         url_kwargs = {}
         if 'timeout' in kwargs:
             url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
@@ -127,8 +127,8 @@ class SensorObservationService_2_0_0(object):
         if kwargs:
             for kw in kwargs:
                 request[kw]=kwargs[kw]
-       
-        data = urlencode(request)        
+
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
         tr = etree.fromstring(response)
@@ -155,7 +155,7 @@ class SensorObservationService_2_0_0(object):
             anything else e.g. vendor specific parameters
         """
 
-        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']        
+        base_url = self.get_operation_by_name('GetObservation').methods[method]['url']
 
         request = {'service': 'SOS', 'version': self.version, 'request': 'GetObservation'}
 
@@ -172,7 +172,7 @@ class SensorObservationService_2_0_0(object):
         # Optional Fields
         if eventTime is not None:
             request['temporalFilter'] = eventTime
-        
+
         url_kwargs = {}
         if 'timeout' in kwargs:
             url_kwargs['timeout'] = kwargs.pop('timeout') # Client specified timeout value
@@ -181,7 +181,7 @@ class SensorObservationService_2_0_0(object):
             for kw in kwargs:
                 request[kw]=kwargs[kw]
 
-        data = urlencode(request)        
+        data = urlencode(request)
 
         response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
         try:
@@ -189,13 +189,13 @@ class SensorObservationService_2_0_0(object):
             if tr.tag == nspath_eval("ows:ExceptionReport", namespaces):
                 raise ows.ExceptionReport(tr)
             else:
-                return response                
+                return response
         except ows.ExceptionReport:
             raise
         except BaseException:
             return response
 
-    def get_operation_by_name(self, name): 
+    def get_operation_by_name(self, name):
         """
             Return a Operation item by name, case insensitive
         """
@@ -262,7 +262,7 @@ class SosObservationOffering(object):
 
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
-        
+
 class SosCapabilitiesReader(object):
     def __init__(self, version="2.0.0", url=None, username=None, password=None):
         self.version = version
@@ -312,4 +312,3 @@ class SosCapabilitiesReader(object):
         if not isinstance(st, str):
             raise ValueError("String must be of type string, not %s" % type(st))
         return etree.fromstring(st)
-

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -112,7 +112,7 @@ OperationsMetadata
     >>> getcap = ndbc.get_operation_by_name('GetCapabilities')
     >>> isinstance(getcap, OperationsMetadata)
     True
-    
+
     Get by name (case insensitive)
 
     >>> getcap = ndbc.get_operation_by_name('getcapabilities')
@@ -174,6 +174,16 @@ Contents
     >>> len(contents)
     848
 
+Dict access __getitem__
+    >>> ndbc['station-46084'].name
+    'urn:ioos:station:wmo:46084'
+
+    >>> ndbc['rubbishrubbish'].name
+    Traceback (most recent call last):
+      ...
+    KeyError: 'No Observational Offering with id: rubbishrubbish'
+
+
 Network
     >>> network = contents['network-all']
     >>> network.id
@@ -181,10 +191,10 @@ Network
 
     >>> network.name
     'urn:ioos:network:noaa.nws.ndbc:all'
-    
+
     >>> network.description
     'All stations on the NDBC SOS server'
-    
+
     >>> srs = network.srs
     >>> isinstance(srs, Crs)
     True
@@ -204,14 +214,14 @@ Network
     'urn:ogc:def:crs:EPSG::4326'
     >>> bbsrs.getcode()
     'EPSG:4326'
-    
+
     >>> bp = network.begin_position
     >>> isinstance(bp, datetime)
     True
     >>> ep = network.end_position
     >>> isinstance(ep, datetime)
     True
-    
+
     >>> network.result_model
     'om:Observation'
 
@@ -251,7 +261,7 @@ Station
 
     >>> station.description
     "Zeke's Basin, North Carolina"
-    
+
     >>> srs = station.srs
     >>> isinstance(srs, Crs)
     True
@@ -261,7 +271,7 @@ Station
     'EPSG:4326'
     >>> cast_tuple_int_list(station.bbox)
     [-77, 33, -77, 33]
-    
+
     >>> bbsrs = station.bbox_srs
     >>> isinstance(bbsrs, Crs)
     True


### PR DESCRIPTION
sos100 and sos200 implement **getitem** to allow array like access to
the content offerings. was testing for name instead of id to be a valid
key.
Added doctest to verify valid and invalid keys

This is not an important function - but as it is present it should be correct.
