### PR TITLE
Fix two doctest failures.

### DIFF
--- a/tests/doctests/iso_creation.txt
+++ b/tests/doctests/iso_creation.txt
@@ -33,7 +33,7 @@ Print testing of various ISO fields
 
 	>>> md.identifier
 	'286c0725-146e-4533-b1bf-d6e367f6c342'
-	>>> kw
-	{'keywords': ['Agricultural and aquaculture facilities', 'Bio-geographical regions'], 'type': None, 'thesaurus': {'date': '2008-06-01', 'datetype': 'publication', 'title': 'GEMET - INSPIRE themes, version 1.0'}}
+	>>> kw == {'keywords': ['Agricultural and aquaculture facilities', 'Bio-geographical regions'], 'type': None, 'thesaurus': {'date': '2008-06-01', 'datetype': 'publication', 'title': 'GEMET - INSPIRE themes, version 1.0'}}
+	True
     >>> md.languagecode is None
     True

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -32,8 +32,8 @@ you can filter the contents by profile and srs:
     7
     >>> len(service.items('EPSG:4326', profile='global-mercator'))
     0
-    >>> service.items('EPSG:4326')[0]
-    ('http://maps.opengeo.org/geowebcache/service/tms/1.0.0/bluemarble@EPSG%3A4326@png', <owslib.tms.ContentMetadata object at ...>)
+    >>> sorted(service.items('EPSG:4326'))[0]  # doctest: +ELLIPSIS
+    ('http://maps.opengeo.org/geowebcache/service/tms/1.0.0/blue@EPSG%3A4326@png', <owslib.tms.ContentMetadata object at ...>)
 
 The details of the TileMap are fetched on demand
     >>> tm._tile_map == None


### PR DESCRIPTION
The first commit fixes a doctest that will fail on Python 3 because dictionaries are not guaranteed to be output in sorted order. But I've actually seen this problem with Python 2.7 in `tox`. So this changes the test to compare against the result, which I've seen used for all the other doctests that involve a dictionary.

The second commit fixes a doctest that is not guaranteed to be stable (since it depends on ordering from an external service).

With these two commits, I can get `tox` to pass locally except for the `tests/doctests/wps_response6.txt` doctest which times out.