### PR TITLE
Updated exception handling

### DIFF
--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -32,7 +32,7 @@ class WebCoverageService_1_0_0(WCSBase):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
     
     def __init__(self,url,xml, cookies):
         self.version='1.0.0'
@@ -166,7 +166,7 @@ class WebCoverageService_1_0_0(WCSBase):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
 
 class OperationMetadata(object):

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -36,7 +36,7 @@ class WebCoverageService_1_1_0(WCSBase):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
     
     def __init__(self,url,xml, cookies):
         self.version='1.1.0'
@@ -191,7 +191,7 @@ class WebCoverageService_1_1_0(WCSBase):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
         
 class Operation(object):
     """Abstraction for operation metadata    

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -68,7 +68,7 @@ class MpartMime(object):
             os.mkdir(unpackdir)
         except OSError as e:
             # Ignore directory exists error
-            if e.errno <> errno.EEXIST:
+            if e.errno != errno.EEXIST:
                 raise
                
         #now walk through the multipart mime and write out files

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -66,7 +66,7 @@ class MpartMime(object):
         #create the directory if it doesn't exist:
         try:
             os.mkdir(unpackdir)
-        except OSError, e:
+        except OSError as e:
             # Ignore directory exists error
             if e.errno <> errno.EEXIST:
                 raise

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -402,7 +402,7 @@ class CatalogueServiceWeb:
         validtransactions = ['insert', 'update', 'delete']
 
         if ttype not in validtransactions:  # invalid transaction
-            raise RuntimeError, 'Invalid transaction \'%s\'.' % ttype
+            raise RuntimeError('Invalid transaction \'%s\'.' % ttype)
 
         node1 = etree.SubElement(node0, util.nspath_eval('csw:%s' % ttype.capitalize(), namespaces))
 
@@ -411,7 +411,7 @@ class CatalogueServiceWeb:
 
         if ttype == 'insert':
             if record is None:
-                raise RuntimeError, 'Nothing to insert.'
+                raise RuntimeError('Nothing to insert.')
             node1.append(etree.fromstring(record))
  
         if ttype == 'update':
@@ -487,7 +487,7 @@ class CatalogueServiceWeb:
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
     def getService_urls(self, service_string=None):
         """
@@ -650,7 +650,7 @@ class CatalogueServiceWeb:
         ]
 
         if self._exml.getroot().tag not in valid_xpaths:
-            raise RuntimeError, 'Document is XML, but not CSW-ish'
+            raise RuntimeError('Document is XML, but not CSW-ish')
 
         # check if it's an OGC Exception
         val = self._exml.find(util.nspath_eval('ows:Exception', namespaces))

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -70,7 +70,7 @@ class WebFeatureService_1_0_0(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
     
     
     def __init__(self, url, version, xml=None, parse_remote_metadata=False, timeout=30):
@@ -238,7 +238,7 @@ class WebFeatureService_1_0_0(object):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
 class ServiceIdentification(object):
     ''' Implements IServiceIdentificationMetadata '''

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -321,7 +321,7 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] == 'TC211':
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -53,7 +53,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
 
 
     def __init__(self, url, version, xml=None, parse_remote_metadata=False, timeout=30):
@@ -244,7 +244,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
 
 

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -299,7 +299,7 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] in ['TC211', '19115', '19139']:
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -61,7 +61,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
     
     
     def __init__(self, url,  version, xml=None, parse_remote_metadata=False, timeout=30):
@@ -303,7 +303,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
 
 class StoredQuery(object):
     '''' Class to describe a storedquery '''

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -390,7 +390,7 @@ class ContentMetadata:
                         metadataUrl['metadata'] = Metadata(doc)
                     except:  # ISO
                         metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -33,7 +33,7 @@ class SensorObservationService_1_0_0(object):
         if id in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
-            raise KeyError, "No Observational Offering with id: %s" % id
+            raise KeyError("No Observational Offering with id: %s" % id)
 
     def __init__(self, url, version='1.0.0', xml=None, username=None, password=None):
         """Initialize."""
@@ -206,7 +206,7 @@ class SensorObservationService_1_0_0(object):
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No Operation named %s" % name
+        raise KeyError("No Operation named %s" % name)
 
 class SosObservationOffering(object):
     def __init__(self, element):

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -228,7 +228,7 @@ class SosObservationOffering(object):
             # (left, bottom, right, top) in self.bbox_srs units
             self.bbox = (float(lower_left_corner[1]), float(lower_left_corner[0]), float(upper_right_corner[1]), float(upper_right_corner[0]))
             self.bbox_srs = Crs(testXMLValue(envelope.attrib.get('srsName'), True))
-        except Exception, err:
+        except Exception:
             self.bbox = None
             self.bbox_srs = None
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -35,7 +35,7 @@ class SensorObservationService_2_0_0(object):
         if id in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[id]
         else:
-            raise KeyError, "No Observational Offering with id: %s" % id
+            raise KeyError("No Observational Offering with id: %s" % id)
 
     def __init__(self, url, version='2.0.0', xml=None, username=None, password=None):
         """Initialize."""
@@ -202,7 +202,7 @@ class SensorObservationService_2_0_0(object):
         for item in self.operations:
             if item.name.lower() == name.lower():
                 return item
-        raise KeyError, "No Operation named %s" % name
+        raise KeyError("No Operation named %s" % name)
 
 class SosObservationOffering(object):
     def __init__(self, element):

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -222,7 +222,7 @@ class SosObservationOffering(object):
             # (left, bottom, right, top) in self.bbox_srs units
             self.bbox = (float(lower_left_corner[1]), float(lower_left_corner[0]), float(upper_right_corner[1]), float(upper_right_corner[0]))
             self.bbox_srs = Crs(testXMLValue(envelope.attrib.get('srsName'), True))
-        except Exception, err:
+        except Exception:
             self.bbox = None
             self.bbox_srs = None
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -177,7 +177,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         if cookies is not None:
             req.add_header('Cookie', cookies)
         u = openit(req, timeout=timeout)
-    except HTTPError, e: #Some servers may set the http header to 400 if returning an OGC service exception or 401 if unauthorised.
+    except HTTPError as e: #Some servers may set the http header to 400 if returning an OGC service exception or 401 if unauthorised.
         if e.code in [400, 401]:
             raise ServiceException, e.read()
         else:

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -179,7 +179,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         u = openit(req, timeout=timeout)
     except HTTPError as e: #Some servers may set the http header to 400 if returning an OGC service exception or 401 if unauthorised.
         if e.code in [400, 401]:
-            raise ServiceException, e.read()
+            raise ServiceException(e.read())
         else:
             raise e
     # check for service exceptions without the http header set
@@ -193,8 +193,7 @@ def openURL(url_base, data, method='Get', cookies=None, username=None, password=
         if serviceException is None:
             serviceException=se_tree.find('ServiceException')
         if serviceException is not None:
-            raise ServiceException, \
-            str(serviceException.text).strip()
+            raise ServiceException(str(serviceException.text).strip())
         u.seek(0) #return cursor to start of u      
     return u
 

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -485,7 +485,7 @@ class ContentMetadata:
                             metadataUrl['metadata'] = Metadata(doc)
                         if metadataUrl['type'] == 'TC211':
                             metadataUrl['metadata'] = MD_Metadata(doc)
-                except Exception, err:
+                except Exception:
                     metadataUrl['metadata'] = None
 
             self.metadataUrls.append(metadataUrl)

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -55,7 +55,7 @@ class WebMapService(object):
         if name in self.__getattribute__('contents').keys():
             return self.__getattribute__('contents')[name]
         else:
-            raise KeyError, "No content named %s" % name
+            raise KeyError("No content named %s" % name)
 
     
     def __init__(self, url, version='1.1.1', xml=None, 
@@ -261,7 +261,7 @@ class WebMapService(object):
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
     
 class ServiceIdentification(object):
     ''' Implements IServiceIdentificationMetadata '''
@@ -300,14 +300,14 @@ class ServiceProvider(object):
         for item in self.contents:
             if item.name == name:
                 return item
-        raise KeyError, "No content named %s" % name
+        raise KeyError("No content named %s" % name)
 
     def getOperationByName(self, name):
         """Return a named content item."""
         for item in self.operations:
             if item.name == name:
                 return item
-        raise KeyError, "No operation named %s" % name
+        raise KeyError("No operation named %s" % name)
         
 class ContentMetadata:
     """


### PR DESCRIPTION
Firstly, use new syntax `except E as N:` instead of `except E, N:` which is ambiguous and unsupported in Python 3. Secondly, use objects for raising exceptions, i.e., `raise Exception(args)` instead of `raise Exception, args`.

This requires Python 2.6, BTW.