### PR TITLE
Add all __future__ imports

### DIFF
--- a/owslib/__init__.py
+++ b/owslib/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import
+
 __version__ = '0.8-dev'

--- a/owslib/__init__.py
+++ b/owslib/__init__.py
@@ -1,3 +1,3 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 __version__ = '0.8-dev'

--- a/owslib/__init__.py
+++ b/owslib/__init__.py
@@ -1,3 +1,3 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 __version__ = '0.8-dev'

--- a/owslib/coverage/__init__.py
+++ b/owslib/coverage/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/owslib/coverage/__init__.py
+++ b/owslib/coverage/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/owslib/coverage/__init__.py
+++ b/owslib/coverage/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -9,6 +9,8 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
+from __future__ import absolute_import
+
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
 from urllib import urlencode
 from owslib.util import openURL, testXMLValue

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -9,7 +9,7 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
 from urllib import urlencode

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -9,7 +9,7 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.coverage.wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
 from urllib import urlencode

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -11,7 +11,7 @@
 
 ##########NOTE: Does not conform to new interfaces yet #################
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from .wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
 from owslib.util import openURL, testXMLValue

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -11,7 +11,7 @@
 
 ##########NOTE: Does not conform to new interfaces yet #################
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from .wcsBase import WCSBase, WCSCapabilitiesReader, ServiceException
 from owslib.util import openURL, testXMLValue

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,6 +9,8 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
+from __future__ import absolute_import
+
 from urllib import urlencode
 from urllib2 import urlopen, Request
 from owslib.etree import etree

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,7 +9,7 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from urllib import urlencode
 from urllib2 import urlopen, Request

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,7 +9,7 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from urllib import urlencode
 from urllib2 import urlopen, Request

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -13,7 +13,7 @@
 #decoder=wcsdecoder.WCSDecoder(u)
 #decoder.getCoverages()
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import os
 from owslib.etree import etree

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -13,6 +13,8 @@
 #decoder=wcsdecoder.WCSDecoder(u)
 #decoder.getCoverages()
 
+from __future__ import absolute_import
+
 import os
 from owslib.etree import etree
 import email

--- a/owslib/coverage/wcsdecoder.py
+++ b/owslib/coverage/wcsdecoder.py
@@ -13,7 +13,7 @@
 #decoder=wcsdecoder.WCSDecoder(u)
 #decoder.getCoverages()
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import os
 from owslib.etree import etree

--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -9,7 +9,7 @@
 
 """ API for OGC CRS constructs. """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 # list of URN codes for EPSG in which axis order
 # of coordinates are y,x (e.g. lat, long)

--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -9,7 +9,7 @@
 
 """ API for OGC CRS constructs. """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 # list of URN codes for EPSG in which axis order
 # of coordinates are y,x (e.g. lat, long)

--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -9,6 +9,8 @@
 
 """ API for OGC CRS constructs. """
 
+from __future__ import absolute_import
+
 # list of URN codes for EPSG in which axis order
 # of coordinates are y,x (e.g. lat, long)
 axisorder_yx = frozenset([

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -9,6 +9,8 @@
 
 """ CSW request and response processor """
 
+from __future__ import absolute_import
+
 import base64
 import inspect
 import warnings

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -9,7 +9,7 @@
 
 """ CSW request and response processor """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import base64
 import inspect

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -9,7 +9,7 @@
 
 """ CSW request and response processor """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import base64
 import inspect

--- a/owslib/dif.py
+++ b/owslib/dif.py
@@ -9,6 +9,8 @@
 
 """ DIF metadata parser """
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import util
 from owslib.namespaces import Namespaces

--- a/owslib/dif.py
+++ b/owslib/dif.py
@@ -9,7 +9,7 @@
 
 """ DIF metadata parser """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/dif.py
+++ b/owslib/dif.py
@@ -9,7 +9,7 @@
 
 """ DIF metadata parser """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -4,6 +4,8 @@
 # Contact email: sgillies@frii.com
 # =============================================================================
 
+from __future__ import absolute_import
+
 
 def patch_well_known_namespaces(etree_module):
 

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -4,7 +4,7 @@
 # Contact email: sgillies@frii.com
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 
 def patch_well_known_namespaces(etree_module):

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -4,7 +4,7 @@
 # Contact email: sgillies@frii.com
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 
 def patch_well_known_namespaces(etree_module):

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -5,7 +5,7 @@
 #
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.crs import Crs
 

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -5,6 +5,8 @@
 #
 # =============================================================================
 
+from __future__ import absolute_import
+
 from owslib.crs import Crs
 
 from urllib import urlencode

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -5,7 +5,7 @@
 #
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.crs import Crs
 

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -6,6 +6,8 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
+from __future__ import absolute_import
+
 import cgi
 from cStringIO import StringIO
 from urllib import urlencode

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -6,7 +6,7 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import cgi
 from cStringIO import StringIO

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -6,7 +6,7 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import cgi
 from cStringIO import StringIO

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,7 +7,7 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import cgi
 from cStringIO import StringIO

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,7 +7,7 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import cgi
 from cStringIO import StringIO

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,6 +7,8 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
+from __future__ import absolute_import
+
 import cgi
 from cStringIO import StringIO
 from urllib import urlencode

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -6,7 +6,7 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 #owslib imports:
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -6,7 +6,7 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 #owslib imports:
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -6,6 +6,8 @@
 # $Id: wfs.py 503 2006-02-01 17:09:12Z dokai $
 # =============================================================================
 
+from __future__ import absolute_import
+
 #owslib imports:
 from owslib.ows import ServiceIdentification, ServiceProvider, OperationsMetadata
 from owslib.etree import etree

--- a/owslib/fes.py
+++ b/owslib/fes.py
@@ -15,7 +15,7 @@ Filter Encoding: http://www.opengeospatial.org/standards/filter
 Currently supports version 1.1.0 (04-095).
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/fes.py
+++ b/owslib/fes.py
@@ -15,7 +15,7 @@ Filter Encoding: http://www.opengeospatial.org/standards/filter
 Currently supports version 1.1.0 (04-095).
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/fes.py
+++ b/owslib/fes.py
@@ -15,6 +15,8 @@ Filter Encoding: http://www.opengeospatial.org/standards/filter
 Currently supports version 1.1.0 (04-095).
 """
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import util
 from owslib.namespaces import Namespaces

--- a/owslib/fgdc.py
+++ b/owslib/fgdc.py
@@ -9,7 +9,7 @@
 
 """ FGDC metadata parser """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/fgdc.py
+++ b/owslib/fgdc.py
@@ -9,6 +9,8 @@
 
 """ FGDC metadata parser """
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import util
 

--- a/owslib/fgdc.py
+++ b/owslib/fgdc.py
@@ -9,7 +9,7 @@
 
 """ FGDC metadata parser """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/interfaces.py
+++ b/owslib/interfaces.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 
 # Follows the 4 aspects of service metadata

--- a/owslib/interfaces.py
+++ b/owslib/interfaces.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 
 # Follows the 4 aspects of service metadata

--- a/owslib/interfaces.py
+++ b/owslib/interfaces.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 
 # Follows the 4 aspects of service metadata
 

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -10,7 +10,7 @@
 
 """ ISO metadata parser """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -10,7 +10,7 @@
 
 """ ISO metadata parser """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import util

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -10,6 +10,8 @@
 
 """ ISO metadata parser """
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import util
 from owslib.namespaces import Namespaces

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 
 class Namespaces(object):

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+
+
 class Namespaces(object):
     """
         Class for holding and maniputlating a dictionary containing the various namespaces for

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 
 class Namespaces(object):

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -15,7 +15,7 @@ OWS Common: http://www.opengeospatial.org/standards/common
 Currently supports version 1.1.0 (06-121r3).
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import crs, util

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -15,6 +15,8 @@ OWS Common: http://www.opengeospatial.org/standards/common
 Currently supports version 1.1.0 (06-121r3).
 """
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import crs, util
 from owslib.namespaces import Namespaces

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -15,7 +15,7 @@ OWS Common: http://www.opengeospatial.org/standards/common
 Currently supports version 1.1.0 (06-121r3).
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import crs, util

--- a/owslib/sos.py
+++ b/owslib/sos.py
@@ -11,7 +11,7 @@
 Sensor Observation Service (SOS) methods and metadata. Factory function.
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from .swe.observation import sos100, sos200
 

--- a/owslib/sos.py
+++ b/owslib/sos.py
@@ -11,7 +11,7 @@
 Sensor Observation Service (SOS) methods and metadata. Factory function.
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from .swe.observation import sos100, sos200
 

--- a/owslib/swe/__init__.py
+++ b/owslib/swe/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/owslib/swe/__init__.py
+++ b/owslib/swe/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/owslib/swe/__init__.py
+++ b/owslib/swe/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, print_function)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.util import nspath_eval
 from owslib.namespaces import Namespaces

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import (absolute_import, print_function)
 
 from owslib.util import nspath_eval
 from owslib.namespaces import Namespaces

--- a/owslib/swe/observation/__init__.py
+++ b/owslib/swe/observation/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/owslib/swe/observation/__init__.py
+++ b/owslib/swe/observation/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/owslib/swe/observation/__init__.py
+++ b/owslib/swe/observation/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import cgi
 from owslib.etree import etree
 from datetime import datetime

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import cgi
 from owslib.etree import etree

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import cgi
 from owslib.etree import etree

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import cgi
 from owslib.etree import etree
 from datetime import datetime

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import cgi
 from owslib.etree import etree

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import cgi
 from owslib.etree import etree

--- a/owslib/swe/sensor/__init__.py
+++ b/owslib/swe/sensor/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/owslib/swe/sensor/__init__.py
+++ b/owslib/swe/sensor/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/owslib/swe/sensor/__init__.py
+++ b/owslib/swe/sensor/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib import crs, util

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib import crs, util

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib import crs, util
 from owslib.util import testXMLValue, testXMLAttribute, nspath_eval, xmltag_split, dict_union, extract_xml_list

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -15,7 +15,7 @@
 # TMS as defined in:
 # http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from .etree import etree
 from .util import openURL, testXMLValue

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -15,7 +15,7 @@
 # TMS as defined in:
 # http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from .etree import etree
 from .util import openURL, testXMLValue

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -7,7 +7,7 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-from __future__ import print_function
+from __future__ import (absolute_import, print_function)
 
 import base64
 import sys

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -7,7 +7,7 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
-from __future__ import (absolute_import, print_function)
+from __future__ import (absolute_import, division, print_function)
 
 import base64
 import sys

--- a/owslib/waterml/__init__.py
+++ b/owslib/waterml/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/owslib/waterml/__init__.py
+++ b/owslib/waterml/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/owslib/waterml/__init__.py
+++ b/owslib/waterml/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from owslib.etree import etree
 from owslib.util import nspath, testXMLValue, openURL
 from owslib.util import xml_to_dict as _xml_to_dict

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib.util import nspath, testXMLValue, openURL

--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.etree import etree
 from owslib.util import nspath, testXMLValue, openURL

--- a/owslib/waterml/wml10.py
+++ b/owslib/waterml/wml10.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree

--- a/owslib/waterml/wml10.py
+++ b/owslib/waterml/wml10.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 

--- a/owslib/waterml/wml10.py
+++ b/owslib/waterml/wml10.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree

--- a/owslib/waterml/wml11.py
+++ b/owslib/waterml/wml11.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree

--- a/owslib/waterml/wml11.py
+++ b/owslib/waterml/wml11.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree
 

--- a/owslib/waterml/wml11.py
+++ b/owslib/waterml/wml11.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from owslib.waterml.wml import SitesResponse, TimeSeriesResponse, VariablesResponse, namespaces
 from owslib.etree import etree

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -13,7 +13,7 @@
 Web Coverage Server (WCS) methods and metadata. Factory function.
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import urllib2
 from . import etree

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -13,7 +13,7 @@
 Web Coverage Server (WCS) methods and metadata. Factory function.
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import urllib2
 from . import etree

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -13,7 +13,7 @@
 Web Feature Server (WFS) methods and metadata. Factory function.
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from .feature import wfs100, wfs110, wfs200
 

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -13,7 +13,7 @@
 Web Feature Server (WFS) methods and metadata. Factory function.
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from .feature import wfs100, wfs110, wfs200
 

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -16,7 +16,7 @@ https://portal.opengeospatial.org/files/?artifact_id=8618
 
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 from .etree import etree
 

--- a/owslib/wmc.py
+++ b/owslib/wmc.py
@@ -16,7 +16,7 @@ https://portal.opengeospatial.org/files/?artifact_id=8618
 
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 from .etree import etree
 

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -15,7 +15,7 @@ API for Web Map Service (WMS) methods and metadata.
 Currently supports only version 1.1.1 of the WMS protocol.
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import cgi
 import urllib2

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -15,7 +15,7 @@ API for Web Map Service (WMS) methods and metadata.
 Currently supports only version 1.1.1 of the WMS protocol.
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import cgi
 import urllib2

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -29,7 +29,7 @@ would be appreciated.
 
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import warnings
 import urlparse

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -29,7 +29,7 @@ would be appreciated.
 
 """
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import warnings
 import urlparse

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -83,7 +83,8 @@ Also, the directory tests/ contains several examples of well-formed "Execute" re
     - The files PMLExecuteRequest*.xml contain requests that can be submitted to the live PML WPS service.
 
 """
-from __future__ import print_function
+
+from __future__ import (absolute_import, print_function)
 
 from owslib.etree import etree
 from owslib.ows import DEFAULT_OWS_NAMESPACE, ServiceIdentification, ServiceProvider, OperationsMetadata

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -84,7 +84,7 @@ Also, the directory tests/ contains several examples of well-formed "Execute" re
 
 """
 
-from __future__ import (absolute_import, print_function)
+from __future__ import (absolute_import, division, print_function)
 
 from owslib.etree import etree
 from owslib.ows import DEFAULT_OWS_NAMESPACE, ServiceIdentification, ServiceProvider, OperationsMetadata

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+
+from __future__ import absolute_import

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
 
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)

--- a/tests/doctests/crs.txt
+++ b/tests/doctests/crs.txt
@@ -1,4 +1,4 @@
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib import crs
     >>> c=crs.Crs('EPSG:4326')
     >>> c.code

--- a/tests/doctests/crs.txt
+++ b/tests/doctests/crs.txt
@@ -1,4 +1,4 @@
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib import crs
     >>> c=crs.Crs('EPSG:4326')
     >>> c.code

--- a/tests/doctests/crs.txt
+++ b/tests/doctests/crs.txt
@@ -1,3 +1,4 @@
+    >>> from __future__ import absolute_import
     >>> from owslib import crs
     >>> c=crs.Crs('EPSG:4326')
     >>> c.code

--- a/tests/doctests/csw_conterra.txt
+++ b/tests/doctests/csw_conterra.txt
@@ -1,4 +1,4 @@
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> c=cs('https://gateway.ceh.ac.uk/soapServices/CSWStartup')
     >>> c.version

--- a/tests/doctests/csw_conterra.txt
+++ b/tests/doctests/csw_conterra.txt
@@ -1,3 +1,4 @@
+    >>> from __future__ import absolute_import
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> c=cs('https://gateway.ceh.ac.uk/soapServices/CSWStartup')
     >>> c.version

--- a/tests/doctests/csw_conterra.txt
+++ b/tests/doctests/csw_conterra.txt
@@ -1,4 +1,4 @@
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> c=cs('https://gateway.ceh.ac.uk/soapServices/CSWStartup')
     >>> c.version

--- a/tests/doctests/csw_gdp.txt
+++ b/tests/doctests/csw_gdp.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib import fes    
     >>> from owslib.dif import namespaces 
     >>> from owslib.csw import CatalogueServiceWeb as cs

--- a/tests/doctests/csw_gdp.txt
+++ b/tests/doctests/csw_gdp.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib import fes    
     >>> from owslib.dif import namespaces 
     >>> from owslib.csw import CatalogueServiceWeb as cs

--- a/tests/doctests/csw_gdp.txt
+++ b/tests/doctests/csw_gdp.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib import fes    
     >>> from owslib.dif import namespaces 
     >>> from owslib.csw import CatalogueServiceWeb as cs

--- a/tests/doctests/csw_geoserver.txt
+++ b/tests/doctests/csw_geoserver.txt
@@ -1,3 +1,4 @@
+>>> from __future__ import absolute_import
 >>> from owslib.csw import CatalogueServiceWeb
 >>> c=CatalogueServiceWeb('http://sdi.georchestra.org/geoserver/ows')
 >>> c.getrecords2(typenames='csw:Record')

--- a/tests/doctests/csw_geoserver.txt
+++ b/tests/doctests/csw_geoserver.txt
@@ -1,4 +1,4 @@
->>> from __future__ import (absolute_import, division)
+>>> from __future__ import (absolute_import, division, print_function)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> c=CatalogueServiceWeb('http://sdi.georchestra.org/geoserver/ows')
 >>> c.getrecords2(typenames='csw:Record')

--- a/tests/doctests/csw_geoserver.txt
+++ b/tests/doctests/csw_geoserver.txt
@@ -1,4 +1,4 @@
->>> from __future__ import absolute_import
+>>> from __future__ import (absolute_import, division)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> c=CatalogueServiceWeb('http://sdi.georchestra.org/geoserver/ows')
 >>> c.getrecords2(typenames='csw:Record')

--- a/tests/doctests/csw_nlr.txt
+++ b/tests/doctests/csw_nlr.txt
@@ -1,5 +1,5 @@
 
->>> from __future__ import (absolute_import, division)
+>>> from __future__ import (absolute_import, division, print_function)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_nlr.txt
+++ b/tests/doctests/csw_nlr.txt
@@ -1,4 +1,5 @@
 
+>>> from __future__ import absolute_import
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_nlr.txt
+++ b/tests/doctests/csw_nlr.txt
@@ -1,5 +1,5 @@
 
->>> from __future__ import absolute_import
+>>> from __future__ import (absolute_import, division)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_pycsw.txt
+++ b/tests/doctests/csw_pycsw.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 

--- a/tests/doctests/csw_pycsw.txt
+++ b/tests/doctests/csw_pycsw.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 

--- a/tests/doctests/csw_pycsw.txt
+++ b/tests/doctests/csw_pycsw.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 

--- a/tests/doctests/csw_pycsw_skip_caps.txt
+++ b/tests/doctests/csw_pycsw_skip_caps.txt
@@ -5,7 +5,7 @@ for the appropriate URL since skip_caps=True.
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 Properties

--- a/tests/doctests/csw_pycsw_skip_caps.txt
+++ b/tests/doctests/csw_pycsw_skip_caps.txt
@@ -5,6 +5,7 @@ for the appropriate URL since skip_caps=True.
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 Properties

--- a/tests/doctests/csw_pycsw_skip_caps.txt
+++ b/tests/doctests/csw_pycsw_skip_caps.txt
@@ -5,7 +5,7 @@ for the appropriate URL since skip_caps=True.
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.csw import CatalogueServiceWeb as cs
 
 Properties

--- a/tests/doctests/csw_skgeodsy.txt
+++ b/tests/doctests/csw_skgeodsy.txt
@@ -1,4 +1,4 @@
->>> from __future__ import absolute_import
+>>> from __future__ import (absolute_import, division)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_skgeodsy.txt
+++ b/tests/doctests/csw_skgeodsy.txt
@@ -1,3 +1,4 @@
+>>> from __future__ import absolute_import
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_skgeodsy.txt
+++ b/tests/doctests/csw_skgeodsy.txt
@@ -1,4 +1,4 @@
->>> from __future__ import (absolute_import, division)
+>>> from __future__ import (absolute_import, division, print_function)
 >>> from owslib.csw import CatalogueServiceWeb
 >>> from owslib import fes
 

--- a/tests/doctests/csw_uuid_constrain.txt
+++ b/tests/doctests/csw_uuid_constrain.txt
@@ -1,4 +1,5 @@
 Imports
+    >>> from __future__ import absolute_import
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> from xml.dom import minidom as md
     >>> from owslib import fes, csw

--- a/tests/doctests/csw_uuid_constrain.txt
+++ b/tests/doctests/csw_uuid_constrain.txt
@@ -1,5 +1,5 @@
 Imports
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> from xml.dom import minidom as md
     >>> from owslib import fes, csw

--- a/tests/doctests/csw_uuid_constrain.txt
+++ b/tests/doctests/csw_uuid_constrain.txt
@@ -1,5 +1,5 @@
 Imports
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.csw import CatalogueServiceWeb as cs
     >>> from xml.dom import minidom as md
     >>> from owslib import fes, csw

--- a/tests/doctests/fes_ogc_filters.txt
+++ b/tests/doctests/fes_ogc_filters.txt
@@ -1,5 +1,5 @@
 Imports
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib import fes
     >>> from owslib.etree import etree
     >>> from tests.utils import compare_xml

--- a/tests/doctests/fes_ogc_filters.txt
+++ b/tests/doctests/fes_ogc_filters.txt
@@ -1,5 +1,5 @@
 Imports
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib import fes
     >>> from owslib.etree import etree
     >>> from tests.utils import compare_xml

--- a/tests/doctests/fes_ogc_filters.txt
+++ b/tests/doctests/fes_ogc_filters.txt
@@ -1,4 +1,5 @@
 Imports
+    >>> from __future__ import absolute_import
     >>> from owslib import fes
     >>> from owslib.etree import etree
     >>> from tests.utils import compare_xml

--- a/tests/doctests/iso_codelist.txt
+++ b/tests/doctests/iso_codelist.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> import urllib2
     >>> from owslib.etree import etree

--- a/tests/doctests/iso_codelist.txt
+++ b/tests/doctests/iso_codelist.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> import urllib2
     >>> from owslib.etree import etree

--- a/tests/doctests/iso_codelist.txt
+++ b/tests/doctests/iso_codelist.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> import urllib2
     >>> from owslib.etree import etree

--- a/tests/doctests/iso_creation.txt
+++ b/tests/doctests/iso_creation.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> import urllib2
     >>> from owslib.etree import etree
     >>> from owslib.iso import MD_Metadata, MD_DataIdentification, CI_ResponsibleParty

--- a/tests/doctests/iso_creation.txt
+++ b/tests/doctests/iso_creation.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> import urllib2
     >>> from owslib.etree import etree
     >>> from owslib.iso import MD_Metadata, MD_DataIdentification, CI_ResponsibleParty

--- a/tests/doctests/iso_creation.txt
+++ b/tests/doctests/iso_creation.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> import urllib2
     >>> from owslib.etree import etree
     >>> from owslib.iso import MD_Metadata, MD_DataIdentification, CI_ResponsibleParty

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.namespaces import Namespaces
 
 

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.namespaces import Namespaces
 
 

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.namespaces import Namespaces
 
 

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -2,7 +2,7 @@
 #Author: Dominic Lowe, 17th September 2009    
 #Part of OWSLib package.
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.csw import CatalogueServiceWeb
     >>> from owslib.wms import WebMapService

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -2,6 +2,7 @@
 #Author: Dominic Lowe, 17th September 2009    
 #Part of OWSLib package.
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.csw import CatalogueServiceWeb
     >>> from owslib.wms import WebMapService

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -2,7 +2,7 @@
 #Author: Dominic Lowe, 17th September 2009    
 #Part of OWSLib package.
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.csw import CatalogueServiceWeb
     >>> from owslib.wms import WebMapService

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.swe.sensor.sml import SensorML
     >>> from dateutil import parser

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.ows import OperationsMetadata

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.ows import OperationsMetadata

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.ows import OperationsMetadata

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.sos import SensorObservationService
     >>> from owslib.fes import FilterCapabilities200

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.swe.common import Time, DataChoice, DataRecord, AbstractSimpleComponent
     >>> from owslib.etree import etree

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.common import Time, DataChoice, DataRecord, AbstractSimpleComponent
     >>> from owslib.etree import etree

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.swe.common import Time, DataChoice, DataRecord, AbstractSimpleComponent
     >>> from owslib.etree import etree

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -1,9 +1,13 @@
+Imports
+
+    >>> from __future__ import absolute_import
+    >>> from owslib import tms
+
 You can find a list of servers at
 http://svn.osgeo.org/gdal/trunk/gdal/frmts/wms/WMSServerList.txt
 
 Find out what a TMS has to offer. Service metadata:
 
-    >>> from owslib import tms
     >>> service = tms.TileMapService('http://maps.opengeo.org/geowebcache/service/tms/1.0.0')
     >>> service.identification.title
     'Tile Map Service'

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib import tms
 
 You can find a list of servers at

--- a/tests/doctests/tms.txt
+++ b/tests/doctests/tms.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib import tms
 
 You can find a list of servers at

--- a/tests/doctests/wcs_idee.txt
+++ b/tests/doctests/wcs_idee.txt
@@ -4,6 +4,7 @@ COWS Web Coverage Service doctest
 WCS Version 1.0.0
 =================
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, scratch_file
     >>> from owslib.wcs import WebCoverageService
 

--- a/tests/doctests/wcs_idee.txt
+++ b/tests/doctests/wcs_idee.txt
@@ -4,7 +4,7 @@ COWS Web Coverage Service doctest
 WCS Version 1.0.0
 =================
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, scratch_file
     >>> from owslib.wcs import WebCoverageService
 

--- a/tests/doctests/wcs_idee.txt
+++ b/tests/doctests/wcs_idee.txt
@@ -4,7 +4,7 @@ COWS Web Coverage Service doctest
 WCS Version 1.0.0
 =================
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, scratch_file
     >>> from owslib.wcs import WebCoverageService
 

--- a/tests/doctests/wcs_thredds.txt
+++ b/tests/doctests/wcs_thredds.txt
@@ -6,7 +6,7 @@ Version 1.0.0
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wcs import WebCoverageService
     >>> from tests.utils import scratch_file
 

--- a/tests/doctests/wcs_thredds.txt
+++ b/tests/doctests/wcs_thredds.txt
@@ -6,7 +6,7 @@ Version 1.0.0
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wcs import WebCoverageService
     >>> from tests.utils import scratch_file
 

--- a/tests/doctests/wcs_thredds.txt
+++ b/tests/doctests/wcs_thredds.txt
@@ -6,6 +6,7 @@ Version 1.0.0
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wcs import WebCoverageService
     >>> from tests.utils import scratch_file
 

--- a/tests/doctests/wfs1_generic.txt
+++ b/tests/doctests/wfs1_generic.txt
@@ -1,6 +1,6 @@
 Imports and initialize
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wfs import WebFeatureService
     >>> from urlparse import urlparse
     >>> from tests.utils import resource_file, sorted_url_query

--- a/tests/doctests/wfs1_generic.txt
+++ b/tests/doctests/wfs1_generic.txt
@@ -1,5 +1,6 @@
 Imports and initialize
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wfs import WebFeatureService
     >>> from urlparse import urlparse
     >>> from tests.utils import resource_file, sorted_url_query

--- a/tests/doctests/wfs1_generic.txt
+++ b/tests/doctests/wfs1_generic.txt
@@ -1,6 +1,6 @@
 Imports and initialize
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wfs import WebFeatureService
     >>> from urlparse import urlparse
     >>> from tests.utils import resource_file, sorted_url_query

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -1,6 +1,6 @@
 Imports and initialize
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -1,6 +1,6 @@
 Imports and initialize
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -1,5 +1,6 @@
 Imports and initialize
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wfs import WebFeatureService
     >>> from operator import itemgetter

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wfs import WebFeatureService
     >>> from operator import itemgetter

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wfs import WebFeatureService
     >>> from operator import itemgetter

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wfs import WebFeatureService
     
 Test the getfeature method

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wfs import WebFeatureService
     
 Test the getfeature method

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wfs import WebFeatureService
     
 Test the getfeature method

--- a/tests/doctests/wfs_USDASSURGO.txt
+++ b/tests/doctests/wfs_USDASSURGO.txt
@@ -1,7 +1,7 @@
 # Test ability of OWSLib.wfs to interact with USDA SSURGO WFS 1.0.0 web service
 # Contact e-mail: selimnairb@gmail.com
 
->>> from __future__ import (absolute_import, division)
+>>> from __future__ import (absolute_import, division, print_function)
 >>> import unittest
 >>> from owslib.wfs import WebFeatureService
 >>> wfs_filter = "<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName='EPSG:4326'><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>"

--- a/tests/doctests/wfs_USDASSURGO.txt
+++ b/tests/doctests/wfs_USDASSURGO.txt
@@ -1,6 +1,7 @@
 # Test ability of OWSLib.wfs to interact with USDA SSURGO WFS 1.0.0 web service
 # Contact e-mail: selimnairb@gmail.com
 
+>>> from __future__ import absolute_import
 >>> import unittest
 >>> from owslib.wfs import WebFeatureService
 >>> wfs_filter = "<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName='EPSG:4326'><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>"

--- a/tests/doctests/wfs_USDASSURGO.txt
+++ b/tests/doctests/wfs_USDASSURGO.txt
@@ -1,7 +1,7 @@
 # Test ability of OWSLib.wfs to interact with USDA SSURGO WFS 1.0.0 web service
 # Contact e-mail: selimnairb@gmail.com
 
->>> from __future__ import absolute_import
+>>> from __future__ import (absolute_import, division)
 >>> import unittest
 >>> from owslib.wfs import WebFeatureService
 >>> wfs_filter = "<Filter><BBOX><PropertyName>Geometry</PropertyName> <Box srsName='EPSG:4326'><coordinates>-76.766960,39.283611 -76.684120,39.338394</coordinates> </Box></BBOX></Filter>"

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -1,5 +1,6 @@
 Imports
 
+	>>> from __future__ import absolute_import
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml10 import WaterML_1_0 as wml
 

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -1,6 +1,6 @@
 Imports
 
-	>>> from __future__ import (absolute_import, division)
+	>>> from __future__ import (absolute_import, division, print_function)
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml10 import WaterML_1_0 as wml
 

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -1,6 +1,6 @@
 Imports
 
-	>>> from __future__ import absolute_import
+	>>> from __future__ import (absolute_import, division)
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml10 import WaterML_1_0 as wml
 

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -2,7 +2,7 @@ Using WaterML 1.1 for examples
 
 Imports
 
-	>>> from __future__ import absolute_import
+	>>> from __future__ import (absolute_import, division)
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -2,6 +2,7 @@ Using WaterML 1.1 for examples
 
 Imports
 
+	>>> from __future__ import absolute_import
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -2,7 +2,7 @@ Using WaterML 1.1 for examples
 
 Imports
 
-	>>> from __future__ import (absolute_import, division)
+	>>> from __future__ import (absolute_import, division, print_function)
 	>>> from tests.utils import resource_file
 	>>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -1,5 +1,6 @@
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file
     >>> from owslib.wms import WebMapService
     

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file
     >>> from owslib.wms import WebMapService
     

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -1,6 +1,6 @@
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file
     >>> from owslib.wms import WebMapService
     

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> import os

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> import os

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> import os

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import resource_file
     >>> from operator import itemgetter

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file, scratch_file
     >>> import os

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file, scratch_file
     >>> import os

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from owslib.wms import WebMapService
     >>> from tests.utils import cast_tuple_int_list, cast_tuple_int_list_srs, resource_file, scratch_file
     >>> import os

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import scratch_file
 
 Find out what a WMTS has to offer. Service metadata:

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import scratch_file
 
 Find out what a WMTS has to offer. Service metadata:

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import scratch_file
 
 Find out what a WMTS has to offer. Service metadata:

--- a/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
+++ b/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
+++ b/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
+++ b/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
 

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
     

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -1,7 +1,7 @@
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
     

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -1,6 +1,7 @@
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import cast_tuple_int_list, resource_file
     >>> from owslib.wmts import WebMapTileService
     

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, print_function)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService, printInputOutput
 

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import print_function
+    >>> from __future__ import (absolute_import, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService, printInputOutput
 

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, print_function)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService, printInputOutput
 

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import print_function
+    >>> from __future__ import (absolute_import, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService, printInputOutput
 

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -3,6 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -3,6 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_getcapabilities_ceda.txt
+++ b/tests/doctests/wps_getcapabilities_ceda.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, print_function)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService
 

--- a/tests/doctests/wps_getcapabilities_ceda.txt
+++ b/tests/doctests/wps_getcapabilities_ceda.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import print_function
+    >>> from __future__ import (absolute_import, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService
 

--- a/tests/doctests/wps_getcapabilities_usgs.txt
+++ b/tests/doctests/wps_getcapabilities_usgs.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import (absolute_import, print_function)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService
 

--- a/tests/doctests/wps_getcapabilities_usgs.txt
+++ b/tests/doctests/wps_getcapabilities_usgs.txt
@@ -3,7 +3,7 @@ This test does not execute any live HTTP request, rather it parses XML files con
 
 Imports
 
-    >>> from __future__ import print_function
+    >>> from __future__ import (absolute_import, print_function)
     >>> from tests.utils import resource_file
     >>> from owslib.wps import WebProcessingService
 

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -3,6 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WPSExecution, WFSFeatureCollection, WFSQuery
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -3,7 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WPSExecution, WFSFeatureCollection, WFSQuery
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -3,7 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WPSExecution, WFSFeatureCollection, WFSQuery
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -3,7 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Import python modules
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import GMLMultiPolygonFeatureCollection, WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -3,6 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Import python modules
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import GMLMultiPolygonFeatureCollection, WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -3,7 +3,7 @@ The specific request involves a FeatureWeightedGridStatisticsAlgorithm process o
 
 Import python modules
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import GMLMultiPolygonFeatureCollection, WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -3,7 +3,7 @@ The specific request involves a "reprojectImage" process submitted to the PML WP
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -3,6 +3,7 @@ The specific request involves a "reprojectImage" process submitted to the PML WP
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -3,7 +3,7 @@ The specific request involves a "reprojectImage" process submitted to the PML WP
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -3,6 +3,7 @@ The specific request involves a "reprojectCoords" process submitted to the PML W
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -3,7 +3,7 @@ The specific request involves a "reprojectCoords" process submitted to the PML W
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -3,7 +3,7 @@ The specific request involves a "reprojectCoords" process submitted to the PML W
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -3,7 +3,7 @@ The specific request involves a "v.net.path" process submitted to the PML WPS se
 
 Imports
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -3,7 +3,7 @@ The specific request involves a "v.net.path" process submitted to the PML WPS se
 
 Imports
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -3,6 +3,7 @@ The specific request involves a "v.net.path" process submitted to the PML WPS se
 
 Imports
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml
     >>> from owslib.wps import WebProcessingService, WPSExecution
     >>> from owslib.etree import etree

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -1,6 +1,6 @@
 Instantiate WPS
 
-    >>> from __future__ import absolute_import
+    >>> from __future__ import (absolute_import, division)
     >>> from tests.utils import resource_file, compare_xml, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -1,5 +1,6 @@
 Instantiate WPS
 
+    >>> from __future__ import absolute_import
     >>> from tests.utils import resource_file, compare_xml, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -1,6 +1,6 @@
 Instantiate WPS
 
-    >>> from __future__ import (absolute_import, division)
+    >>> from __future__ import (absolute_import, division, print_function)
     >>> from tests.utils import resource_file, compare_xml, setup_logging
     >>> from owslib.wps import WebProcessingService
     >>> logger = setup_logging('INFO')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import os
 import sys

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import (absolute_import, division)
 
 import logging
 import os

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division)
+from __future__ import (absolute_import, division, print_function)
 
 import logging
 import os


### PR DESCRIPTION
This PR adds all the (useful) `__future__` imports to all remaining files:
 * `absolute_import` was covered in #214 for files where it mattered. This PR just adds it to the remaining files.
 * `division` has no effect, since there are no divisions in the code. But it's future-proof to add it, and has no cost.
 * `print_function` was covered in #217 for files where it mattered. Again, this PR adds it to the remaining files.

There's also `unicode_literals` for full compatibility with Python 3. I did not add that one because it requires considerable care to ensure that you are not mixing `str` with `bytes` everywhere.