### PR TITLE
Adds python repr for SosObservationOffering

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -273,6 +273,9 @@ class SosObservationOffering(object):
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
 
+    def __repr__(self):
+        return "<SosObservationOffering '%s'>" % self.name
+
 class SosCapabilitiesReader(object):
     def __init__(self, version="1.0.0", url=None, username=None, password=None):
         self.version = version

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -267,6 +267,9 @@ class SosObservationOffering(object):
 
     def __str__(self):
         return 'Offering id: %s, name: %s' % (self.id, self.name)
+    
+    def __repr__(self):
+        return "<SosObservationOffering '%s'>" % self.name
 
 class SosCapabilitiesReader(object):
     def __init__(self, version="2.0.0", url=None, username=None, password=None):


### PR DESCRIPTION
```
sos.offerings
-->
[<SosObservationOffering 'urn:ioos:network:nanoos:all'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:apl_chaba'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:apl_npb1ptwells'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:apl_npb2carr'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_coaof'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_dsdma'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_grays'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_jetta'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_mottb'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_ogi02'>,
 <SosObservationOffering 'urn:ioos:station:nanoos:cmop_sandi'>,
...
```