### PR TITLE
Added 'procedure' as optional parameter for SOS GetObservation request

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -135,6 +135,7 @@ class SensorObservationService_1_0_0(object):
                                 offerings=None,
                                 observedProperties=None,
                                 eventTime=None,
+                                procedure=None,
                                 method='Get',
                                 **kwargs):
         """
@@ -168,6 +169,9 @@ class SensorObservationService_1_0_0(object):
         # Optional Fields
         if eventTime is not None:
             request['eventTime'] = eventTime
+
+        if procedure is not None:
+            request['procedure'] = procedure
 
         if kwargs:
             for kw in kwargs:


### PR DESCRIPTION
The URL for a SOS request should allow 'procedure' as an option in the request string; for example:
```
http://my.server.com:8080/my_sos/sos?
request=GetObservation&service=SOS&version=1.0.0&
offering=MY_OFFER&
observedproperty=urn:ogc:def:phenomenon:OGC:1.0.30:foo&
procedure=BAR&
responseFormat=text/xml;subtype="om/1.0.0"
```
