### PR TITLE
SOS namespace addition

### DIFF
--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -31,6 +31,7 @@ class Namespaces(object):
         'ows200':   'http://www.opengis.net/ows/2.0',
         'rim'   :   'urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0',
         'rdf'   :   'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        'sa'    :   'http://www.opengis.net/sampling/1.0',
         'sml'   :   'http://www.opengis.net/sensorML/1.0.1',
         'sml101':   'http://www.opengis.net/sensorML/1.0.1',
         'sos'   :   'http://www.opengis.net/sos/1.0',

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -10,7 +10,7 @@ from owslib.namespaces import Namespaces
 
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["ogc","sml","gml","sos","swe","xlink"])
+    ns = n.get_namespaces(["ogc","sml","gml","sos","swe","xlink","sa"])
     ns["ows"] = n.get_namespace("ows110")
     return ns
 namespaces = get_namespaces()

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -135,6 +135,7 @@ class SensorObservationService_1_0_0(object):
                                 offerings=None,
                                 observedProperties=None,
                                 eventTime=None,
+                                procedure=None,
                                 method='Get',
                                 **kwargs):
         """
@@ -168,6 +169,9 @@ class SensorObservationService_1_0_0(object):
         # Optional Fields
         if eventTime is not None:
             request['eventTime'] = eventTime
+
+        if procedure is not None:
+            request['procedure'] = procedure
 
         if kwargs:
             for kw in kwargs:

--- a/tests/doctests/namespaces.txt
+++ b/tests/doctests/namespaces.txt
@@ -33,6 +33,9 @@ Correct Usage Tests
     >>> ns.get_namespace('csw')
     'http://www.opengis.net/cat/csw/2.0.2'
 
+    >>> ns.get_namespace('sa')
+    'http://www.opengis.net/sampling/1.0'
+
     # 'om300' does not exist as a namespace, so the below will return nothing
     >>> ns.get_namespace('om300')
 


### PR DESCRIPTION
Adds the 'sa' namespace for handling SOS data.  An example from a GetObservation request:

```
<om:featureOfInterest xlink:title="my_sensor_id">
    <sa:SamplingPoint gml:id="my_sensor_id">
        <sa:sampledFeature xlink:href="urn:ogc:def:nil:OGC:unknown"/>
        <sa:position>
            <gml:Point gml:id="point_sf_42">
                <gml:pos srsName="urn:ogc:def:crs:EPSG::4326">15.751542 18.280503</gml:pos>
            </gml:Point>
        </sa:position>
    </sa:SamplingPoint>
</om:featureOfInterest>
```