### PR TITLE
Add support to `count` parameter in GetFeature requestion for WFS 2.0.0

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -132,8 +132,11 @@ class WebFeatureService_(object):
             request['propertyname'] = ','.join(propertyname)
         if featureversion: 
             request['featureversion'] = str(featureversion)
-        if maxfeatures: 
-            request['maxfeatures'] = str(maxfeatures)
+        if maxfeatures:
+            if self.version == '2.0.0':
+                request['count'] = str(maxfeatures)
+            else:
+                request['maxfeatures'] = str(maxfeatures)
         if startindex:
             request['startindex'] = str(startindex)
         if storedQueryID: 


### PR DESCRIPTION
The GetFeature request parameters have been slightly changed in WFS 2.0.0. For example `maxFeatures` is now `count`. This minor commit fixes the issue. 