### PR TITLE
Make the Crs type hashable.

### DIFF
--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -1839,5 +1839,8 @@ class Crs(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(repr(self))
+
     def __repr__(self):
         return self.getcodeurn()


### PR DESCRIPTION
It is quite possible that other classes could be made hashable as well. However, this was the only one that I needed to get Cartopy working correctly on Python 3.