### PR TITLE
Fix encoding problem for ResponseWrapper

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -129,10 +129,7 @@ class ResponseWrapper(object):
         return self._response.headers
 
     def read(self):
-        if not self._response.encoding:
-            return self._response.content           # bytes
-
-        return self._response.text.encode('utf-8')  # str
+        return self._response.content
 
     def geturl(self):
         return self._response.url
@@ -378,10 +375,7 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
         rkwargs['auth'] = (username, password)
 
     up = requests.post(url, request, headers=headers, **rkwargs)
-    if not up.encoding:
-        return up.content           # bytes
-
-    return up.text.encode('utf-8')  # str
+    return up.content
 
 def element_to_string(element, encoding=None, xml_declaration=False):
     """

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -101,6 +101,6 @@ Test exceptions
 Lastly, test the getcapabilities method
 
     >>> wfs = WebFeatureService('http://nsidc.org/cgi-bin/atlas_south?', version='1.0')
-    >>> xml = wfs.getcapabilities().read().decode('utf-8')
-    >>> xml.find('<WFS_Capabilities') > 0
+    >>> xml = wfs.getcapabilities().read()
+    >>> xml.find(b'<WFS_Capabilities') > 0
     True


### PR DESCRIPTION
Using response encoding [here](https://github.com/geopython/OWSLib/blob/master/owslib/util.py#L133) is not reliable approach to get document encoding. Requests library only consider HTTP headers when attempting to work out text encodings and if `Content-Type` header is `text/xml` and it doesn't contain `charset` parameter then Request returns `ISO-8859-1` encoding:

```python
>>> from owslib.wms import WebMapService
>>> service = WebMapService('http://maps.kosmosnimki.ru/TileService.ashx/apikeyU96GP973UH', version='1.1.1')
>>> print service['7B3470B2C40E4B71B9AF9D1AFE17FA51'].abstract
ÐÑÑÐ¼ÑÐº
>>>
>>> import requests
>>> req = requests.get('http://maps.kosmosnimki.ru/TileService.ashx/apikeyU96GP973UH?SERVICE=WMS&Request=GetCapabilities&VERSION=1.1.1')
>>> req.encoding
'ISO-8859-1
>>> print req.content[:40]
<?xml version="1.0" encoding="utf-8"?>
```