### PR TITLE
No need to explictly set "Content-length" header with requests

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -361,7 +361,6 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
     headers = {
         'User-Agent'      : 'OWSLib (https://geopython.github.io/OWSLib)',
         'Content-type'    : 'text/xml',
-        'Content-length'  : '%d' % len(request),
         'Accept'          : 'text/xml',
         'Accept-Language' : lang,
         'Accept-Encoding' : 'gzip,deflate',


### PR DESCRIPTION
We do not need to specify Content-length now as requests adds it in.

In fact it is helpful to remove it because there is a bug with older requests versions causing ConnectionError(!) - with this change it now works with requests 1.1. I know we specify >2.7 but all these little things help when dependency hell approaches...