### PR TITLE
Fix lxml import for ParseError, fix csw test

### DIFF
--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -34,7 +34,8 @@ def patch_well_known_namespaces(etree_module):
 
 # try to find lxml or elementtree
 try:
-    from lxml import etree, ParseError
+    from lxml import etree
+    from lxml.etree import ParseError
     ElementType = etree._Element
 except ImportError:
     try:

--- a/tests/doctests/csw_ngdc.txt
+++ b/tests/doctests/csw_ngdc.txt
@@ -21,7 +21,7 @@ Get some records
     >>> uuid_filter = fes.PropertyIsEqualTo(propertyname='sys.siteuuid', literal="{%s}" % aoos_uuid)
 
     >>> c.getrecords2([uuid_filter], esn='full', maxrecords=999999)
-    >>> len(c.records) > 60
+    >>> len(c.records) > 40
     True
     >>> 'AOOS SOS' in c.records
     True


### PR DESCRIPTION
As pointed out by @drnextgis on 66200494ab59, I had the import for ParseError in the lxml path incorrect.  This patch fixes it, as well as an unrelated CSW test that had started failing because the source happened to be producing less records than when the test was written (moving targets and all).