### PR TITLE
Encode output of __str__ and __repr__ methods

### DIFF
--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -156,9 +156,9 @@ class Constraint(object):
 
     def __repr__(self):
         if self.values:
-            return "Constraint: %s - %s" % (self.name, self.values)
+            return ("Constraint: %s - %s" % (self.name, self.values)).encode('utf-8')
         else:
-            return "Constraint: %s" % self.name
+            return ("Constraint: %s" % self.name).encode('utf-8')
 
 
 class OperationsMetadata(object):

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -275,10 +275,10 @@ class SosObservationOffering(object):
             self.response_modes.append(testXMLValue(rm))
 
     def __str__(self):
-        return 'Offering id: %s, name: %s' % (self.id, self.name)
+        return ('Offering id: %s, name: %s' % (self.id, self.name)).encode('utf-8')
 
     def __repr__(self):
-        return "<SosObservationOffering '%s'>" % self.name
+        return ("<SosObservationOffering '%s'>" % self.name).encode('utf-8')
 
 class SosCapabilitiesReader(object):
     def __init__(self, version="1.0.0", url=None, username=None, password=None):

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -269,10 +269,10 @@ class SosObservationOffering(object):
             self.observation_models.append(testXMLValue(om))
 
     def __str__(self):
-        return 'Offering id: %s, name: %s' % (self.id, self.name)
-    
+        return ('Offering id: %s, name: %s' % (self.id, self.name)).encode('utf-8')
+
     def __repr__(self):
-        return "<SosObservationOffering '%s'>" % self.name
+        return ("<SosObservationOffering '%s'>" % self.name).encode('utf-8')
 
 class SosCapabilitiesReader(object):
     def __init__(self, version="2.0.0", url=None, username=None, password=None):

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -176,7 +176,7 @@ class ContentMetadata(object):
     Abstraction for TMS layer metadata.
     """
     def __str__(self):
-        return 'Layer Title: %s, URL: %s' % (self.title, self.id)
+        return ('Layer Title: %s, URL: %s' % (self.title, self.id)).encode('utf-8')
 
     def __init__(self, elem, un=None, pw=None):
         if elem.tag != 'TileMap':

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -511,7 +511,7 @@ class ContentMetadata:
             self.layers.append(ContentMetadata(child, self))
 
     def __str__(self):
-        return 'Layer Name: %s Title: %s' % (self.name, self.title)
+        return ('Layer Name: %s Title: %s' % (self.name, self.title)).encode('utf-8')
 
 
 class OperationMetadata:

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -687,7 +687,7 @@ class ContentMetadata:
         return self._tilematrixsets
 
     def __str__(self):
-        return 'Layer Name: %s Title: %s' % (self.name, self.title)
+        return ('Layer Name: %s Title: %s' % (self.name, self.title)).encode('utf-8')
 
 
 class WMTSCapabilitiesReader:


### PR DESCRIPTION
Encode string representation of objects. Fix issue #248.