### PR TITLE
only try to reset statuslocation if it is None to begin with

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -728,7 +728,8 @@ class WPSExecution():
         wpsns = getNamespace(root)
 
         self.serviceInstance = root.get( 'serviceInstance' )
-        self.statusLocation = root.get( 'statusLocation' )
+        if self.statusLocation is None:
+            self.statusLocation = root.get( 'statusLocation' )
         
         # <ns0:Status creationTime="2011-11-09T14:19:50Z">
         #  <ns0:ProcessSucceeded>PyWPS Process v.net.path successfully calculated</ns0:ProcessSucceeded>


### PR DESCRIPTION
We came across an issue that this minor change addresses. The statuslocation doesn't exist in response documents sometimes and this was setting it to None when it didn't come back.