### PR TITLE
Add support for RESTful only WMTS

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -344,7 +344,7 @@ TILEMATRIX=6&TILEROW=4&TILECOL=4&FORMAT=image%2Fjpeg'
         if numres > 0:
             # choose random ResourceURL if more than one available
             resindex = randint(0, numres - 1)
-            resurl = self[layer].resourceURLs[resindex]['template']
+            resurl = tileresourceurls[resindex]['template']
             if tilematrixset:
                 resurl = resurl.replace('{TileMatrixSet}', tilematrixset)
             resurl = resurl.replace('{TileMatrix}', tilematrix)

--- a/tests/doctests/wmts_RESTonly.txt
+++ b/tests/doctests/wmts_RESTonly.txt
@@ -1,0 +1,34 @@
+Imports:
+
+    >>> from __future__ import (absolute_import, division, print_function)
+    >>> from tests.utils import scratch_file
+
+ServiceMetadata:
+
+    >>> from owslib.wmts import WebMapTileService
+    >>> wmts = WebMapTileService("http://geoserv.weichand.de/mapproxy/wmts/1.0.0/WMTSCapabilities.xml")
+    >>> wmts.identification.type
+    'OGC WMTS'
+    >>> wmts.identification.version
+    '1.0.0'
+    >>> wmts.identification.title
+    'WMTS-Testserver DOP80'
+
+Content:
+
+    >>> sorted(list(wmts.contents))
+    ['dop80']
+
+RESTful WMTS:
+
+  >>> wmts.restonly
+  True
+
+  >>> wmts.buildTileResource(layer='dop80', tilematrixset='webmercator', tilematrix='11', row='706', column='1089')
+  'http://geoserv.weichand.de/mapproxy/wmts/dop80/webmercator/11/1089/706.png'
+
+  >>> tile = wmts.gettile(layer='dop80', tilematrixset='webmercator', tilematrix='11', row='706', column='1089')
+  >>> out = open(scratch_file('bvv_bayern_dop80.png'), 'wb')
+  >>> bytes_written = out.write(tile.read())
+  >>> out.close()
+

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -27,6 +27,8 @@ Test capabilities
 
     >>> wmts.identification.fees
 
+    >>> wmts.restonly
+    False
 
 Service Provider:
 


### PR DESCRIPTION
With this PR OWSLib will support **RESTful only WMTS**.
- will not crash if no operations are available in the capabilities
- added property function `.restonly`
- added function `.buildTileResource()` corresponding to `.buildTileRequest()`
- function `.gettile()` can now also be used for downloading a tile from a RESTful WMTS
- added test `wmts_RESTonly`
- updated test `wmts_geoserver21` (check if `restonly`)