### PR TITLE
Add a children attribute to ContentMetadata to handle WMS nested layers

### DIFF
--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -62,7 +62,27 @@ Test single item accessor
     >>> x = wms['opengeo:poi'].styles
     >>> x == {'point': {'legend': 'http://localhost:8080/geoserver/wms?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=poi', 'title': 'A boring default style'}}
     True
+
+Test nested layer
+
+    >>> wms['parent_layer'].title
+    'Parent Layer'
     
+    >>> wms['parent_layer'].queryable
+    1
+    
+    >>> len(wms['parent_layer'].children)
+    1
+    
+    >>> wms['parent_layer'].children[0].title
+    'Child Layer'
+    
+    >>> len(wms['child_layer'].children)
+    0
+    
+    >>> wms['child_layer'].parent.title
+    'Parent Layer'
+
 Expect a KeyError for invalid names
 
     >>> wms['utterly bogus'].title

--- a/tests/resources/wms_geoserver-cap.xml
+++ b/tests/resources/wms_geoserver-cap.xml
@@ -140,14 +140,14 @@
         <KeywordList/>
         <SRS>EPSG:4326</SRS>
         <!--WKT definition of this CRS:
-GEOGCS["WGS 84", 
-  DATUM["World Geodetic System 1984", 
-    SPHEROID["WGS 84", 6378137.0, 298.257223563, AUTHORITY["EPSG","7030"]], 
-    AUTHORITY["EPSG","6326"]], 
-  PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], 
-  UNIT["degree", 0.017453292519943295], 
-  AXIS["Geodetic longitude", EAST], 
-  AXIS["Geodetic latitude", NORTH], 
+GEOGCS["WGS 84",
+  DATUM["World Geodetic System 1984",
+    SPHEROID["WGS 84", 6378137.0, 298.257223563, AUTHORITY["EPSG","7030"]],
+    AUTHORITY["EPSG","6326"]],
+  PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]],
+  UNIT["degree", 0.017453292519943295],
+  AXIS["Geodetic longitude", EAST],
+  AXIS["Geodetic latitude", NORTH],
   AUTHORITY["EPSG","4326"]]-->
         <LatLonBoundingBox minx="-74.012" miny="40.708" maxx="-74.002" maxy="40.72"/>
         <BoundingBox SRS="EPSG:4326" minx="-74.012" miny="40.708" maxx="-74.002" maxy="40.72"/>
@@ -168,6 +168,14 @@ GEOGCS["WGS 84",
             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost:8080/geoserver/wms?request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer=poi"/>
           </LegendURL>
         </Style>
+      </Layer>
+      <Layer queryable="0">
+        <Name>parent_layer</Name>
+        <Title>Parent Layer</Title>
+        <Layer queryable="1">
+            <Name>child_layer</Name>
+            <Title>Child Layer</Title>
+        </Layer>
       </Layer>
     </Layer>
   </Capability>


### PR DESCRIPTION
Inspired by the work of Ivan Boldyrev <lispnik@gmail.com> available
here: https://github.com/monoid/owslib/tree/tree

Close #8 

PS: I think it would be nice to add tests for this in OWSLib test suite. Do you know a public WMS with nested layers? I did my test on a private sever.