### PR TITLE
Added deprecation warnings for identificationinfo and keywords

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -11,6 +11,7 @@
 """ ISO metadata parser """
 
 from __future__ import (absolute_import, division, print_function)
+import warnings
 
 from owslib.etree import etree
 from owslib import util
@@ -102,12 +103,12 @@ class MD_Metadata(object):
                 self.referencesystem = None
 
             # TODO: merge .identificationinfo into .identification
-            #warnings.warn(
-            #    'the .identification and .serviceidentification properties will merge into '
-            #    '.identification being a list of properties.  This is currently implemented '
-            #    'in .identificationinfo.  '
-            #    'Please see https://github.com/geopython/OWSLib/issues/38 for more information',
-            #    FutureWarning)
+            warnings.warn(
+                'the .identification and .serviceidentification properties will merge into '
+                '.identification being a list of properties.  This is currently implemented '
+                'in .identificationinfo.  '
+                'Please see https://github.com/geopython/OWSLib/issues/38 for more information',
+                FutureWarning)
 
             val = md.find(util.nspath_eval('gmd:identificationInfo/gmd:MD_DataIdentification', namespaces))
             val2 = md.find(util.nspath_eval('gmd:identificationInfo/srv:SV_ServiceIdentification', namespaces))
@@ -295,7 +296,7 @@ class MD_DataIdentification(object):
             self.status = None
             self.contact = []
             self.keywords = []
-            self.mdkeywords = []
+            self.keywords2 = []
             self.topiccategory = []
             self.supplementalinformation = None
             self.extent = None
@@ -418,6 +419,13 @@ class MD_DataIdentification(object):
                 o = CI_ResponsibleParty(i)
                 self.contact.append(o)
 
+            warnings.warn(
+                'The .keywords and .keywords2 properties will merge into the '
+                '.keywords property in the future, with .keywords becoming a list '
+                'of MD_Keywords instances. This is currently implemented in .keywords2. '
+                'Please see https://github.com/geopython/OWSLib/issues/301 for more information',
+                FutureWarning)
+
             self.keywords = []
 
             for i in md.findall(util.nspath_eval('gmd:descriptiveKeywords', namespaces)):
@@ -446,9 +454,9 @@ class MD_DataIdentification(object):
 
                 self.keywords.append(mdkw)
 
-            self.mdkeywords = []
+            self.keywords2 = []
             for mdkw in md.findall(util.nspath_eval('gmd:descriptiveKeywords/gmd:MD_Keywords', namespaces)):
-                self.mdkeywords.append(MD_Keywords(mdkw))
+                self.keywords2.append(MD_Keywords(mdkw))
 
             self.topiccategory = []
             for i in md.findall(util.nspath_eval('gmd:topicCategory/gmd:MD_TopicCategoryCode', namespaces)):

--- a/tests/doctests/iso_keywords.txt
+++ b/tests/doctests/iso_keywords.txt
@@ -13,14 +13,14 @@ Print testing some metadata elements
     >>> md.identificationinfo[0].title
     'Air temperature'
 
-    >>> len(md.identificationinfo[0].mdkeywords) == len(md.identificationinfo[0].keywords)
+    >>> len(md.identificationinfo[0].keywords2) == len(md.identificationinfo[0].keywords)
     True
 
-    >>> len(md.identificationinfo[0].mdkeywords) > 0
+    >>> len(md.identificationinfo[0].keywords2) > 0
     True
 
-    >>> len(md.identificationinfo[0].mdkeywords[0].keywords) > 0
+    >>> len(md.identificationinfo[0].keywords2[0].keywords) > 0
     True
 
-    >>> md.identificationinfo[0].mdkeywords[0].thesaurus['title']
+    >>> md.identificationinfo[0].keywords2[0].thesaurus['title']
     'GEMET - INSPIRE themes, version 1.0'


### PR DESCRIPTION
Changed `identification.mdkeywords` to `identification.keywords2` and added the deprecation warnings for this and the `MD_Metadata.identification`. See #301 