### PR TITLE
fix WMTS parsing when ServiceProvider does not exist

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -196,7 +196,8 @@ class WebMapTileService(object):
 
         # serviceProvider metadata
         serviceprov = self._capabilities.find(_SERVICE_PROVIDER_TAG)
-        self.provider = ServiceProvider(serviceprov)
+        if serviceprov is not None:
+            self.provider = ServiceProvider(serviceprov)
 
         # serviceOperations metadata
         self.operations = []

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -36,8 +36,11 @@ Available Layers:
 
 Fetch a tile (using some defaults):
 
-  >>> tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor', tilematrixset='EPSG4326_250m', tilematrix='0', row=0, column=0, format="image/jpeg")
-  >>> out = open(scratch_file('nasa_modis_terra_truecolour.jpg'), 'wb')
-  >>> bytes_written = out.write(tile.read())
-  >>> out.close()
+    >>> tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor', tilematrixset='EPSG4326_250m', tilematrix='0', row=0, column=0, format="image/jpeg")
+    >>> out = open(scratch_file('nasa_modis_terra_truecolour.jpg'), 'wb')
+    >>> bytes_written = out.write(tile.read())
+    >>> out.close()
 
+Test a WMTS without a ServiceProvider tag in Capababilities XML
+
+    >>> wmts = WebMapTileService('http://data.geus.dk/arcgis/rest/services/OneGeologyGlobal/S071_G2500_OneGeology/MapServer/WMTS/1.0.0/WMTSCapabilities.xml')


### PR DESCRIPTION
Fixes #309 