### PR TITLE
csw_linz.txt: doctest fix get more records.

### DIFF
--- a/tests/doctests/csw_linz.txt
+++ b/tests/doctests/csw_linz.txt
@@ -14,11 +14,11 @@ Imports
     >>> c.provider.name
     'Land Information New Zealand'
     >>> prop = fes.PropertyIsLike('csw:AnyText', 'parcel boundaries')
-    >>> c.getrecords2([prop])
+    >>> c.getrecords2([prop], maxrecords=20)
     >>> c.results['matches']
     23
     >>> c.results['returned']
-    10
+    20
     >>> c.records['4d8c2d95-4ac2-1aa3-5b81-3cd4eff1ad0f'].title
     'NZ Strata Parcels'
     >>> c.records['4d8c2d95-4ac2-1aa3-5b81-3cd4eff1ad0f'].abstract


### PR DESCRIPTION
Fix to doctest csw_linz.txt to retrieve 20 records instead of 10.  The 'NZ Strata Parcels' data is no longer in the first 10 results.

This should fix the unit tests, which are currently failing.

Two of the tests failed.  The failure for Python 2.6 LXML=false, looks like the server aborted the connection.  The failure for Python 3.4 LXML=true, was a timeout error, perhaps Travis paused the process for more than 30 seconds (which could be increased, but should it?).