### PR TITLE
CSW: fix outputschema setting when raw XML is specified

### DIFF
--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -324,6 +324,9 @@ class CatalogueServiceWeb(object):
             val = self.request.find(util.nspath_eval('csw:Query/csw:ElementSetName', namespaces))
             if val is not None:
                 esn = util.testXMLValue(val)
+            val = self.request.attrib.get('outputSchema')
+            if val is not None:
+                outputschema = util.testXMLValue(val, True)
         else:
             # construct request
             node0 = self._setrootelement('csw:GetRecords')


### PR DESCRIPTION
cc 
As per http://osgeo-org.1560.x6.nabble.com/Federated-Search-question-td5258881.html, when `owslib.csw.getrecords2` is called with the `xml` parameter, other parameters are ignored.

This PR fixes the issue that the `outputschema` parameter (which are set in the XML document/request passed) is ignored, but acted upon during this codepath.