### PR TITLE
Support custom headers for WMS requests

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -139,14 +139,14 @@ class ResponseWrapper(object):
 
     # @TODO: __getattribute__ for poking at response
 
-def openURL(url_base, data=None, method='Get', cookies=None, username=None, password=None, timeout=30):
+def openURL(url_base, data=None, method='Get', cookies=None, username=None, password=None, timeout=30, headers=None):
     """
     Function to open URLs.
 
     Uses requests library but with additional checks for OGC service exceptions and url formatting.
     Also handles cookies and simple user password authentication.
     """
-    headers = None
+    headers = headers if headers is not None else {}
     rkwargs = {}
 
     rkwargs['timeout'] = timeout
@@ -164,7 +164,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
     if method.lower() == 'post':
         try:
             xml = etree.fromstring(data)
-            headers = {'Content-Type': 'text/xml'}
+            headers['Content-Type'] = 'text/xml'
         except (ParseError, UnicodeEncodeError):
             pass
 


### PR DESCRIPTION
I've faced with the following issue. WMS server responds `403 Access denied` on all WMS requests with default [Requests](http://docs.python-requests.org/en/master/) `User-Agent` header:

```python
r = requests.get('http://maps.rosreestr.ru/arcgis/services/Cadastre/CadastreWMS/MapServer/WMSServer?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities')
r.text
u'<!DOCTYPE html>\n<html>\n  <head>\n    <title>403 Access denied. Code 0x10.</title>\n  </head>\n  <body>\n    <h1>Error 403 Access denied. Code 0x10.</h1>\n    <p>Access denied. Code 0x10.</p>\n    <h3>Guru Meditation:</h3>\n    <p>XID: 1053459697</p>\n    <hr>\n    <p>Varnish cache server</p>\n  </body>\n</html>\n'
```

But if set up custom header all works fine:

```python
>>> r = requests.get('http://maps.rosreestr.ru/arcgis/services/Cadastre/CadastreWMS/MapServer/WMSServer?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities', headers={'user-agent': 'OWSLib'})
>>> r.text
u'<?xml version="1.0" encoding="UTF-8"?>\n<WMT_MS_Capabilities version="1.1.1">...
```

This PR adds ability to use custom headers for WMS requests.