### PR TITLE
Fix wmts.txt test. Replace abstract, due change on the server's end. …

### DIFF
--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -14,8 +14,8 @@ Find out what a WMTS has to offer. Service metadata:
     '1.0.0'
     >>> wmts.identification.title
     'NASA Global Imagery Browse Services for EOSDIS'
-    >>> str.strip(wmts.identification.abstract)
-    'Near real time imagery from multiple NASA instruments'
+    >>> bytearray(wmts.identification.abstract, 'utf-8')
+    bytearray(b'The Global Imagery Browse Services (GIBS) system is a core EOSDIS component which provides a scalable, responsive, highly available, and community standards based set of imagery services.  These services are designed with the goal of advancing user interactions with EOSDIS\xe2\x80\x99 inter-disciplinary data through enhanced visual representation and discovery.')
     >>> wmts.identification.keywords
     ['World', 'Global']
 


### PR DESCRIPTION
… ~~Install libraries to silence SSL related InsecurePlatformWarnings in requirements-dev.txt.~~

This patch uses environment markers, which is a feature in pip version 6.0 (released 2014-12-22).

This test seems to be failing due to other tests failing.

**EDIT:** Separated SSL library installation related changes into PR #328