### PR TITLE
[Testing] Install ssl related libraries, which stops the SSL related…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,7 @@ pytest
 pytest-cov
 Pillow
 tox
+# install libraries to stop SSL related InsecurePlatformWarning
+pyopenssl        ; python_version < '2.7.9'
+ndg-httpsclient  ; python_version < '2.7.9'
+pyasn1           ; python_version < '2.7.9'


### PR DESCRIPTION
…InsecurePatformWarning for Python versions below 2.7.9.  Environment markers require pip 6.0+ (6.0 was relased 2014-12-22).  This is only intended to be for Travis-CI's sake (I think Travis has pip 6.0.1 installed by default), not really intended for the end user.