### PR TITLE
Fix #129: Add username and password arguments to WFS class constructors

### DIFF
--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -1,0 +1,66 @@
+import cgi
+from owslib.etree import etree
+from owslib.util import openURL
+
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
+
+
+
+class WFSCapabilitiesReader(object):
+    """Read and parse capabilities document into a lxml.etree infoset
+    """
+
+    def __init__(self, version='1.0', username=None, password=None):
+        """Initialize"""
+        self.version = version
+        self.username = username
+        self.password = password
+        self._infoset = None
+
+    def capabilities_url(self, service_url):
+        """Return a capabilities url
+        """
+        qs = []
+        if service_url.find('?') != -1:
+            qs = cgi.parse_qsl(service_url.split('?')[1])
+
+        params = [x[0] for x in qs]
+
+        if 'service' not in params:
+            qs.append(('service', 'WFS'))
+        if 'request' not in params:
+            qs.append(('request', 'GetCapabilities'))
+        if 'version' not in params:
+            qs.append(('version', self.version))
+
+        urlqs = urlencode(tuple(qs))
+        return service_url.split('?')[0] + '?' + urlqs
+
+    def read(self, url, timeout=30):
+        """Get and parse a WFS capabilities document, returning an
+        instance of WFSCapabilitiesInfoset
+
+        Parameters
+        ----------
+        url : string
+            The URL to the WFS capabilities document.
+        timeout : number
+            A timeout value (in seconds) for the request.
+        """
+        request = self.capabilities_url(url)
+        u = openURL(request, timeout=timeout,
+                    username=self.username, password=self.password)
+        return etree.fromstring(u.read())
+
+    def readString(self, st):
+        """Parse a WFS capabilities document, returning an
+        instance of WFSCapabilitiesInfoset
+
+        string should be an XML capabilities document
+        """
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            raise ValueError("String must be of type string or bytes, not %s" % type(st))
+        return etree.fromstring(st)

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -1,9 +1,9 @@
-# -*- coding: ISO-8859-15 -*-
+# -*- coding: utf-8 -*-
 # =============================================================================
 # Copyright (c) 2004, 2006 Sean C. Gillies
 # Copyright (c) 2009 STFC <http://www.stfc.ac.uk>
 #
-# Authors : 
+# Authors :
 #          Dominic Lowe <dominic.lowe@stfc.ac.uk>
 #
 # Contact email: dominic.lowe@stfc.ac.uk
@@ -19,9 +19,9 @@ from .feature import wfs100, wfs110, wfs200
 
 
 def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=False,
-                      timeout=30):
+                      timeout=30, username=None, password=None):
     ''' wfs factory function, returns a version specific WebFeatureService object
-    
+
     @type url: string
     @param url: url of WFS capabilities document
     @type xml: string
@@ -29,15 +29,22 @@ def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=Fals
     @type parse_remote_metadata: boolean
     @param parse_remote_metadata: whether to fully process MetadataURL elements
     @param timeout: time (in seconds) after which requests should timeout
+    @param username: service authentication username
+    @param password: service authentication password
     @return: initialized WebFeatureService_2_0_0 object
     '''
     if version in  ['1.0', '1.0.0']:
-        return wfs100.WebFeatureService_1_0_0(url, version, xml, parse_remote_metadata, 
-                                              timeout=timeout)
+        return wfs100.WebFeatureService_1_0_0(url, version, xml, parse_remote_metadata,
+                                              timeout=timeout,
+                                              username=username,
+                                              password=password)
     elif version in  ['1.1', '1.1.0']:
         return wfs110.WebFeatureService_1_1_0(url, version, xml, parse_remote_metadata,
-                                              timeout=timeout)
+                                              timeout=timeout,
+                                              username=username,
+                                              password=password)
     elif version in ['2.0', '2.0.0']:
         return wfs200.WebFeatureService_2_0_0(url,  version, xml, parse_remote_metadata,
-                                              timeout=timeout)
-
+                                              timeout=timeout,
+                                              username=username,
+                                              password=password)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pep8
 pytest
 pytest-cov


### PR DESCRIPTION
This changeset allows passing low-level HTTP authentication details
to high level WebFeatureService API.

WFSCapabilitiesReader was moved to features.common in order to avoid duplication.