### PR TITLE
Support custom http header fields for WMTS

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -184,7 +184,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
     if req.status_code in [400, 401]:
         raise ServiceException(req.text)
 
-    if req.status_code in [404]:    # add more if needed
+    if req.status_code in [404, 403]:    # add more if needed
         req.raise_for_status()
 
     # check for service exceptions without the http header set


### PR DESCRIPTION
Support custom http header fields for the WebMapTileService class. Inspired by commit aecdfbb5fe90a24d5ec3595817228b393e86bf99, which did the same for WMS.

Also: Raise an exception for HTTP error 403 (Forbidden).
