### PR TITLE
Handle servers that give 500 errors better

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -199,7 +199,7 @@ def openURL(url_base, data=None, method=None, cookies=None, username=None, passw
     if req.status_code in [400, 401]:
         raise ServiceException(req.text)
 
-    if req.status_code in [404]:    # add more if needed
+    if req.status_code in [404, 500, 502, 503, 504]:    # add more if needed
         req.raise_for_status()
 
     # check for service exceptions without the http header set


### PR DESCRIPTION
If I do a GetCapabilities request on a server and it replies with http status 500, because something is fundamentally wrong with the server, then this PR means owslib will not raise an HTTP exception.

Previously this only occurred for 40x statuses.

I currently am trying to talk to this GeoNetwork CSW:

http://geonet.allerdale.gov.uk/geonetwork/srv/en/csw?version=2.0.2&request=GetCapabilities&service=CSW

which returns a 500 error and an HTML page, but no doubt they will fix it soon, otherwise I'd submit a doctest.

Without this PR we get some random exception trying to parse the HTML response:

>>> from owslib.csw import CatalogueServiceWeb
>>> c=CatalogueServiceWeb('http://geonet.allerdale.gov.uk/geonetwork/srv/en/csw')
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest csw_error.txt[1]>", line 1, in <module>
        c=CatalogueServiceWeb('http://geonet.allerdale.gov.uk/geonetwork/srv/en/csw')
      File "owslib/csw.py", line 88, in __init__
        self._invoke()
      File "owslib/csw.py", line 668, in _invoke
        self._exml = etree.parse(BytesIO(self.response))
      File "lxml.etree.pyx", line 3198, in lxml.etree.parse (src/lxml/lxml.etree.c:65048)
      File "parser.pxi", line 1588, in lxml.etree._parseDocument (src/lxml/lxml.etree.c:93355)
      File "parser.pxi", line 1617, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:93649)
      File "parser.pxi", line 1495, in lxml.etree._parseDoc (src/lxml/lxml.etree.c:92453)
      File "parser.pxi", line 1011, in lxml.etree._BaseParser._parseDoc (src/lxml/lxml.etree.c:89097)
      File "parser.pxi", line 577, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:84804)
      File "parser.pxi", line 676, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:85904)
      File "parser.pxi", line 616, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:85228)
    XMLSyntaxError: Opening and ending tag mismatch: link line 7 and head, line 8, column 11

and with this PR we get a much nicer HTTPException that tells us the URL with all the params that we are trying (which I can tell the user so he/she can debug the server):

Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest csw_error.txt[1]>", line 1, in <module>
        c=CatalogueServiceWeb('http://geonet.allerdale.gov.uk/geonetwork/srv/en/csw')
      File "owslib/csw.py", line 88, in __init__
        self._invoke()
      File "owslib/csw.py", line 650, in _invoke
        self.response = openURL(self.request, None, 'Get', username=self.username, password=self.password, timeout=self.timeout).read()
      File "owslib/util.py", line 203, in openURL
        req.raise_for_status()
      File "/home/co/ckan/local/lib/python2.7/site-packages/requests/models.py", line 851, in raise_for_status
        raise HTTPError(http_error_msg, response=self)
    HTTPError: 500 Server Error: Internal Server Error

I included the 50x codes that I felt are pretty certain to be "server not happy", and missed off "501 Not Implemented" which sort of implied the request was not supported now but may be in the future, but the server did know what it was doing. Anyway, I'm open to changing this list to all the 5xx ones if preferred.