### PR TITLE
wfs110 - Missing credentials

### DIFF
--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -76,7 +76,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         self.password = password
         self._capabilities = None
         self.owscommon = OwsCommon('1.0.0')
-        reader = WFSCapabilitiesReader(self.version)
+        reader = WFSCapabilitiesReader(self.version, username=username, password=password)
         if xml:
             self._capabilities = reader.readString(xml)
         else:

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -84,7 +84,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         self.username = username
         self.password = password
         self._capabilities = None
-        reader = WFSCapabilitiesReader(self.version)
+        reader = WFSCapabilitiesReader(self.version, username=username, password=password)
         if xml:
             self._capabilities = reader.readString(xml)
         else:


### PR DESCRIPTION
When creating the WFSCapabilitiesReader, provided credentials are discarded