### PR TITLE
Fixing doc in CSW-T - missing "" in parameter

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -382,7 +382,7 @@ Transaction: insert
 
 .. code-block:: python
 
-  >>> csw.transaction(ttype='insert', typename='gmd:MD_Metadata', record=open(file.xml).read())
+  >>> csw.transaction(ttype='insert', typename='gmd:MD_Metadata', record=open("file.xml").read())
 
 Transaction: update
 


### PR DESCRIPTION
Minor modification: missing quote between argument in open() in doc