### PR TITLE
Swe fixes

### DIFF
--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -268,6 +268,10 @@ def get_time(value, referenceTime, uom):
         elif value.lower() == "-inf":
             value  = NegativeInfiniteDateTime()
 
+    # Usually due to not finding the element
+    except TypeError:
+        value = None
+
     return value
 
 class Time(AbstractSimpleComponent):
@@ -284,8 +288,10 @@ class Time(AbstractSimpleComponent):
         # Attributes
         self.localFrame         = testXMLAttribute(element,"localFrame")                                    # anyURI, optional
         try:
-            self.referenceTime  = parser.parse(testXMLAttribute(element,"referenceTime"))                   # dateTime, optional
-        except (AttributeError, ValueError):
+            self.referenceTime  = parser.parse(testXMLAttribute(element,
+                                                                "referenceTime")
+                                               ) # dateTime, optional
+        except (AttributeError, ValueError, TypeError):
             self.referenceTime  = None
 
         value                   = testXMLValue(element.find(nspv("swe20:value")))                           # TimePosition, min=0, max=1
@@ -306,7 +312,7 @@ class TimeRange(AbstractSimpleComponent):
         self.localFrame         = testXMLAttribute(element,"localFrame")                                # anyURI, optional
         try:
             self.referenceTime  = parser.parse(testXMLAttribute(element,"referenceTime"))               # dateTime, optional
-        except (AttributeError, ValueError):
+        except (AttributeError, ValueError, TypeError):
             self.referenceTime  = None
 
         values                  = make_pair(testXMLValue(element.find(nspv("swe20:value"))))            # TimePosition, min=0, max=1

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from owslib.etree import etree
 
 import inspect
+from sys import modules
 
 def get_namespaces():
     ns = Namespaces()
@@ -19,7 +20,6 @@ namespaces = get_namespaces()
 def nspv(path):
     return nspath_eval(path, namespaces)
 
-from sys import modules
 def make_pair(string, cast=None):
     if string is None:
         return None

--- a/owslib/swe/common.py
+++ b/owslib/swe/common.py
@@ -8,7 +8,6 @@ from dateutil import parser
 from datetime import timedelta
 
 from owslib.etree import etree
-from sys import modules
 
 import inspect
 


### PR DESCRIPTION
Fixes an issue with optional SWE elements where optional time element would raise an uncaught exception if the element was not found.

Removed use of eval to delegate to class constructors, and instead used a dict generated from the classes contained within the module, mapping the string name as a key to the corresponding class.

Code in question is here:
https://github.com/geopython/OWSLib/blob/c86c02f/owslib/swe/common.py#L67-L72

The eval could previously run arbitrary code conforming to valid XML tag names with a properly crafted XML payload.

For example, passing the etree parsed element to `NamedObject`'s constructor with contents of:

"<root name='foo'><etree.tostring></etree.tostring></root>"

is valid payload and will result in a string of '<etree.tostring/>' being returned, which is not desirable.

Fortunately, restrictions on XML tag characters prevent anything too malicious from happening in the current codebase, i.e. no parens or quotes so you can't do `__import__('os').system('rm -rf /important_dir')`
