### PR TITLE
Support for missing style elements.

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -52,6 +52,9 @@ _OWS_NS = '{http://www.opengis.net/ows/1.1}'
 _WMTS_NS = '{http://www.opengis.net/wmts/1.0}'
 _XLINK_NS = '{http://www.w3.org/1999/xlink}'
 
+# OpenGIS Web Map Tile Service (WMTS) Implementation Standard
+# Version 1.0.0, document 07-057r7
+
 _ABSTRACT_TAG = _OWS_NS + 'Abstract'
 _IDENTIFIER_TAG = _OWS_NS + 'Identifier'
 _LOWER_CORNER_TAG = _OWS_NS + 'LowerCorner'
@@ -77,7 +80,11 @@ _MIN_TILE_ROW_TAG = _WMTS_NS + 'MinTileRow'
 _RESOURCE_URL_TAG = _WMTS_NS + 'ResourceURL'
 _SCALE_DENOMINATOR_TAG = _WMTS_NS + 'ScaleDenominator'
 _SERVICE_METADATA_URL_TAG = _WMTS_NS + 'ServiceMetadataURL'
+
+# Table 7, page 20-21, Parts of Style data structure
 _STYLE_TAG = _WMTS_NS + 'Style'
+_STYLE_LEGEND_URL = _WMTS_NS + 'LegendURL'
+
 _THEME_TAG = _WMTS_NS + 'Theme'
 _THEMES_TAG = _WMTS_NS + 'Themes'
 _TILE_HEIGHT_TAG = _WMTS_NS + 'TileHeight'
@@ -729,12 +736,33 @@ class ContentMetadata:
             style = {}
             isdefaulttext = s.attrib.get('isDefault')
             style['isDefault'] = (isdefaulttext == "true")
-            identifier = s.find(_IDENTIFIER_TAG)
+            identifier = s.find(_IDENTIFIER_TAG)  # one and mandatory
             if identifier is None:
                 raise ValueError('%s missing identifier' % (s,))
+
             title = s.find(_TITLE_TAG)
             if title is not None:
-                style['title'] = title.text
+                style['title'] = testXMLValue(title)
+
+            abstract = s.find(_ABSTRACT_TAG)
+            if abstract is not None:
+                style['abstract'] = testXMLValue(abstract)
+
+            legendURL = s.find(_STYLE_LEGEND_URL)
+            if legendURL is not None:
+                style['legend'] = legendURL.attrib[_HREF_TAG]
+                if 'width' in legendURL.attrib.keys():
+                    style['width'] = legendURL.attrib.get('width')
+                if 'height' in legendURL.attrib.keys():
+                    style['height'] = legendURL.attrib.get('height')
+                if 'format' in legendURL.attrib.keys():
+                    style['format'] = legendURL.attrib.get('format')
+
+            keywords = [f.text for f in s.findall(
+                        _KEYWORDS_TAG+'/'+_KEYWORD_TAG)]
+            if keywords:  # keywords is a list []
+                style['keywords'] = keywords
+
             self.styles[identifier.text] = style
 
         self.formats = [f.text for f in elem.findall(_FORMAT_TAG)]

--- a/tests/doctests/wmts.txt
+++ b/tests/doctests/wmts.txt
@@ -44,3 +44,9 @@ Fetch a tile (using some defaults):
 Test a WMTS without a ServiceProvider tag in Capababilities XML
 
     >>> wmts = WebMapTileService('http://data.geus.dk/arcgis/rest/services/OneGeologyGlobal/S071_G2500_OneGeology/MapServer/WMTS/1.0.0/WMTSCapabilities.xml')
+
+Test styles for several layers
+    >>> wmts1.contents['MLS_SO2_147hPa_Night'].styles
+    {'default': {'isDefault': True, 'title': 'default'}}
+    >>> wmts1.contents['MLS_SO2_147hPa_Night'].styles
+    {'default': {'isDefault': True, 'title': 'default'}}

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -147,6 +147,26 @@ Test single item accessor
     >>> wmts['geonode:GH_Areas_Protegidas4326'].resourceURLs
     []
 
+Test several layers styles
+    >>> wmts.contents['geonode:MANGROVES'].styles
+    {'MANGROVES': {'isDefault': True}}
+    >>> wmts.contents['geonode:asfalto'].styles
+    {'asfalto': {'isDefault': True}}
+    >>> wmts.contents['geonode:hotspots_revisited_2004_polygons'].styles
+    {'hotspots_revisited_2004_polygons': {'abstract': 'TEST Abstract: hotspots revisited 2004 polygons',
+      'format': 'image/png',
+      'height': '100',
+      'isDefault': True,
+      'keywords': ['testkeywords1', 'test keywords 2', 'test keywords 3'],
+      'legend': 'http://www.maps.bob/etopo2/legend.png',
+      'title': 'TEST Title: hotspots revisited 2004 polygons',
+      'width': '100'}}
+    >>> wmts.contents['geonode:asfalto'].styles
+    {'asfalto': {'format': 'image/png',
+      'isDefault': True,
+      'legend': 'http://www.maps.bob/etopo2/legend.png',
+      'title': 'TEST Title: hotspots revisited 2004 polygons'}}
+
 Test operations
     # TODO
 

--- a/tests/resources/geoserver21-wmts-cap.xml
+++ b/tests/resources/geoserver21-wmts-cap.xml
@@ -470,6 +470,19 @@ http://www.lme.noaa.gov/index.php?option=com_content&amp;view=article&amp;id=177
     <ows:Identifier>geonode:hotspots_revisited_2004_polygons</ows:Identifier>
     <Style isDefault="true">
       <ows:Identifier>hotspots_revisited_2004_polygons</ows:Identifier>
+      <!--
+        NOTE: tags has been copied here to test the styles LegendURL.
+        LegendURL copied and modified from 07-057r7_Web_Map_Tile_Service_Standard.pdf, page 33
+      -->
+      <ows:Title>TEST Title: hotspots revisited 2004 polygons</ows:Title>
+      <ows:Abstract>TEST Abstract: hotspots revisited 2004 polygons</ows:Abstract>
+      <ows:Keywords>
+        <ows:Keyword>testkeywords1</ows:Keyword>
+        <ows:Keyword>test keywords 2</ows:Keyword>
+        <ows:Keyword>test keywords 3</ows:Keyword>
+      </ows:Keywords>
+      <LegendURL format="image/png" width="100" height="100" xlink:href="http://www.maps.bob/etopo2/legend.png" />
+      <!-- END customization -->
     </Style>
     <Format>image/png</Format>
     <Format>image/jpeg</Format>
@@ -864,6 +877,13 @@ http://www.lme.noaa.gov/index.php?option=com_content&amp;view=article&amp;id=177
     <ows:Identifier>geonode:asfalto</ows:Identifier>
     <Style isDefault="true">
       <ows:Identifier>asfalto</ows:Identifier>
+      <!--
+        NOTE: tags has been copied here to test the styles LegendURL.
+        LegendURL copied and modified from 07-057r7_Web_Map_Tile_Service_Standard.pdf, page 33
+      -->
+      <ows:Title>TEST Title: hotspots revisited 2004 polygons</ows:Title>
+      <LegendURL format="image/png" xlink:href="http://www.maps.bob/etopo2/legend.png" />
+      <!-- END customization -->
     </Style>
     <Format>image/png</Format>
     <Format>image/jpeg</Format>


### PR DESCRIPTION
Based on OpenGIS Web Map Tile Service (WMTS) Implementation Standard
Version 1.0.0, document 07-057r7, page 20-21 it has beed added for the
style tag the support for astract, title, keywords and legendURL
(legend, width, height) elements.