### PR TITLE
drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
 #  - "pypy"
@@ -11,7 +10,6 @@ env:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install -r requirements-2.6.txt; fi
   - if [ "$LXML" == "true" ]; then pip install lxml; fi
 script:
   - python -m pytest

--- a/etc/debian/control
+++ b/etc/debian/control
@@ -2,12 +2,12 @@ Source: owslib
 Section: python
 Priority: optional
 Maintainer: Angelos Tzotsos <gcpp.kalxas@gmail.com>
-Build-Depends: debhelper (>= 7.0.50), python-setuptools (>= 0.6), python-support (>=0.6), python-all-dev (>= 2.3.5-11), python (>= 2.6.6-3)
+Build-Depends: debhelper (>= 7.0.50), python-setuptools (>= 0.6), python-support (>=0.6), python-all-dev (>= 2.3.5-11), python (>= 2.7)
 Standards-Version: 3.9.3
-X-Python-Version: >= 2.5
+X-Python-Version: >= 2.7
 Homepage: http://geopython.github.com/OWSLib/
 
 Package: python-owslib
 Architecture: all
-Depends: ${misc:Depends}, debconf, python (>=2.5), python-lxml
+Depends: ${misc:Depends}, debconf, python (>=2.7), python-lxml
 Description: OWSLib is a Python package for client programming with Open Geospatial Consortium (OGC) web service (hence OWS) interface standards, and their related content models.

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -668,6 +668,7 @@ class CatalogueServiceWeb(object):
                     ns_keys = [x.split(':')[0] for x in ns.split(' ')]
                     self.request = add_namespaces(self.request, ns_keys)
 
+            print(etree.tostring(self.request))
             self.request = util.element_to_string(self.request, encoding='utf-8')
 
             self.response = util.http_post(request_url, self.request, self.lang, self.timeout, self.username, self.password)

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -668,7 +668,6 @@ class CatalogueServiceWeb(object):
                     ns_keys = [x.split(':')[0] for x in ns.split(' ')]
                     self.request = add_namespaces(self.request, ns_keys)
 
-            print(etree.tostring(self.request))
             self.request = util.element_to_string(self.request, encoding='utf-8')
 
             self.response = util.http_post(request_url, self.request, self.lang, self.timeout, self.username, self.password)

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -5,32 +5,6 @@
 # =============================================================================
 
 from __future__ import (absolute_import, division, print_function)
-import six
-import inspect
-
-def patch_well_known_namespaces(etree_module):
-
-    import warnings
-    from owslib.namespaces import Namespaces
-    ns = Namespaces()
-
-    """Monkey patches the etree module to add some well-known namespaces."""
-
-    try:
-        register_namespace = etree_module.register_namespace
-    except AttributeError:
-        try:
-            etree_module._namespace_map
-
-            def register_namespace(prefix, uri):
-                etree_module._namespace_map[uri] = prefix
-        except AttributeError:
-            def register_namespace(prefix, uri):
-                pass
-            warnings.warn("Only 'lxml.etree' >= 2.3 and 'xml.etree.ElementTree' >= 1.3 are fully supported!")
-
-    for k, v in six.iteritems(ns.get_namespaces()):
-        register_namespace(k, v)
 
 # try to find lxml or elementtree
 try:
@@ -38,29 +12,9 @@ try:
     from lxml.etree import ParseError
     ElementType = etree._Element
 except ImportError:
+    import xml.etree.ElementTree as etree
     try:
-        # Python 2.x/3.x with ElementTree included
-        import xml.etree.ElementTree as etree
-
-        try:
-            from xml.etree.ElementTree import ParseError
-        except ImportError:
-            from xml.parsers.expat import ExpatError as ParseError
-
-        if hasattr(etree, 'Element') and inspect.isclass(etree.Element):
-            # python 3.4, 3.3, 2.7
-            ElementType = etree.Element
-        else:
-            # python 2.6
-            ElementType = etree._ElementInterface
-
+        from xml.etree.ElementTree import ParseError
     except ImportError:
-        try:
-            # Python < 2.5 with ElementTree installed
-            import elementtree.ElementTree as etree
-            ParseError = StandardError      # i can't find a ParseError related item in elementtree docs!
-            ElementType = etree.Element
-        except ImportError:
-            raise RuntimeError('You need either lxml or ElementTree to use OWSLib!')
-
-patch_well_known_namespaces(etree)
+        from xml.parsers.expat import ExpatError as ParseError
+        ElementType = etree.Element

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -5,6 +5,26 @@
 # =============================================================================
 
 from __future__ import (absolute_import, division, print_function)
+import six
+from owslib.namespaces import Namespaces
+
+
+def patch_well_known_namespaces(etree_module):
+    """Monkey patches the etree module to add some well-known namespaces."""
+
+    ns = Namespaces()
+
+    try:
+        register_namespace = etree_module.register_namespace
+    except AttributeError:
+        etree_module._namespace_map
+
+        def register_namespace(prefix, uri):
+            etree_module._namespace_map[uri] = prefix
+
+    for k, v in six.iteritems(ns.get_namespaces()):
+        register_namespace(k, v)
+
 
 # try to find lxml or elementtree
 try:
@@ -18,3 +38,5 @@ except ImportError:
         from xml.etree.ElementTree import ParseError
     except ImportError:
         from xml.parsers.expat import ExpatError as ParseError
+
+patch_well_known_namespaces(etree)

--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -13,8 +13,8 @@ try:
     ElementType = etree._Element
 except ImportError:
     import xml.etree.ElementTree as etree
+    ElementType = etree.Element
     try:
         from xml.etree.ElementTree import ParseError
     except ImportError:
         from xml.parsers.expat import ExpatError as ParseError
-        ElementType = etree.Element

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -152,7 +152,7 @@ class WebFeatureService_1_0_0(object):
         """
         Helper method to make sure the StringIO being returned will work.
 
-        Differences between Python 2.6/2.7/3.x mean we have a lot of cases to handle.
+        Differences between Python 2.7/3.x mean we have a lot of cases to handle.
         """
         if PY2:
             return StringIO(strval)

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -141,7 +141,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         """
         Helper method to make sure the StringIO being returned will work.
 
-        Differences between Python 2.6/2.7/3.x mean we have a lot of cases to handle.
+        Differences between Python 2.7/3.x mean we have a lot of cases to handle.
         """
         if PY2:
             return StringIO(strval)

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -160,7 +160,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         """
         Helper method to make sure the StringIO being returned will work.
 
-        Differences between Python 2.6/2.7/3.x mean we have a lot of cases to handle.
+        Differences between Python 2.7/3.x mean we have a lot of cases to handle.
         """
         if PY2:
             return StringIO(strval)

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -10,6 +10,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import sys
+from collections import OrderedDict
 from dateutil import parser
 from datetime import datetime
 import pytz
@@ -634,13 +635,6 @@ except AttributeError:
 log = logging.getLogger('owslib')
 log.addHandler(NullHandler())
 
-# OrderedDict
-try:  # 2.7
-    from collections import OrderedDict
-except:  # 2.6
-    from ordereddict import OrderedDict
-
-
 def which_etree():
     """decipher which etree library is being used by OWSLib"""
 
@@ -668,23 +662,9 @@ def findall(root, xpath, attribute_name=None, attribute_value=None):
 
     found_elements = []
 
-
-    # python 2.6 < does not support complicated XPATH expressions used lower
-    if (2, 6) == sys.version_info[0:2] and which_etree() != 'lxml.etree':
-
-        elements = root.getiterator(xpath)
-
-        if attribute_name is not None and attribute_value is not None:
-            for element in elements:
-                if element.attrib.get(attribute_name) == attribute_value:
-                    found_elements.append(element)
-        else:
-            found_elements = elements
-    # python at least 2.7 and/or lxml can do things much simplier
-    else:
-        if attribute_name is not None and attribute_value is not None:
-            xpath = '%s[@%s="%s"]' % (xpath, attribute_name, attribute_value)
-        found_elements = root.findall('.//' + xpath)
+    if attribute_name is not None and attribute_value is not None:
+        xpath = '%s[@%s="%s"]' % (xpath, attribute_name, attribute_value)
+    found_elements = root.findall('.//' + xpath)
 
     if found_elements == []:
         found_elements = None

--- a/requirements-2.6.txt
+++ b/requirements-2.6.txt
@@ -1,1 +1,0 @@
-ordereddict==1.1

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ class PyTest(TestCommand):
 readme = open('README.txt').read()
 reqs = [line.strip() for line in open('requirements.txt')]
 
-if sys.version[:3] < '2.7':
-    reqs += [line.strip() for line in open('requirements-2.6.txt')]
-
 setup(name              = 'OWSLib',
       version           = owslib.__version__,
       description       = 'OGC Web Service utility library',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ python_functions=check
 
 [tox]
 skipsdist=True
-envlist=py27-with-lxml,py27-with-old-lxml,py27-without-lxml,py26-with-lxml,py26-with-old-lxml,py26-without-lxml
+envlist=py27-with-lxml,py27-with-old-lxml,py27-without-lxml
 
 [testenv:py27-with-lxml]
 basepython = /opt/python-2.7.6/bin/python
@@ -24,26 +24,6 @@ deps=-rrequirements.txt
 basepython = /opt/python-2.7.6/bin/python
 deps=-rrequirements.txt
      -rrequirements-dev.txt
-
-[testenv:py26-with-lxml]
-basepython = /opt/python-2.6.9/bin/python
-deps=-rrequirements.txt
-     -rrequirements-dev.txt
-     -rrequirements-2.6.txt
-     lxml
-
-[testenv:py26-with-old-lxml]
-basepython = /opt/python-2.6.9/bin/python
-deps=-rrequirements.txt
-     -rrequirements-dev.txt
-     -rrequirements-2.6.txt
-     lxml<2.3
-
-[testenv:py26-without-lxml]
-basepython = /opt/python-2.6.9/bin/python
-deps=-rrequirements.txt
-     -rrequirements-dev.txt
-     -rrequirements-2.6.txt
 
 [testenv]
 recreate=False


### PR DESCRIPTION
This PR drops support for Python 2.6 per https://lists.osgeo.org/pipermail/owslib-devel/2017-July/000295.html.