### PR TITLE
concatenate bytes with bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
+  - "3.6"
 #  - "pypy"
 sudo: false
 env:

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -688,14 +688,14 @@ class WPSExecution():
         """
 
         if self.isSucceded():
-            content = ''
+            content = b''
             for output in self.processOutputs:
 
                 output_content = output.retrieveData(
                     self.username, self.password)
 
                 # ExecuteResponse contains reference to server-side output
-                if output_content is not "":
+                if output_content is not b'':
                     content = content + output_content
                     if filepath is None:
                         filepath = output.fileName


### PR DESCRIPTION
Pinging @rsignell-usgs who needs this to fix https://github.com/USGS-CIDA/pyGDP/pull/141

`output_content` will be bytes in Python 3 and concatenating it with string causes `OWSLib` to fail when we do:

```python
content = content + output_content
```

Latest master status on Travis-CI is:

```
Python 2.7 LXML=true :: 9 failed, 73 passed, 9 warnings
Python 2.7 LXML=false :: 9 failed, 73 passed, 7 warnings
Python 3.4 LXML=true :: 16 failed, 66 passed
Python 3.4 LXML=false :: 16 failed, 66 passed
```

I got slightly less failures with `Python 3.4 LXML=false` (14 failed, 68 passed) also a few less failure for Python 3.6 in both cases. However, I don't think it is related to this change b/c I don't think that part of the code is covered with a test.

PS: I also remove Python 2.6 from the Travis-CI configuration and added Python 3.6 to it.