### PR TITLE
Support PROJ4 CRS definition

### DIFF
--- a/owslib/crs.py
+++ b/owslib/crs.py
@@ -1783,7 +1783,11 @@ class Crs(object):
         elif len(values) == 2:  # it's an authority:code code
             self.encoding = "code"
             self.authority = values[0].upper()
-            self.code = int(values[1])
+
+            try:
+                self.code = int(values[1])
+            except:
+                self.code = values[1]
 
         # if the user has not forced the axisorder,
         # scan the list of codes that have an axis ordering of

--- a/tests/doctests/crs.txt
+++ b/tests/doctests/crs.txt
@@ -33,3 +33,8 @@
     4326
     >>> c.axisorder
     'yx'
+    >>> c=crs.Crs('PROJ4:+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 +x_0=600000 +y_0=2200000')
+    >>> c.authority
+    'PROJ4'
+    >>> c.code
+    '+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 +x_0=600000 +y_0=2200000'


### PR DESCRIPTION
WMS GetCapabilities like

http://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities

can't be parsed because of exception on CRS instanciation on PROJ4 definition.