### PR TITLE
Fix getTypedValue for booleans.

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -494,7 +494,7 @@ def getTypedValue(data_type, value):
     '''Utility function to cast a string value to the appropriate XSD type. '''
 
     if data_type == 'boolean':
-        return bool(value)
+        return True if value.lower() == 'true' else False
     elif data_type == 'integer':
         return int(value)
     elif data_type == 'float':


### PR DESCRIPTION
xs:boolean is either 'true' or 'false', but since bool('false') returns
True, we better check if the string equals 'true'.