### PR TITLE
Add parsing of FC_FeatureCatalogue to CSW

### DIFF
--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -30,7 +30,7 @@ from owslib.etree import etree
 from owslib import fes
 from owslib import util
 from owslib import ows
-from owslib.iso import MD_Metadata
+from owslib.iso import MD_Metadata, FC_FeatureCatalogue
 from owslib.fgdc import Metadata
 from owslib.dif import DIF
 from owslib.gm03 import GM03
@@ -547,6 +547,9 @@ class CatalogueServiceWeb(object):
                 val = i.find(util.nspath_eval('gmd:fileIdentifier/gco:CharacterString', namespaces))
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = MD_Metadata(i)
+            for i in self._exml.findall('.//'+util.nspath_eval('gfc:FC_FeatureCatalogue', namespaces)):
+                identifier = i.attrib['uuid']
+                self.records[identifier] = FC_FeatureCatalogue(i)
         elif outputschema == namespaces['fgdc']: # fgdc csdgm
             for i in self._exml.findall('.//metadata'):
                 val = i.find('idinfo/datasetid')

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -548,7 +548,7 @@ class CatalogueServiceWeb(object):
                 identifier = self._setidentifierkey(util.testXMLValue(val))
                 self.records[identifier] = MD_Metadata(i)
             for i in self._exml.findall('.//'+util.nspath_eval('gfc:FC_FeatureCatalogue', namespaces)):
-                identifier = i.attrib['uuid']
+                identifier = self._setidentifierkey(util.testXMLValue(i.attrib['uuid'], attrib=True))
                 self.records[identifier] = FC_FeatureCatalogue(i)
         elif outputschema == namespaces['fgdc']: # fgdc csdgm
             for i in self._exml.findall('.//metadata'):

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -20,7 +20,7 @@ from owslib.namespaces import Namespaces
 # default variables
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["gco","gmd","gml","gml32","gmx","gts","srv","xlink"])
+    ns = n.get_namespaces(["gco","gfc","gmd","gml","gml32","gmx","gts","srv","xlink"])
     ns[None] = n.get_namespace("gmd")
     return ns
 namespaces = get_namespaces()
@@ -907,3 +907,114 @@ class CodelistCatalogue(object):
             return ids
         else:
             return None
+
+class FC_FeatureCatalogue(object):
+    """Process gfc:FC_FeatureCatalogue"""
+    def __init__(self, fc=None):
+        if fc is None:
+            self.xml = None
+            self.identifier = None
+            self.name = None
+            self.versiondate = None
+            self.producer = None
+            self.featuretypes = []
+        else:
+            if hasattr(fc, 'getroot'):  # standalone document
+                self.xml = etree.tostring(fc.getroot())
+            else:  # part of a larger document
+                self.xml = etree.tostring(fc)
+
+            val = fc.attrib['uuid']
+            self.identifier = util.testXMLValue(val, attrib=True)
+
+            val = fc.find(util.nspath_eval('gmx:name/gco:CharacterString', namespaces))
+            self.name = util.testXMLValue(val)
+
+            val = fc.find(util.nspath_eval('gmx:versionDate/gco:Date', namespaces))
+            self.versiondate = util.testXMLValue(val)
+
+            if not self.versiondate:
+                val = fc.find(util.nspath_eval('gmx:versionDate/gco:DateTime', namespaces))
+                self.versiondate = util.testXMLValue(val)
+
+            o = fc.find(util.nspath_eval('gfc:producer/gmd:CI_ResponsibleParty', namespaces))
+            self.producer = CI_ResponsibleParty(o)
+
+            self.featuretypes = []
+            for i in fc.findall(util.nspath_eval('gfc:featureType/gfc:FC_FeatureType', namespaces)):
+                self.featuretypes.append(FC_FeatureType(i))
+
+class FC_FeatureType(object):
+    """Process gfc:FC_FeatureType"""
+    def __init__(self, ft=None):
+        if ft is None:
+            self.xml = None
+            self.identifier = None
+            self.typename = None
+            self.definition = None
+            self.attributes = []
+        else:
+            if hasattr(ft, 'getroot'):  # standalone document
+                self.xml = etree.tostring(ft.getroot())
+            else:  # part of a larger document
+                self.xml = etree.tostring(ft)
+
+            val = ft.attrib['uuid']
+            self.identifier = util.testXMLValue(val, attrib=True)
+
+            val = ft.find(util.nspath_eval('gfc:typeName/gco:LocalName', namespaces))
+            self.typename = util.testXMLValue(val)
+
+            val = ft.find(util.nspath_eval('gfc:definition/gco:CharacterString', namespaces))
+            self.definition = util.testXMLValue(val)
+
+            self.attributes = []
+            for i in ft.findall(util.nspath_eval('gfc:carrierOfCharacteristics/gfc:FC_FeatureAttribute', namespaces)):
+                self.attributes.append(FC_FeatureAttribute(i))
+
+class FC_FeatureAttribute(object):
+    """Process gfc:FC_FeatureAttribute"""
+    def __init__(self, fa=None):
+        if fa is None:
+            self.xml = None
+            self.membername = None
+            self.definition = None
+            self.listedvalues = []
+        else:
+            if hasattr(fa, 'getroot'):  # standalone document
+                self.xml = etree.tostring(fa.getroot())
+            else:  # part of a larger document
+                self.xml = etree.tostring(fa)
+
+            val = fa.find(util.nspath_eval('gfc:memberName/gco:LocalName', namespaces))
+            self.membername = util.testXMLValue(val)
+
+            val = fa.find(util.nspath_eval('gfc:definition/gco:CharacterString', namespaces))
+            self.definition = util.testXMLValue(val)
+
+            self.listedvalues = []
+            for i in fa.findall(util.nspath_eval('gfc:listedValue/gfc:FC_ListedValue', namespaces)):
+                self.listedvalues.append(FC_ListedValue(i))
+
+class FC_ListedValue(object):
+    """Process gfc:FC_ListedValue"""
+    def __init__(self, lv=None):
+        if lv is None:
+            self.xml = None
+            self.label = None
+            self.code = None
+            self.definition = None
+        else:
+            if hasattr(lv, 'getroot'):  # standalone document
+                self.xml = etree.tostring(lv.getroot())
+            else:  # part of a larger document
+                self.xml = etree.tostring(lv)
+
+            val = lv.find(util.nspath_eval('gfc:label/gco:CharacterString', namespaces))
+            self.label = util.testXMLValue(val)
+
+            val = lv.find(util.nspath_eval('gfc:code/gco:CharacterString', namespaces))
+            self.code = util.testXMLValue(val)
+
+            val = lv.find(util.nspath_eval('gfc:definition/gco:CharacterString', namespaces))
+            self.definition = util.testXMLValue(val)

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -917,6 +917,7 @@ class MD_FeatureCatalogueDescription(object):
     def __init__(self, fcd=None):
         if fcd is None:
             self.xml = None
+            self.compliancecode = None
             self.language = []
             self.includedwithdataset = None
             self.featuretypenames = []
@@ -926,6 +927,12 @@ class MD_FeatureCatalogueDescription(object):
                 self.xml = etree.tostring(fcd.getroot())
             else:  # part of a larger document
                 self.xml = etree.tostring(fcd)
+
+            self.compliancecode = None
+            val = fcd.find(util.nspath_eval('gmd:complianceCode/gco:Boolean', namespaces))
+            val = util.testXMLValue(val)
+            if val is not None:
+                self.compliancecode = util.getTypedValue('boolean', val)
 
             self.language = []
             for i in fcd.findall(util.nspath_eval('gmd:language/gco:CharacterString', namespaces)):
@@ -954,7 +961,6 @@ class MD_FeatureCatalogueDescription(object):
                 val = util.testXMLValue(val, attrib=True)
                 if val is not None:
                     self.featurecatalogues.append(val)
-
 
 class FC_FeatureCatalogue(object):
     """Process gfc:FC_FeatureCatalogue"""
@@ -1001,6 +1007,9 @@ class FC_FeatureType(object):
             self.identifier = None
             self.typename = None
             self.definition = None
+            self.isabstract = None
+            self.aliases = []
+            self.featurecatalogue = None
             self.attributes = []
         else:
             if hasattr(ft, 'getroot'):  # standalone document
@@ -1016,6 +1025,16 @@ class FC_FeatureType(object):
 
             val = ft.find(util.nspath_eval('gfc:definition/gco:CharacterString', namespaces))
             self.definition = util.testXMLValue(val)
+
+            self.isabstract = None
+            val = ft.find(util.nspath_eval('gfc:isAbstract/gco:Boolean', namespaces))
+            val = util.testXMLValue(val)
+            if val is not None:
+                self.isabstract = util.getTypedValue('boolean', val)
+
+            self.aliases = []
+            for i in ft.findall(util.nspath_eval('gfc:aliases/gco:LocalName', namespaces)):
+                self.aliases.append(util.testXMLValue(i))
 
             self.attributes = []
             for i in ft.findall(util.nspath_eval('gfc:carrierOfCharacteristics/gfc:FC_FeatureAttribute', namespaces)):

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -986,7 +986,8 @@ class FC_FeatureCatalogue(object):
                 self.versiondate = util.testXMLValue(val)
 
             o = fc.find(util.nspath_eval('gfc:producer/gmd:CI_ResponsibleParty', namespaces))
-            self.producer = CI_ResponsibleParty(o)
+            if o is not None:
+                self.producer = CI_ResponsibleParty(o)
 
             self.featuretypes = []
             for i in fc.findall(util.nspath_eval('gfc:featureType/gfc:FC_FeatureType', namespaces)):

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -940,6 +940,7 @@ class MD_FeatureCatalogueDescription(object):
                 if val is not None:
                     self.language.append(val)
 
+            self.includedwithdataset = None
             val = fcd.find(util.nspath_eval('gmd:includedWithDataset/gco:Boolean', namespaces))
             val = util.testXMLValue(val)
             if val is not None:
@@ -991,9 +992,10 @@ class FC_FeatureCatalogue(object):
                 val = fc.find(util.nspath_eval('gmx:versionDate/gco:DateTime', namespaces))
                 self.versiondate = util.testXMLValue(val)
 
-            o = fc.find(util.nspath_eval('gfc:producer/gmd:CI_ResponsibleParty', namespaces))
-            if o is not None:
-                self.producer = CI_ResponsibleParty(o)
+            self.producer = None
+            prod = fc.find(util.nspath_eval('gfc:producer/gmd:CI_ResponsibleParty', namespaces))
+            if prod is not None:
+                self.producer = CI_ResponsibleParty(prod)
 
             self.featuretypes = []
             for i in fc.findall(util.nspath_eval('gfc:featureType/gfc:FC_FeatureType', namespaces)):
@@ -1009,7 +1011,6 @@ class FC_FeatureType(object):
             self.definition = None
             self.isabstract = None
             self.aliases = []
-            self.featurecatalogue = None
             self.attributes = []
         else:
             if hasattr(ft, 'getroot'):  # standalone document

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -979,6 +979,8 @@ class FC_FeatureAttribute(object):
             self.xml = None
             self.membername = None
             self.definition = None
+            self.code = None
+            self.valuetype = None
             self.listedvalues = []
         else:
             if hasattr(fa, 'getroot'):  # standalone document
@@ -991,6 +993,12 @@ class FC_FeatureAttribute(object):
 
             val = fa.find(util.nspath_eval('gfc:definition/gco:CharacterString', namespaces))
             self.definition = util.testXMLValue(val)
+
+            val = fa.find(util.nspath_eval('gfc:code/gco:CharacterString', namespaces))
+            self.code = util.testXMLValue(val)
+
+            val = fa.find(util.nspath_eval('gfc:valueType/gco:TypeName/gco:aName/gco:CharacterString', namespaces))
+            self.valuetype = util.testXMLValue(val)
 
             self.listedvalues = []
             for i in fa.findall(util.nspath_eval('gfc:listedValue/gfc:FC_ListedValue', namespaces)):

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -49,6 +49,7 @@ class MD_Metadata(object):
             self.identification = None
             self.serviceidentification = None
             self.identificationinfo = []
+            self.contentinfo = []
             self.distribution = None
             self.dataquality = None
         else:
@@ -139,6 +140,10 @@ class MD_Metadata(object):
                         self.identificationinfo.append(MD_DataIdentification(val, 'service'))
                     elif tagval == 'SV_ServiceIdentification':
                         self.identificationinfo.append(SV_ServiceIdentification(val))
+
+            self.contentinfo = []
+            for contentinfo in md.findall(util.nspath_eval('gmd:contentInfo/gmd:MD_FeatureCatalogueDescription', namespaces)):
+                self.contentinfo.append(MD_FeatureCatalogueDescription(contentinfo))
 
             val = md.find(util.nspath_eval('gmd:distributionInfo/gmd:MD_Distribution', namespaces))
 
@@ -255,7 +260,6 @@ class CI_ResponsibleParty(object):
               self.onlineresource = None
 
             self.role = _testCodeListValue(md.find(util.nspath_eval('gmd:role/gmd:CI_RoleCode', namespaces)))
-
 
 class MD_Keywords(object):
     """
@@ -907,6 +911,50 @@ class CodelistCatalogue(object):
             return ids
         else:
             return None
+
+class MD_FeatureCatalogueDescription(object):
+    """Process gmd:MD_FeatureCatalogueDescription"""
+    def __init__(self, fcd=None):
+        if fcd is None:
+            self.xml = None
+            self.language = []
+            self.includedwithdataset = None
+            self.featuretypenames = []
+            self.featurecatalogues = []
+        else:
+            if hasattr(fcd, 'getroot'):  # standalone document
+                self.xml = etree.tostring(fcd.getroot())
+            else:  # part of a larger document
+                self.xml = etree.tostring(fcd)
+
+            self.language = []
+            for i in fcd.findall(util.nspath_eval('gmd:language/gco:CharacterString', namespaces)):
+                val = util.testXMLValue(i)
+                if val is not None:
+                    self.language.append(val)
+
+            val = fcd.find(util.nspath_eval('gmd:includedWithDataset/gco:Boolean', namespaces))
+            val = util.testXMLValue(val)
+            if val is not None:
+                self.includedwithdataset = util.getTypedValue('boolean', val)
+
+            self.featuretypenames = []
+            for i in fcd.findall(util.nspath_eval('gmd:featureTypes/gco:LocalName', namespaces)):
+                val = util.testXMLValue(i)
+                if val is not None:
+                    self.featuretypenames.append(val)
+            for i in fcd.findall(util.nspath_eval('gmd:featureTypes/gco:ScopedName', namespaces)):
+                val = util.testXMLValue(i)
+                if val is not None:
+                    self.featuretypenames.append(val)
+
+            self.featurecatalogues = []
+            for i in fcd.findall(util.nspath_eval('gmd:featureCatalogueCitation', namespaces)):
+                val = i.attrib['uuidref']
+                val = util.testXMLValue(val, attrib=True)
+                if val is not None:
+                    self.featurecatalogues.append(val)
+
 
 class FC_FeatureCatalogue(object):
     """Process gfc:FC_FeatureCatalogue"""

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -18,6 +18,7 @@ class Namespaces(object):
         'fes'   :   'http://www.opengis.net/fes/2.0',
         'fgdc'  :   'http://www.opengis.net/cat/csw/csdgm',
         'gco'   :   'http://www.isotc211.org/2005/gco',
+        'gfc'   :   'http://www.isotc211.org/2005/gfc',
         'gm03'  :   'http://www.interlis.ch/INTERLIS2.3',
         'gmd'   :   'http://www.isotc211.org/2005/gmd',
         'gmi'   :   'http://www.isotc211.org/2005/gmi',


### PR DESCRIPTION
I tried adding the parsing of gfc:FC_FeatureCatalogue's to the csw module, allowing to get these results from a csw service. Feature catalogues offer more information of the feature type of a vector layer, containing f.ex. a full description of each attribute or the domain (possible values) of an attribute with a description.

I added the parsing of gfc:FC_FeatureCatalogue under the 'gmd' outputSchema, since this is how Geonetwork treats them as well.

I also added the gmd:contentInfo (containing gmd:MD_FeatureCatalogueDescription) to the MD_Metadata class, because this is the way the metadata of a layer is linked with the feature catalogue.

I included the (in my opinion) most useful fields in each type. In most cases, the schema allows more fields to be present but these are not parsed. There is always the 'xml' field containing the raw content for users to parse it themselves.

I'm happy to answer questions or discuss improvements!