### PR TITLE
Completely remove srsname validation for WFS 1.1.0

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -34,7 +34,7 @@ class WebFeatureService_(object):
 
         # srs of the bbox is specified in the bbox as fifth paramter
         if len(bbox) == 5:
-            srs = self.getSRS(bbox[4],typename[0])
+            srs = Crs(bbox[4])
         # take default srs
         else:
             srs = self.contents[typename[0]].crsOptions[0]
@@ -75,9 +75,11 @@ class WebFeatureService_(object):
             # GetCaps document (the 'id' attribute in the Crs object).
             return self.contents[typename].crsOptions[index]
         except ValueError:
-            options = ", ".join(map(lambda x: x.id, self.contents[typename].crsOptions))
-            log.warning("Requested srsName '%s' not available for requested typename '%s'. \
-                         Options are: %s. " % (srs.getcode(), typename, options))
+            options = ", ".join(map(lambda crs: crs.id,
+                                self.contents[typename].crsOptions))
+            log.warning("Requested srsName %r is not declared as being "
+                        "allowed for requested typename %r. "
+                        "Options are: %r.", srs.getcode(), typename, options)
             return None
 
     def getGETGetFeatureRequest(self, typename=None, filter=None, bbox=None, featureid=None,

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -196,17 +196,12 @@ class WebFeatureService_1_1_0(WebFeatureService_):
             typename = [typename]
 
         if srsname is not None:
-            # check, if desired SRS is supported by the service for this typename
-            if typename is not None:
-                # convert srsname string to Crs object found in GetCaps
-                srsnameobj = self.getSRS(srsname, typename[0])
-                if srsnameobj is not None:
-                    request['srsname'] = srsnameobj.id
-                else:
-                    options = ", ".join(map(lambda x: x.id, self.contents[typename[0]].crsOptions))
-                    raise ServiceException("SRSNAME %s not supported.  Options: %s" % (srsname, options))
-            else:
-                request['srsname'] = str(srsname)
+            request['srsname'] = str(srsname)
+
+            # Check, if desired SRS is supported by the service for each
+            # typename. Warning will be thrown if that SRS is not allowed."
+            for name in typename:
+                _ = self.getSRS(srsname, name)
 
         # check featureid
         if featureid:


### PR DESCRIPTION
Because this unnecessary srs checking prevents to send valid WFS requests. For example:

```python
from owslib.wfs import WebFeatureService

wfs = WebFeatureService(url='https://ahocevar.com/geoserver/wfs',
                        version='1.1.0')
response = wfs.getfeature(
    typename='usa:states',
    maxfeatures=1,
    srsname='EPSG:3857',
    bbox=(-10297596.4506, 4203425.05946,
          -9398696.99795, 4751325.67821,
          'EPSG:3857'))
```

Although this request is completely valid OWSLib throws an error:

```python
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "/home/dr/ngw/env/local/lib/python2.7/site-packages/owslib/feature/wfs110.py", line 207, in getfeature
    raise ServiceException("SRSNAME %s not supported.  Options: %s" % (srsname, options))
owslib.util.ServiceException: SRSNAME EPSG:3857 not supported.  Options: urn:x-ogc:def:crs:EPSG:4326
```

But if sent request manually all works fine: https://ahocevar.com/geoserver/wfs?srsname=EPSG:3857&service=WFS&maxfeatures=1&propertyname=*&request=GetFeature&typename=usa:states&version=1.1.0&bbox=-10297596.4506,4203425.05946,-9398696.99795,4751325.67821,EPSG:3857

This PR is more general than https://github.com/geopython/OWSLib/pull/352