### PR TITLE
Fix FutureWarning in extract_xml_list.

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -538,13 +538,10 @@ def extract_xml_list(elements):
 Some people don't have seperate tags for their keywords and seperate them with
 a newline. This will extract out all of the keywords correctly.
 """
-    if elements:
-        keywords = [re.split(r'[\n\r]+',f.text) for f in elements if f.text]
-        flattened = [item.strip() for sublist in keywords for item in sublist]
-        remove_blank = [_f for _f in flattened if _f]
-        return remove_blank
-    else:
-        return []
+    keywords = (re.split(r'[\n\r]+',f.text) for f in elements if f.text)
+    flattened = (item.strip() for sublist in keywords for item in sublist)
+    remove_blank = [_f for _f in flattened if _f]
+    return remove_blank
 
 
 def strip_bom(raw_text):


### PR DESCRIPTION
Checking `if elements` raises a `FutureWarning`, but it's not necessary as the comprehensions will produce an empty list for empty input anyway.