### PR TITLE
Added `MD_LegalConstraints` to uselimitation' XPath

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -368,12 +368,16 @@ class MD_DataIdentification(object):
 
             self.uselimitation = []
             self.uselimitation_url = []
-            for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gco:CharacterString', namespaces)):
+            for i in \
+                    md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation/gco:CharacterString', namespaces)) + \
+                    md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gco:CharacterString', namespaces)):
                 val = util.testXMLValue(i)
                 if val is not None:
                     self.uselimitation.append(val)
 
-            for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gmx:Anchor', namespaces)):
+            for i in \
+                    md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation/gmx:Anchor', namespaces)) + \
+                    md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation/gmx:Anchor', namespaces)):
                 val = util.testXMLValue(i)
                 val1 = i.attrib.get(util.nspath_eval('xlink:href', namespaces))
 


### PR DESCRIPTION
Hi,

According to ISO model, `useLimitation` is an authorized type for `MD_LegalConstraints`.
`MD_LegalConstraints_Type` is an extension of `MD_Constraints_Type`.

http://www.isotc211.org/2005/gmd/constraints.xsd

``` xml
    <xs:complexType name="MD_Constraints_Type">
        <xs:annotation>
            <xs:documentation>Restrictions on the access and use of a dataset or metadata</xs:documentation>
        </xs:annotation>
        <xs:complexContent>
            <xs:extension base="gco:AbstractObject_Type">
                <xs:sequence>
                    <xs:element name="useLimitation" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
                </xs:sequence>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>

    <xs:complexType name="MD_LegalConstraints_Type">
        <xs:annotation>
            <xs:documentation>Restrictions and legal prerequisites for accessing and using the dataset.</xs:documentation>
        </xs:annotation>
        <xs:complexContent>
            <xs:extension base="gmd:MD_Constraints_Type">
                <xs:sequence>
                    <xs:element name="accessConstraints" type="gmd:MD_RestrictionCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
                    <xs:element name="useConstraints" type="gmd:MD_RestrictionCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
                    <xs:element name="otherConstraints" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
                </xs:sequence>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>
```

m431m
