### PR TITLE
Allow the lack of optional ows:ServiceProvider and ows:ServiceIdentification

### DIFF
--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -90,10 +90,12 @@ class WebFeatureService_1_1_0(WebFeatureService_):
 
         # ServiceIdentification
         val = self._capabilities.find(util.nspath_eval('ows:ServiceIdentification', namespaces))
-        self.identification=ServiceIdentification(val,self.owscommon.namespace)
+        if val is not None:
+            self.identification=ServiceIdentification(val,self.owscommon.namespace)
         # ServiceProvider
         val = self._capabilities.find(util.nspath_eval('ows:ServiceProvider', namespaces))
-        self.provider=ServiceProvider(val,self.owscommon.namespace)
+        if val is not None:
+            self.provider=ServiceProvider(val,self.owscommon.namespace)
         # ServiceOperations metadata
         self.operations=[]
         for elem in self._capabilities.findall(util.nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -98,21 +98,23 @@ class WebFeatureService_2_0_0(WebFeatureService_):
 
         #serviceIdentification metadata
         serviceidentelem=self._capabilities.find(nspath('ServiceIdentification'))
-        self.identification=ServiceIdentification(serviceidentelem)
+        if serviceidentelem is not None:
+            self.identification=ServiceIdentification(serviceidentelem)
         #need to add to keywords list from featuretypelist information:
         featuretypelistelem=self._capabilities.find(nspath('FeatureTypeList', ns=WFS_NAMESPACE))
         featuretypeelems=featuretypelistelem.findall(nspath('FeatureType', ns=WFS_NAMESPACE))
-        for f in featuretypeelems:
-            kwds=f.findall(nspath('Keywords/Keyword',ns=OWS_NAMESPACE))
-            if kwds is not None:
-                for kwd in kwds[:]:
-                    if kwd.text not in self.identification.keywords:
-                        self.identification.keywords.append(kwd.text)
-
+        if serviceidentelem is not None:
+            for f in featuretypeelems:
+                kwds=f.findall(nspath('Keywords/Keyword',ns=OWS_NAMESPACE))
+                if kwds is not None:
+                    for kwd in kwds[:]:
+                        if kwd.text not in self.identification.keywords:
+                            self.identification.keywords.append(kwd.text)
 
         #TODO: update serviceProvider metadata, miss it out for now
         serviceproviderelem=self._capabilities.find(nspath('ServiceProvider'))
-        self.provider=ServiceProvider(serviceproviderelem)
+        if serviceproviderelem:
+            self.provider=ServiceProvider(serviceproviderelem)
 
         #serviceOperations metadata
         self.operations=[]


### PR DESCRIPTION
In WFS 1.1.0 and 2.0.0, ows:ServiceProvider and
ows:ServiceIdentification
are both optional.

This patch makes owslib more compliant with servers' GetCapabilities that do not return either of these fields.
