### PR TITLE
Support namespace to get 'crs' and 'dimension' attributes in Bounding…

### DIFF
--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -219,14 +219,14 @@ class BoundingBox(object):
         self.maxx = None
         self.maxy = None
 
-        val = elem.attrib.get('crs')
+        val = elem.attrib.get('crs') or elem.attrib.get('{%s}crs' % namespace)
         try:
             self.crs = crs.Crs(val)
         except (AttributeError, ValueError):
             LOGGER.warning('Invalid CRS %r. Expected integer')
             self.crs = None
 
-        val = elem.attrib.get('dimensions')
+        val = elem.attrib.get('dimensions') or elem.attrib.get('{%s}dimensions' % namespace)
         if val is not None:
             self.dimensions = int(util.testXMLValue(val, True))
         else:  # assume 2


### PR DESCRIPTION
In a wps requests, if attributes 'crs' and 'dimension' are given with namespace in the input boundingBox description, these attributes are not taken into account.
With the proposed fix, 'crs' and 'dimension' attributes are read in both cases (with and without namespace).