### PR TITLE
Fix #333: add overwrite option to build_get_url

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -479,21 +479,42 @@ def getNamespace(element):
     else:
         return ""
 
-def build_get_url(base_url, params):
-    ''' Utility function to build a full HTTP GET URL from the service base URL and a dictionary of HTTP parameters. '''
 
-    qs = []
+def build_get_url(base_url, params, overwrite=False):
+    ''' Utility function to build a full HTTP GET URL from the service base URL and a dictionary of HTTP parameters.
+
+    TODO: handle parameters case-insensitive?
+
+    @param overwrite: boolean flag to allow overwrite of parameters of the base_url (default: False)
+    '''
+
+    qs_base = []
     if base_url.find('?') != -1:
-        qs = cgi.parse_qsl(base_url.split('?')[1])
+        qs_base = cgi.parse_qsl(base_url.split('?')[1])
+
+    qs_params = []
+    for key, value in six.iteritems(params):
+        qs_params.append((key, value))
+
+    qs = qs_add = []
+    if overwrite is True:
+        # all params and additional base
+        qs = qs_params
+        qs_add = qs_base
+    else:
+        # all base and additional params
+        qs = qs_base
+        qs_add = qs_params
 
     pars = [x[0] for x in qs]
 
-    for key,value in six.iteritems(params):
+    for key, value in qs_add:
         if key not in pars:
-            qs.append( (key,value) )
+            qs.append((key, value))
 
     urlqs = urlencode(tuple(qs))
     return base_url.split('?')[0] + '?' + urlqs
+
 
 def dump(obj, prefix=''):
     '''Utility function to print to standard output a generic object with all its attributes.'''

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,9 @@
 import pytest
 
-from owslib.util import clean_ows_url
+from owslib.util import clean_ows_url, build_get_url
 
 
-def test_util():
+def test_clean_ows_url():
     assert clean_ows_url('http//example.org/wms') == 'http//example.org/wms'
     assert clean_ows_url('http//example.org/wms?service=WMS') == 'http//example.org/wms'
     assert clean_ows_url('http//example.org/wms?SERVICE=WMS') == 'http//example.org/wms'
@@ -16,3 +16,24 @@ def test_util():
 def test_util_py34():
     assert clean_ows_url('http://example.org/wms?map=/path/to/foo.map&SERVICE=WMS&version=1.3.0&request=GetCapabilities') == 'http://example.org/wms?map=%2Fpath%2Fto%2Ffoo.map'  # noqa
     assert clean_ows_url('http://example.org/wms?map=/path/to/foo.map&foo=bar&&SERVICE=WMS&version=1.3.0&request=GetCapabilities') == 'http://example.org/wms?map=%2Fpath%2Fto%2Ffoo.map&foo=bar'  # noqa
+
+
+def test_build_get_url():
+    assert build_get_url("http://example.org/wps", {'service': 'WPS'}) == 'http://example.org/wps?service=WPS'
+    assert build_get_url("http://example.org/wms", {'SERVICE': 'wms'}) == 'http://example.org/wms?SERVICE=wms'
+    assert build_get_url("http://example.org/wps?service=WPS", {'request': 'GetCapabilities'}) == \
+        'http://example.org/wps?service=WPS&request=GetCapabilities'
+    assert build_get_url("http://example.org/wps?service=WPS", {'request': 'GetCapabilities'}) == \
+        'http://example.org/wps?service=WPS&request=GetCapabilities'
+    # Can not overwrite parameter
+    assert build_get_url("http://example.org/ows?SERVICE=WPS", {'SERVICE': 'WMS'}) == \
+        'http://example.org/ows?SERVICE=WPS'
+    # Parameter is case-senstive
+    assert build_get_url("http://example.org/ows?SERVICE=WPS", {'service': 'WMS'}) == \
+        'http://example.org/ows?SERVICE=WPS&service=WMS'
+
+
+def test_build_get_url_overwrite():
+    # Use overwrite flag
+    assert build_get_url("http://example.org/ows?SERVICE=WPS", {'SERVICE': 'WMS'}, overwrite=True) == \
+        'http://example.org/ows?SERVICE=WMS'


### PR DESCRIPTION
This PR fixes #333. 

Changes:
* adds on overwrite flag to `util.build_get_url` to allow overwrite of `base_url` parameters
* adds a test for `build_get_url`