### PR TITLE
fix #453: replace ServiceMetadata in wmts and tms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - if [ "$LXML" == "true" ]; then pip install lxml; fi
 script:
   - python -m pytest
-  #- flake8 owslib/wmts.py
+  - flake8 owslib/wmts.py
   - flake8 owslib/wps.py
 after_success:
   - coveralls

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -65,11 +65,13 @@ class TileMapService(object):
 
 
     def _getcapproperty(self):
+        # TODO: deprecated function. See ticket #453.
         if not self._capabilities:
             reader = TMSCapabilitiesReader(
                 self.version, url=self.url, un=self.username, pw=self.password
                 )
-            self._capabilities = ServiceMetadata(reader.read(self.url))
+            # self._capabilities = ServiceMetadata(reader.read(self.url))
+            self._capabilities = reader.read(self.url, timeout=self.timeout)
         return self._capabilities
 
 

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -187,12 +187,14 @@ class WebMapTileService(object):
         self._buildMetadata(parse_remote_metadata)
 
     def _getcapproperty(self):
+        # TODO: deprecated function. See ticket #453.
         if not self._capabilities:
             reader = WMTSCapabilitiesReader(
                 self.version, url=self.url, un=self.username, pw=self.password
             )
-            xml = reader.read(self.url, self.vendor_kwargs)
-            self._capabilities = ServiceMetadata(xml)
+            # xml = reader.read(self.url, self.vendor_kwargs)
+            # self._capabilities = ServiceMetadata(xml)
+            self._capabilities = reader.read(self.url, self.vendor_kwargs)
         return self._capabilities
 
     def _buildMetadata(self, parse_remote_metadata=False):


### PR DESCRIPTION
This PR fixes #453.

Changes:
* replace `ServiceMetadata` in `wmts` and `tms`
* mark function `_getcapproperty` as deprecated
* enable pep8 checks for `wmts` again