### PR TITLE
Fix #459: add __str__ to wps.Process

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1419,6 +1419,7 @@ class Process(object):
         self.processVersion = elem.get(nspath('processVersion', ns=wpsns))
         self.statusSupported = bool(elem.get("statusSupported"))
         self.storeSupported = bool(elem.get("storeSupported"))
+        self.identifier = None
         self.abstract = None
         self.metadata = []
 
@@ -1476,6 +1477,12 @@ class Process(object):
             self.processOutputs.append(Output(outputElement))
             if self.verbose is True:
                 dump(self.processOutputs[-1], prefix='\tOutput: ')
+
+    def __repr__(self):
+        return self.identifier or 'undefined'
+
+    def __str__(self):
+        return self.__repr__()
 
 
 class BoundingBoxDataInput(object):

--- a/tests/test_wps.py
+++ b/tests/test_wps.py
@@ -1,7 +1,9 @@
 import pytest
 
+
 from tests.utils import resource_file
-from owslib.wps import WebProcessingService, WPSExecution
+from owslib.wps import WebProcessingService, WPSExecution, Process
+from owslib.etree import etree
 
 
 @pytest.fixture
@@ -29,3 +31,15 @@ def test_wps_checkStatus():
     execution.checkStatus(response=xml)
     assert execution.isSucceded()
     assert execution.creationTime == '2011-11-08T21:36:55Z'
+
+
+def test_wps_process_representation(wps):
+    p = wps.processes[0]
+    assert repr(p) == 'CDMSSubsetVariable'
+    assert str(p) == 'CDMSSubsetVariable'
+
+
+def test_wps_process_with_invalid_identifer():
+    p = Process(etree.Element('invalid'))
+    assert repr(p) == 'undefined'
+    assert str(p) == 'undefined'


### PR DESCRIPTION
This PR fixes #459. 

Use identifier for `wps.Process` representation with using `print(myprocess)`.

Changes:
* added `__str__` and `__repr__` method to `wps.Process`.
* initialize `wps.Process.identifier` with `None`.
* added tests for `wps.Process` representation methods `str(p)` and `repr(p)`.