### PR TITLE
Fix #455: using wps execution mode

### DIFF
--- a/tests/test_wps_request7.py
+++ b/tests/test_wps_request7.py
@@ -4,6 +4,7 @@
 
 from tests.utils import resource_file, compare_xml
 from owslib.wps import WebProcessingService, WPSExecution, ComplexDataInput
+from owslib.wps import SYNC
 from owslib.etree import etree
 
 
@@ -16,7 +17,7 @@ def test_wps_request7():
 
     # Build XML request for WPS process execution, sync request
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=outputs, async=False, lineage=False)
+    requestElement = execution.buildRequest(processid, inputs, output=outputs, mode=SYNC, lineage=False)
     request = etree.tostring(requestElement)
 
     # Compare to cached XML request

--- a/tests/test_wps_request8.py
+++ b/tests/test_wps_request8.py
@@ -4,6 +4,7 @@
 
 from tests.utils import resource_file, compare_xml
 from owslib.wps import WebProcessingService, WPSExecution, ComplexDataInput
+from owslib.wps import ASYNC
 from owslib.etree import etree
 
 
@@ -16,7 +17,7 @@ def test_wps_request8():
 
     # Build XML request for WPS process execution
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=outputs, async=True, lineage=True)
+    requestElement = execution.buildRequest(processid, inputs, output=outputs, mode=ASYNC, lineage=True)
     request = etree.tostring(requestElement)
 
     # Compare to cached XML request


### PR DESCRIPTION
This PR fixes #455.

Replace `async` option by `mode` in wps `execute`.

Changes:
* removed `async` option in wps `execute`.
* added `mode` option to wps `execute` method with values `SYNC`, `ASYNC`, `AUTO`.
* updated wps tests with execution mode.