### PR TITLE
parse data-input in wps lineage response (#468)

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -927,13 +927,19 @@ class WPSExecution():
         # <wps:DataInputs xmlns:wps="http://www.opengis.net/wps/1.0.0"
         # xmlns:ows="http://www.opengis.net/ows/1.1"
         # xmlns:xlink="http://www.w3.org/1999/xlink">
+        if len(self.dataInputs) > 0:
+            log.debug('clean data inputs')
+            self.dataInputs[:] = []
         for inputElement in root.findall(nspath('DataInputs/Input', ns=wpsns)):
-            self.dataInputs.append(Input(inputElement))
+            self.dataInputs.append(Output(inputElement))
             if self.verbose is True:
                 dump(self.dataInputs[-1])
 
         # <ns:ProcessOutputs>
         # xmlns:ns="http://www.opengis.net/wps/1.0.0"
+        if len(self.processOutputs) > 0:
+            log.debug('clean process outputs')
+            self.processOutputs[:] = []
         for outputElement in root.findall(nspath('ProcessOutputs/Output', ns=wpsns)):
             self.processOutputs.append(Output(outputElement))
             if self.verbose is True:

--- a/tests/resources/wps_HummingbirdExecuteResponse1.xml
+++ b/tests/resources/wps_HummingbirdExecuteResponse1.xml
@@ -1,0 +1,52 @@
+<wps:ExecuteResponse xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsExecute_response.xsd" service="WPS" version="1.0.0" xml:lang="en-US" serviceInstance="http://localhost:8092/wps?service=WPS&amp;request=GetCapabilities" statusLocation="http://localhost:8090/wpsoutputs/hummingbird/731f5bdc-52b7-11e8-a0a9-109836a7cf3a.xml">
+  <wps:Process wps:processVersion="0.3.0">
+    <ows:Identifier>spotchecker</ows:Identifier>
+    <ows:Title>Spot Checker</ows:Title>
+    <ows:Abstract>Checks a single uploaded or remote dataset against a variety of compliance standards. The dataset is either in the NetCDF format or a remote OpenDAP resource. Available compliance standards are the Climate and Forecast conventions (CF) and project specific rules for CMIP6 and CORDEX.</ows:Abstract>
+  </wps:Process>
+  <wps:Status creationTime="2018-05-08T14:00:54Z">
+    <wps:ProcessSucceeded>PyWPS Process Spot Checker finished</wps:ProcessSucceeded>
+  </wps:Status>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>test</ows:Identifier>
+      <ows:Title>Select the test you want to run.</ows:Title>
+      <ows:Abstract>CF-1.6=Climate and Forecast Conventions (CF)</ows:Abstract>
+      <wps:Data>
+        <wps:LiteralData dataType="string">CF-1.6</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>dataset</ows:Identifier>
+      <ows:Title>Upload your NetCDF file here</ows:Title>
+      <ows:Abstract>or enter a URL pointing to a NetCDF file.</ows:Abstract>
+      <wps:Reference xlink:href="https://www.esrl.noaa.gov/psd/thredds/fileServer/Datasets/ncep.reanalysis.dailyavgs/surface/air.sig995.1952.nc" mimeType="application/x-netcdf" method="GET"/>
+    </wps:Input>
+  </wps:DataInputs>
+  <wps:OutputDefinitions>
+    <wps:Output>
+      <ows:Identifier>output</ows:Identifier>
+      <ows:Title>Test Report</ows:Title>
+      <ows:Abstract>Compliance checker test report.</ows:Abstract>
+    </wps:Output>
+    <wps:Output>
+      <ows:Identifier>ncdump</ows:Identifier>
+      <ows:Title>ncdump of metadata</ows:Title>
+      <ows:Abstract>ncdump of header of checked dataset.</ows:Abstract>
+    </wps:Output>
+  </wps:OutputDefinitions>
+  <wps:ProcessOutputs>
+    <wps:Output>
+      <ows:Identifier>output</ows:Identifier>
+      <ows:Title>Test Report</ows:Title>
+      <ows:Abstract>Compliance checker test report.</ows:Abstract>
+      <wps:Reference xlink:href="http://localhost:8090/wpsoutputs/hummingbird/731f5bdc-52b7-11e8-a0a9-109836a7cf3a/report_oSlKto.html" mimeType="text/plain"/>
+    </wps:Output>
+    <wps:Output>
+      <ows:Identifier>ncdump</ows:Identifier>
+      <ows:Title>ncdump of metadata</ows:Title>
+      <ows:Abstract>ncdump of header of checked dataset.</ows:Abstract>
+      <wps:Reference xlink:href="http://localhost:8090/wpsoutputs/hummingbird/731f5bdc-52b7-11e8-a0a9-109836a7cf3a/nc_dump_xBwpmm.txt" mimeType="text/plain"/>
+    </wps:Output>
+  </wps:ProcessOutputs>
+</wps:ExecuteResponse>

--- a/tests/test_wps.py
+++ b/tests/test_wps.py
@@ -43,3 +43,29 @@ def test_wps_process_with_invalid_identifer():
     p = Process(etree.Element('invalid'))
     assert repr(p) == 'undefined'
     assert str(p) == 'undefined'
+
+
+def test_wps_response_with_lineage():
+    execution = WPSExecution()
+    xml = open(resource_file('wps_HummingbirdExecuteResponse1.xml'), 'rb').read()
+    execution.checkStatus(response=xml)
+    assert execution.isSucceded()
+    assert execution.creationTime == '2018-05-08T14:00:54Z'
+    # check lineage input with literal data
+    inp = execution.dataInputs[0]
+    assert inp.identifier == 'test'
+    assert inp.title == 'Select the test you want to run.'
+    assert inp.abstract == 'CF-1.6=Climate and Forecast Conventions (CF)'
+    assert inp.data[0] == 'CF-1.6'
+    # check lineage input with reference
+    inp = execution.dataInputs[1]
+    assert inp.identifier == 'dataset'
+    assert inp.title == 'Upload your NetCDF file here'
+    assert inp.abstract == 'or enter a URL pointing to a NetCDF file.'
+    assert inp.reference.startswith('https://www.esrl.noaa.gov/')
+    # check output with reference
+    outp = execution.processOutputs[0]
+    assert outp.identifier == 'output'
+    assert outp.title == 'Test Report'
+    assert outp.abstract == 'Compliance checker test report.'
+    assert outp.reference.startswith('http://localhost:8090/wpsoutputs')


### PR DESCRIPTION
This PR fixes #468:

Changes:
* adds a workaround to  `wps` to parse data-inputs in lineage response.
* it uses the `Output` element to parse `data` and `reference` of data-input in lineage 
* adds a test for wps response with lineage