### PR TITLE
Fix util.strip_bom (#408)

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -579,22 +579,25 @@ def strip_bom(raw_text):
     """ return the raw (assumed) xml response without the BOM
     """
     boms = [
+        # utf-8
+        codecs.BOM_UTF8,
+        # utf-16
         codecs.BOM,
         codecs.BOM_BE,
         codecs.BOM_LE,
-        codecs.BOM_UTF8,
         codecs.BOM_UTF16,
         codecs.BOM_UTF16_LE,
         codecs.BOM_UTF16_BE,
+        # utf-32
         codecs.BOM_UTF32,
         codecs.BOM_UTF32_LE,
         codecs.BOM_UTF32_BE
     ]
 
-    if not isinstance(raw_text, str):
+    if isinstance(raw_text, six.binary_type):
         for bom in boms:
             if raw_text.startswith(bom):
-                return raw_text.replace(bom, '')
+                return raw_text[len(bom):]
     return raw_text
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,15 @@
 import pytest
 
-from owslib.util import clean_ows_url, build_get_url
+import codecs
+from owslib.util import clean_ows_url, build_get_url, strip_bom
+
+
+def test_strip_bom():
+    assert strip_bom('<city>Hamburg</city>') == '<city>Hamburg</city>'
+    assert strip_bom(codecs.BOM_UTF8 + '<city>Dublin</city>'.encode('utf-8')) == \
+        '<city>Dublin</city>'.encode('utf-8')
+    assert strip_bom(codecs.BOM_UTF16 + '<city>Vancover</city>'.encode('utf-16')) == \
+        '<city>Vancover</city>'.encode('utf-16')
 
 
 def test_clean_ows_url():


### PR DESCRIPTION
This PR fixes #408.

Changes:
* fix `util.strip_bom` for Python 2/3 and UTF-8, UTF-16
* added a test for `util.strip_bom`