### PR TITLE
Fix #248: sos encoding error

### DIFF
--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+import six
 import cgi
 from owslib.etree import etree
 from datetime import datetime
@@ -10,7 +11,7 @@ except ImportError:     # Python 2
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities
-from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
+from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time, encode_string
 from owslib.namespaces import Namespaces
 
 def get_namespaces():
@@ -221,6 +222,7 @@ class SensorObservationService_1_0_0(object):
                 return item
         raise KeyError("No Operation named %s" % name)
 
+
 class SosObservationOffering(object):
     def __init__(self, element):
         self._root = element
@@ -278,10 +280,11 @@ class SosObservationOffering(object):
             self.response_modes.append(testXMLValue(rm))
 
     def __str__(self):
-        return 'Offering id: %s, name: %s' % (self.id, self.name)
+        return 'Offering id: {}, name: {}'.format(encode_string(self.id), encode_string(self.name))
 
     def __repr__(self):
-        return "<SosObservationOffering '%s'>" % self.name
+        return "<SosObservationOffering '{}'>".format(encode_string(self.name))
+
 
 class SosCapabilitiesReader(object):
     def __init__(self, version="1.0.0", url=None, username=None, password=None):

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -719,3 +719,19 @@ def datetime_from_ansi(ansi):
 
 def is_vector_grid(grid_elem):
     pass
+
+
+def encode_string(text):
+    """
+    On Python 3 this method does nothing and returns the ``text`` string itself.
+    On Python 2 this method returns the ``text`` string encoded with UTF-8.
+
+    See:
+    * https://pythonhosted.org/six/#six.python_2_unicode_compatible
+    * https://www.azavea.com/blog/2014/03/24/solving-unicode-problems-in-python-2-7/
+    """
+    if six.PY3:
+        return text
+    if isinstance(text, str):
+        return text.decode('utf-8').encode('utf-8', 'ignore')
+    return text.encode('utf-8', 'ignore')

--- a/tests/test_sos.py
+++ b/tests/test_sos.py
@@ -1,0 +1,17 @@
+# -*- coding: UTF-8 -*-
+from owslib.sos import SensorObservationService
+
+from tests.utils import service_ok
+
+import pytest
+
+SERVICE_URL = 'http://sos.irceline.be/sos'
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason="SOS service is unreachable")
+def test_sos_caps():
+    sos = SensorObservationService(SERVICE_URL)
+    assert str(sos.contents['81102 - PM10']) == "Offering id: 81102 - PM10, name: Particulate Matter < 10 µm"
+    assert repr(sos.contents['81102 - PM10']) == "<SosObservationOffering 'Particulate Matter < 10 µm'>"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,14 @@
+# -*- coding: UTF-8 -*-
 import pytest
 
 import codecs
-from owslib.util import clean_ows_url, build_get_url, strip_bom
+from owslib.util import clean_ows_url, build_get_url, strip_bom, encode_string
+
+
+def test_encode_string():
+    assert encode_string('hello') == 'hello'
+    assert encode_string('Particulate Matter < 10 µm') == 'Particulate Matter < 10 µm'
+    assert encode_string(u'Particulate Matter < 10 µm') == 'Particulate Matter < 10 µm'
 
 
 def test_strip_bom():


### PR DESCRIPTION
This PR fixes the encoding error reported in #248.

Changes:
* adds method `util.encode_string` to handle string encoding in Python 3 and Python 2.7
* using `util.encode_string` in `sos100` module  for `__str__` and `__repr__` text
* added tests for `sos100` and `util.encode_string`

See also previous PR and discussion #372.