### PR TITLE
Updated wps.Process repr method (#459)

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1449,6 +1449,7 @@ class Process(object):
         self.statusSupported = bool(elem.get("statusSupported"))
         self.storeSupported = bool(elem.get("storeSupported"))
         self.identifier = None
+        self.title = None
         self.abstract = None
         self.metadata = []
 
@@ -1507,11 +1508,11 @@ class Process(object):
             if self.verbose is True:
                 dump(self.processOutputs[-1], prefix='\tOutput: ')
 
-    def __repr__(self):
-        return self.identifier or 'undefined'
-
     def __str__(self):
-        return self.__repr__()
+        return "WPS Process: {}, title={}".format(self.identifier or '', self.title or '')
+
+    def __repr__(self):
+        return "<owslib.wps.Process {}>".format(self.identifier or '')
 
 
 class BoundingBoxDataInput(object):

--- a/tests/test_wps.py
+++ b/tests/test_wps.py
@@ -35,14 +35,14 @@ def test_wps_checkStatus():
 
 def test_wps_process_representation(wps):
     p = wps.processes[0]
-    assert repr(p) == 'CDMSSubsetVariable'
-    assert str(p) == 'CDMSSubsetVariable'
+    assert repr(p) == '<owslib.wps.Process CDMSSubsetVariable>'
+    assert str(p) == 'WPS Process: CDMSSubsetVariable, title=Writes a text file and returns an output.'
 
 
 def test_wps_process_with_invalid_identifer():
     p = Process(etree.Element('invalid'))
-    assert repr(p) == 'undefined'
-    assert str(p) == 'undefined'
+    assert repr(p) == '<owslib.wps.Process >'
+    assert str(p) == 'WPS Process: , title='
 
 
 def test_wps_response_with_lineage():


### PR DESCRIPTION
This PR is an update to issue #459.

Changes:
* The `__repr__` is now: `<owslib.wps.Process identifier>`
* The `__str__` is now: `WPS Process: identifier, title=Title>`