### PR TITLE
skip test_wcs_200 (#494)

### DIFF
--- a/tests/test_wcs_200.py
+++ b/tests/test_wcs_200.py
@@ -10,6 +10,7 @@ SERVICE_URL = 'http://earthserver.pml.ac.uk/rasdaman/ows'
 
 
 @pytest.mark.online
+@pytest.mark.skip(reason="WCS service is broken (#494)")
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WCS service is unreachable")
 def test_wcs_200():


### PR DESCRIPTION
This PR disables `test_wcs_200` as a workaround for #494.