### PR TITLE
Various fixes for ISO

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -459,6 +459,7 @@ class MD_DataIdentification(object):
 
             val = md.find(util.nspath_eval('gmd:abstract/gmx:Anchor', namespaces))
 
+            self.abstract_url = None
             if val is not None:
                 self.abstract = util.testXMLValue(val)
                 self.abstract_url = val.attrib.get(util.nspath_eval('xlink:href', namespaces))

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -500,7 +500,7 @@ class MD_DataIdentification(object):
                 mdkw['thesaurus']['date'] = util.testXMLValue(val)
 
                 val = i.find(util.nspath_eval('gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode', namespaces))
-                mdkw['thesaurus']['datetype'] = util.testXMLValue(val)
+                mdkw['thesaurus']['datetype'] = util.testXMLAttribute(val, 'codeListValue')
 
                 mdkw['keywords'] = []
 

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -405,7 +405,7 @@ class MD_DataIdentification(object):
 
             self.securityconstraints = []
             for i in md.findall(util.nspath_eval('gmd:resourceConstraints/gmd:MD_SecurityConstraints/gmd:classification/gmd:MD_ClassificationCode', namespaces)):
-                val = util.testXMLValue(i)
+                val = _testCodeListValue(i)
                 if val is not None:
                     self.securityconstraints.append(val)
 

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -319,6 +319,7 @@ class MD_DataIdentification(object):
             self.distance = []
             self.uom = []
             self.resourcelanguage = []
+            self.resourcelanguagecode = []
             self.creator = []
             self.publisher = []
             self.contributor = []
@@ -430,9 +431,15 @@ class MD_DataIdentification(object):
                     self.distance.append(val)
                 self.uom.append(i.get("uom"))
 
-            self.resourcelanguage = []
+            self.resourcelanguagecode = []
             for i in md.findall(util.nspath_eval('gmd:language/gmd:LanguageCode', namespaces)):
                 val = _testCodeListValue(i)
+                if val is not None:
+                    self.resourcelanguagecode.append(val)
+
+            self.resourcelanguage = []
+            for i in md.findall(util.nspath_eval('gmd:language/gco:CharacterString', namespaces)):
+                val = util.testXMLValue(i)
                 if val is not None:
                     self.resourcelanguage.append(val)
 

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -349,7 +349,8 @@ class MD_DataIdentification(object):
             self.aggregationinfo = util.testXMLValue(val)
 
             self.uricode = []
-            for i in md.findall(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString', namespaces)):
+            for i in md.findall(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:RS_Identifier/gmd:code/gco:CharacterString', namespaces)) + \
+                     md.findall(util.nspath_eval('gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString', namespaces)):
                 val = util.testXMLValue(i)
                 if val is not None:
                     self.uricode.append(val)

--- a/tests/test_iso_parsing.py
+++ b/tests/test_iso_parsing.py
@@ -364,7 +364,8 @@ def test_md_parsing_geobretagne():
     assert iden.date[0].date == '2018-09-01'
     assert iden.date[0].type == 'revision'
 
-    assert_list(iden.uricode, 0)
+    assert_list(iden.uricode, 1)
+    assert iden.uricode[0] == 'https://geobretagne.fr/geonetwork/apps/georchestra/?uuid=363e3a8e-d0ce-497d-87a9-2a2d58d82772'
     assert_list(iden.uricodespace, 0)
 
     assert_list(iden.uselimitation, 2)

--- a/tests/test_iso_parsing.py
+++ b/tests/test_iso_parsing.py
@@ -202,7 +202,7 @@ def test_md_parsing_dov():
     assert iden.keywords[0]['type'] == ''
     assert iden.keywords[0]['thesaurus']['title'] == "GEMET - INSPIRE thema's, versie 1.0"
     assert iden.keywords[0]['thesaurus']['date'] == '2008-06-01'
-    assert iden.keywords[0]['thesaurus']['datetype'] is None
+    assert iden.keywords[0]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[0]['keywords'], 1)
     assert iden.keywords[0]['keywords'] == ['Geologie']
 
@@ -211,7 +211,7 @@ def test_md_parsing_dov():
     assert iden.keywords[1]['thesaurus'][
                'title'] == "GEMET - Concepten, versie 2.4"
     assert iden.keywords[1]['thesaurus']['date'] == '2010-01-13'
-    assert iden.keywords[1]['thesaurus']['datetype'] is None
+    assert iden.keywords[1]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[1]['keywords'], 2)
     assert iden.keywords[1]['keywords'] == ['grondwater', 'meetnet(werk)']
 
@@ -220,7 +220,7 @@ def test_md_parsing_dov():
     assert iden.keywords[2]['thesaurus'][
                'title'] == "Vlaamse regio's"
     assert iden.keywords[2]['thesaurus']['date'] == '2013-09-25'
-    assert iden.keywords[2]['thesaurus']['datetype'] is None
+    assert iden.keywords[2]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[2]['keywords'], 1)
     assert iden.keywords[2]['keywords'] == ['Vlaams Gewest']
 
@@ -229,7 +229,7 @@ def test_md_parsing_dov():
     assert iden.keywords[3]['thesaurus'][
                'title'] == "GDI-Vlaanderen Trefwoorden"
     assert iden.keywords[3]['thesaurus']['date'] == '2014-02-26'
-    assert iden.keywords[3]['thesaurus']['datetype'] is None
+    assert iden.keywords[3]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[3]['keywords'], 7)
     assert iden.keywords[3]['keywords'] == [
         'Toegevoegd GDI-Vl', 'Herbruikbaar', 'Vlaamse Open data',
@@ -240,7 +240,7 @@ def test_md_parsing_dov():
     assert iden.keywords[4]['type'] is None
     assert iden.keywords[4]['thesaurus']['title'] == "DOV"
     assert iden.keywords[4]['thesaurus']['date'] == '2010-12-01'
-    assert iden.keywords[4]['thesaurus']['datetype'] is None
+    assert iden.keywords[4]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[4]['keywords'], 7)
     assert iden.keywords[4]['keywords'] == [
         'Ondergrond', 'DOV', 'Vlaanderen', 'monitoring', 'meetnetten',
@@ -469,7 +469,7 @@ def test_md_parsing_geobretagne():
     assert iden.keywords[4]['type'] == 'theme'
     assert iden.keywords[4]['thesaurus']['title'] == u"GéoBretagne v 2.0"
     assert iden.keywords[4]['thesaurus']['date'] == '2014-01-13'
-    assert iden.keywords[4]['thesaurus']['datetype'] is None
+    assert iden.keywords[4]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[4]['keywords'], 1)
     assert iden.keywords[4]['keywords'] == [u'référentiels : cadastre']
 
@@ -477,7 +477,7 @@ def test_md_parsing_geobretagne():
     assert iden.keywords[5]['type'] == 'theme'
     assert iden.keywords[5]['thesaurus']['title'] == "INSPIRE themes"
     assert iden.keywords[5]['thesaurus']['date'] == '2008-06-01'
-    assert iden.keywords[5]['thesaurus']['datetype'] is None
+    assert iden.keywords[5]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[5]['keywords'], 1)
     assert iden.keywords[5]['keywords'] == ['Parcelles cadastrales']
 
@@ -485,7 +485,7 @@ def test_md_parsing_geobretagne():
     assert iden.keywords[6]['type'] == 'theme'
     assert iden.keywords[6]['thesaurus']['title'] == "GEMET"
     assert iden.keywords[6]['thesaurus']['date'] == '2012-07-20'
-    assert iden.keywords[6]['thesaurus']['datetype'] is None
+    assert iden.keywords[6]['thesaurus']['datetype'] == 'publication'
     assert_list(iden.keywords[6]['keywords'], 2)
     assert iden.keywords[6]['keywords'] == ['cadastre', u'bâtiment']
 

--- a/tests/test_iso_parsing.py
+++ b/tests/test_iso_parsing.py
@@ -140,7 +140,8 @@ def test_md_parsing_dov():
                      "beschikbaar op " \
                      "https://www.dov.vlaanderen.be/page/gebruiksvoorwaarden-dov-services"
 
-    assert_list(iden.securityconstraints, 0)
+    assert_list(iden.securityconstraints, 1)
+    assert iden.securityconstraints[0] == 'unclassified'
 
     assert_list(iden.useconstraints, 0)
 

--- a/tests/test_iso_parsing.py
+++ b/tests/test_iso_parsing.py
@@ -151,8 +151,9 @@ def test_md_parsing_dov():
     assert_list(iden.distance, 0)
     assert_list(iden.uom, 0)
 
-    assert_list(iden.resourcelanguage, 1)
-    assert iden.resourcelanguage[0] == 'dut'
+    assert_list(iden.resourcelanguage, 0)
+    assert_list(iden.resourcelanguagecode, 1)
+    assert iden.resourcelanguagecode[0] == 'dut'
 
     assert_list(iden.creator, 0)
     assert_list(iden.publisher, 0)
@@ -395,7 +396,9 @@ def test_md_parsing_geobretagne():
     assert_list(iden.distance, 0)
     assert_list(iden.uom, 0)
 
-    assert_list(iden.resourcelanguage, 0)
+    assert_list(iden.resourcelanguage, 1)
+    assert iden.resourcelanguage[0] == 'fre'
+    assert_list(iden.resourcelanguagecode, 0)
 
     assert_list(iden.creator, 0)
     assert_list(iden.publisher, 0)


### PR DESCRIPTION
While fixing issue #491 and writing the ISO parsing tests I discovered some issues in the ISO parsing. In this PR I fix:

* CI_DateTypeCode in thesaurusName should be a codeListValue (this wrong in keywords, while being correct in keywords2).
* MD_ClassificationCode in securityconstraints should be a codeListValue.
* Add support for MD_Identifiers in uricode.
* Initialize the abstract_url variable.
* Add support for language strings in MD_DataIdentification, aligning with MD_Metadata.

Closes #506 