### PR TITLE
ship license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
+include LICENSE
 include *.rst
 recursive-include owslib


### PR DESCRIPTION
The license was renamed but the change was not updated here. The latest source distribution does not ship the license.