### PR TITLE
Add LICENSE to be part of release archives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include *.txt
 include *.rst
 recursive-include owslib


### PR DESCRIPTION
Since the name dropped its txt extension, it was no longer included.