### PR TITLE
add support for WFS 3 (#521)

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -46,7 +46,7 @@ Standards Support
 +-------------------+---------------------+
 | `OGC CSW`_        | 2.0.2               |
 +-------------------+---------------------+
-| `OGC WPS`_        | 1.0.0               |
+| `OGC WPS`_        | 1.0.0, 1.1.0, 2.0, 3.0 |
 +-------------------+---------------------+
 | `OGC Filter`_     | 1.1.0               |
 +-------------------+---------------------+
@@ -285,6 +285,35 @@ services)
 
     >>> response = wfs20.getfeature(storedQueryID='urn:ogc:def:query:OGC-WFS::GetFeatureById', storedQueryParams={'ID':'gmd_ex.1'})
 
+WFS 3.0
+-------
+
+WFS 3.0 is a clean break from the traditional OGC service architecture
+(RESTful, JSON, OpenAPI) and as such OWSLib the code follows the same pattern.
+
+.. code-block:: python
+
+  >>> from owslib.wfs import WebFeatureService
+  >>> w = WebFeatureService('https://geo.kralidis.ca/pygeoapi, version='3.0')
+  >>> w.url
+  'http://geo.kralidis.ca/pygeoapi/'
+  >>> w.version
+  '3.0'
+  >>> conformance = w.conformance()
+  {u'conformsTo': [u'http://www.opengis.net/spec/wfs-1/3.0/req/core', u'http://www.opengis.net/spec/wfs-1/3.0/req/oas30', u'http://www.opengis.net/spec/wfs-1/3.0/req/html', u'http://www.opengis.net/spec/wfs-1/3.0/req/geojson']}
+  >>> collections = w.collections()
+  >>> len(collections)
+  3
+  >>> lakes = w.collection('lakes')
+  >>> lakes['name']
+  'lakes'
+  >>> lakes['title']
+  'Large Lakes'
+  >>> lakes['description']
+  'lakes of the world, public domain'
+  >>> lakes_query = w.collection_items('lakes')
+  >>> lakes_query['features'][0]['properties']
+  {u'scalerank': 0, u'name_alt': None, u'admin': None, u'featureclass': u'Lake', u'id': 0, u'name': u'Lake Baikal'}
 
 WCS
 ---

--- a/owslib/feature/wfs300.py
+++ b/owslib/feature/wfs300.py
@@ -1,0 +1,166 @@
+# =============================================================================
+# Copyright (c) 2018 Tom Kralidis
+#
+# Authors : Tom Kralidis <tomkralidis@gmail.com>
+#
+# Contact email: tomkralidis@gmail.com
+# =============================================================================
+
+import json
+import logging
+
+from six.moves.urllib.parse import urljoin
+import requests
+
+from owslib import __version__
+
+LOGGER = logging.getLogger(__name__)
+
+REQUEST_HEADERS = {
+    'User-Agent': 'OWSLib {} (https://geopython.github.io/OWSLib)'.format(
+        __version__)
+}
+
+
+class WebFeatureService_3_0_0(object):
+    """Abstraction for OGC Web Feature Service (WFS) version 3.0"""
+    def __init__(self, url, version, json_, timeout=30, username=None,
+                 password=None):
+        """
+        initializer; implements Requirement 1 (/req/core/root-op)
+
+        @type url: string
+        @param url: url of WFS root document
+        @type json_: string
+        @param json_: json object
+        @param timeout: time (in seconds) after which requests should timeout
+        @param username: service authentication username
+        @param password: service authentication password
+
+        @return: initialized WebFeatureService_3_0_0 object
+        """
+
+        if '?' in url:
+            self.url, self.url_query_string = url.split('?')
+        else:
+            self.url = url.rstrip('/') + '/'
+            self.url_query_string = None
+
+        self.version = version
+        self.json_ = json_
+        self.timeout = timeout
+        self.username = username
+        self.password = password
+
+        if json_ is not None:  # static JSON string
+            self.links = json.loads(json_)['links']
+        else:
+            response = requests.get(url, headers=REQUEST_HEADERS).json()
+            self.links = response['links']
+
+    def conformance(self):
+        """
+        implements Requirement 5 (/req/core/conformance-op)
+
+        @returns: conformance object
+        """
+
+        url = self._build_url('conformance')
+        LOGGER.debug('Request: {}'.format(url))
+        response = requests.get(url, headers=REQUEST_HEADERS).json()
+        return response
+
+    def collections(self):
+        """
+        implements Requirement 9 (/req/core/collections-op)
+
+        @returns: collections object
+        """
+
+        url = self._build_url('collections')
+        LOGGER.debug('Request: {}'.format(url))
+        response = requests.get(url, headers=REQUEST_HEADERS).json()
+        return response['collections']
+
+    def collection(self, collection_name):
+        """
+        implements Requirement 15 (/req/core/sfc-md-op)
+
+        @type collection_name: string
+        @param collection_name: name of collection
+
+        @returns: feature collection metadata
+        """
+
+        path = 'collections/{}'.format(collection_name)
+        url = self._build_url(path)
+        LOGGER.debug('Request: {}'.format(url))
+        response = requests.get(url, headers=REQUEST_HEADERS).json()
+        return response
+
+    def collection_items(self, collection_name, **kwargs):
+        """
+        implements Requirement 17 (/req/core/fc-op)
+
+        @type collection_name: string
+        @param collection_name: name of collection
+        @type bbox: list
+        @param bbox: list of minx,miny,maxx,maxy
+        @type time: string
+        @param time: time extent or time instant
+        @type limit: int
+        @param limit: limit number of features
+        @type startindex: int
+        @param startindex: start position of results
+
+        @returns: feature results
+        """
+
+        if 'bbox' in kwargs:
+            kwargs['bbox'] = ','.join(kwargs['bbox'])
+
+        path = 'collections/{}/items'.format(collection_name)
+        url = self._build_url(path)
+        LOGGER.debug('Request: {}'.format(url))
+        response = requests.get(url, headers=REQUEST_HEADERS,
+                                params=kwargs).json()
+        return response
+
+    def collection_item(self, collection_name, identifier):
+        """
+        implements Requirement 30 (/req/core/f-op)
+
+        @type collection_name: string
+        @param collection_name: name of collection
+        @type identifier: string
+        @param identifier: feature identifier
+
+        @returns: single feature result
+        """
+
+        path = 'collections/{}/items/{}'.format(collection_name, identifier)
+        url = self._build_url(path)
+        LOGGER.debug('Request: {}'.format(url))
+        response = requests.get(url, headers=REQUEST_HEADERS).json()
+        return response
+
+    def _build_url(self, path=None):
+        """
+        helper function to build a WFS 3.0 URL
+
+        @type path: string
+        @param path: path of WFS URL
+
+        @returns: fully constructed URL path
+        """
+
+        url = self.url
+        if self.url_query_string is not None:
+            LOGGER.debug('base URL has a query string')
+            url = urljoin(url, path)
+            url = '?'.join([url, self.url_query_string])
+        else:
+            url = urljoin(url, path)
+
+        LOGGER.debug('URL: {}'.format(url))
+        return url

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -15,12 +15,13 @@ Web Feature Server (WFS) methods and metadata. Factory function.
 
 from __future__ import (absolute_import, division, print_function)
 
-from .feature import wfs100, wfs110, wfs200
+from .feature import wfs100, wfs110, wfs200, wfs300
 from .util import clean_ows_url
 
 
-def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=False,
-                      timeout=30, username=None, password=None):
+def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
+                      parse_remote_metadata=False, timeout=30, username=None,
+                      password=None):
     ''' wfs factory function, returns a version specific WebFeatureService object
 
     @type url: string
@@ -32,7 +33,7 @@ def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=Fals
     @param timeout: time (in seconds) after which requests should timeout
     @param username: service authentication username
     @param password: service authentication password
-    @return: initialized WebFeatureService_2_0_0 object
+    @return: initialized WebFeatureService object (version dependent)
     '''
 
     clean_url = clean_ows_url(url)
@@ -49,6 +50,11 @@ def WebFeatureService(url, version='1.0.0', xml=None, parse_remote_metadata=Fals
                                               password=password)
     elif version in ['2.0', '2.0.0']:
         return wfs200.WebFeatureService_2_0_0(clean_url, version, xml, parse_remote_metadata,
+                                              timeout=timeout,
+                                              username=username,
+                                              password=password)
+    elif version in ['3.0', '3.0.0']:
+        return wfs300.WebFeatureService_3_0_0(clean_url, version, json_,
                                               timeout=timeout,
                                               username=username,
                                               password=password)

--- a/tests/test_wfs3_ldproxy.py
+++ b/tests/test_wfs3_ldproxy.py
@@ -1,0 +1,21 @@
+from tests.utils import service_ok
+
+import pytest
+
+from owslib.wfs import WebFeatureService
+
+SERVICE_URL = 'https://www.ldproxy.nrw.de/rest/services/kataster/?f=json'
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason='service is unreachable')
+def test_wfs3_ldproxy():
+    w = WebFeatureService(SERVICE_URL, version='3.0')
+
+    assert w.url == 'https://www.ldproxy.nrw.de/rest/services/kataster/'
+    assert w.version == '3.0'
+    assert w.url_query_string == 'f=json'
+
+    conformance = w.conformance()
+    assert len(conformance['conformsTo']) == 5

--- a/tests/test_wfs3_pygeoapi.py
+++ b/tests/test_wfs3_pygeoapi.py
@@ -1,0 +1,34 @@
+from tests.utils import service_ok
+
+import pytest
+
+from owslib.wfs import WebFeatureService
+
+SERVICE_URL = 'http://geo.kralidis.ca/pygeoapi'
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason='service is unreachable')
+def test_wfs3_pygeoapi():
+    w = WebFeatureService(SERVICE_URL, version='3.0')
+
+    assert w.url == 'http://geo.kralidis.ca/pygeoapi/'
+    assert w.version == '3.0'
+    assert w.url_query_string is None
+
+    conformance = w.conformance()
+    assert len(conformance['conformsTo']) == 4
+
+    collections = w.collections()
+    assert len(collections) == 3
+
+    lakes = w.collection('lakes')
+    assert lakes['name'] == 'lakes'
+    assert lakes['title'] == 'Large Lakes'
+    assert lakes['description'] == 'lakes of the world, public domain'
+
+    lakes_query = w.collection_items('lakes', limit=0)
+    assert lakes_query['numberMatched'] == 25
+    assert lakes_query['numberReturned'] == 0
+    assert len(lakes_query['features']) == 0


### PR DESCRIPTION
This PR adds support for the [OGC Web Feature Service 3.0: Part 1 - Core](https://cdn.rawgit.com/opengeospatial/WFS_FES/3.0.0-draft.1/docs/17-069.html#_feature_collections) draft.

WFS3 is a clean break from traditional OGC service architecture (towards RESTful, JSON) and the code follows the same pattern (the only exception being the factory/constructor).