### PR TITLE
added bumpversion (#517)

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -569,6 +569,20 @@ Or ...
     # additional pep8 tests
     pep8 owslib/wmts.py
 
+Bump a new version
+------------------
+
+Make a new version of OWSLib in the following steps:
+
+* Make sure everything is commited to GitHub.
+* Update ``CHANGES.rst`` with the next version.
+* Dry Run: ``bumpversion --dry-run --verbose --new-version 0.17.1 patch``
+* Do it: ``bumpversion --new-version 0.17.1 patch``
+* ... or: ``bumpversion --new-version 0.18.0 minor``
+* Push it: ``git push --tags``
+
+See the bumpversion_ documentation for details.
+
 Support
 =======
 
@@ -672,3 +686,4 @@ Credits
 .. _`CIA.vc`: http://cia.vc/stats/project/OWSLib
 .. _`WaterML`: http://his.cuahsi.org/wofws.html#waterml
 .. _`Swiss GM03`: http://www.geocat.ch/internet/geocat/en/home/documentation/gm03.html
+.. _bumpversion: https://pypi.org/project/bumpversion/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest
 pytest-cov
 Pillow
 tox
+bumpversion
 # install libraries to stop SSL related InsecurePlatformWarning
 pyopenssl        ; python_version < '2.7.9'
 ndg-httpsclient  ; python_version < '2.7.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[bumpversion]
+current_version = 0.17.0
+commit = True
+tag = True
+
+[metadata]
+description-file = README.rst
+
+[bumpversion:file:owslib/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bumpversion:file:VERSION.txt]
+search = {current_version}
+replace = {new_version}


### PR DESCRIPTION
This PR adds `bumpversion` to make a new version of OWSLib. Docs are updated with an example how to use it.

Fixes #517.