### PR TITLE
OnlineResource element within the Service element is optional

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -377,7 +377,10 @@ class ServiceProvider(object):
             self.name=name.text
         else:
             self.name=None
-        self.url=self._root.find('OnlineResource').attrib.get('{http://www.w3.org/1999/xlink}href', '')
+        self.url = None
+        online_resource = self._root.find('OnlineResource')
+        if online_resource is not None:
+            self.url = online_resource.attrib.get('{http://www.w3.org/1999/xlink}href', '')
         #contact metadata
         contact = self._root.find('ContactInformation')
         ## sometimes there is a contact block that is empty, so make

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -411,7 +411,10 @@ class ServiceProvider(object):
             self.name = name.text
         else:
             self.name = None
-        self.url = self._root.find(nspath('OnlineResource', WMS_NAMESPACE)).attrib.get('{http://www.w3.org/1999/xlink}href', '')
+        self.url = None
+        online_resource = self._root.find(nspath('OnlineResource', WMS_NAMESPACE))
+        if online_resource is not None:
+            self.url = online_resource.attrib.get('{http://www.w3.org/1999/xlink}href', '')
         # contact metadata
         contact = self._root.find(nspath('ContactInformation', WMS_NAMESPACE))
         # sometimes there is a contact block that is empty, so make


### PR DESCRIPTION
This PR solves the following issue:

```
>>> from owslib.wms import WebMapService
>>> wms = WebMapService('http://maps.kosmosnimki.ru/rest/ver1/service/wms?apikey=***', version='1.3.0')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/denis/git/OWSLib/owslib/wms.py", line 55, in WebMapService
    timeout=timeout, headers=headers)
  File "/home/denis/git/OWSLib/owslib/map/wms130.py", line 84, in __init__
    self._buildMetadata(parse_remote_metadata)
  File "/home/denis/git/OWSLib/owslib/map/wms130.py", line 97, in _buildMetadata
    self.provider = ServiceProvider(serviceelem)
  File "/home/denis/git/OWSLib/owslib/map/wms130.py", line 414, in __init__
    self.url = self._root.find(nspath('OnlineResource', WMS_NAMESPACE)).attrib.get('{http://www.w3.org/1999/xlink}href', '')
AttributeError: 'NoneType' object has no attribute 'attrib'
```