### PR TITLE
make as_reference attribute optional (#536)

### DIFF
--- a/tests/test_wps_request10.py
+++ b/tests/test_wps_request10.py
@@ -39,7 +39,7 @@ def test_wps_request10():
 
     # build XML request for WPS process execution
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=output)
+    requestElement = execution.buildRequest(processid, inputs, output=[(output, True)])
     request = etree.tostring(requestElement)
 
     # Compare to cached XML request

--- a/tests/test_wps_request2.py
+++ b/tests/test_wps_request2.py
@@ -6,7 +6,7 @@ from owslib.wps import WPSExecution, WFSFeatureCollection, WFSQuery
 from owslib.etree import etree
 
 
-def test_wps_request3():
+def test_wps_request2():
     # Supply process input argument
     wfsUrl = "http://igsarm-cida-gdp2.er.usgs.gov:8082/geoserver/wfs"
     query = WFSQuery("sample:CONUS_States",
@@ -39,7 +39,7 @@ def test_wps_request3():
 
     # build XML request for WPS process execution
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=output)
+    requestElement = execution.buildRequest(processid, inputs, output=[(output, True)])
     request = etree.tostring(requestElement)
 
     # Compare to cached XML request

--- a/tests/test_wps_request3.py
+++ b/tests/test_wps_request3.py
@@ -33,7 +33,7 @@ def test_wps_request3():
     output = "OUTPUT"
     # build XML request for WPS process execution
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=output)
+    requestElement = execution.buildRequest(processid, inputs, output=[(output, True)])
     request = etree.tostring(requestElement)
     # Compare to cached XML request
     _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'rb').read()

--- a/tests/test_wps_request4.py
+++ b/tests/test_wps_request4.py
@@ -15,7 +15,7 @@ def test_wps_request4():
 
     # build XML request for WPS process execution
     execution = WPSExecution()
-    requestElement = execution.buildRequest(processid, inputs, output=output)
+    requestElement = execution.buildRequest(processid, inputs, output=[(output, True)])
     request = etree.tostring(requestElement)
 
     # Compare to cached XML request


### PR DESCRIPTION
This PR fixes issue #536.

It makes the `as_reference` attribute of an output parameter optional.