### PR TITLE
is_reference returns False if value is binary type

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -121,6 +121,7 @@ try:                    # Python 3
 except ImportError:     # Python 2
     from urlparse import urlparse
 
+import six
 # namespace definition
 n = Namespaces()
 
@@ -158,11 +159,14 @@ def is_reference(val):
     """
     Checks if the provided value is a reference (URL).
     """
-    try:
-        parsed = urlparse(val)
-        is_ref = parsed.scheme != ''
-    except Exception:
+    if isinstance(val, six.binary_type):
         is_ref = False
+    else:
+        try:
+            parsed = urlparse(val)
+            is_ref = parsed.scheme != ''
+        except Exception:
+            is_ref = False
     return is_ref
 
 

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -159,14 +159,11 @@ def is_reference(val):
     """
     Checks if the provided value is a reference (URL).
     """
-    if isinstance(val, six.binary_type):
+    try:
+        parsed = urlparse(val)
+        is_ref = bool(parsed.scheme)
+    except Exception:
         is_ref = False
-    else:
-        try:
-            parsed = urlparse(val)
-            is_ref = parsed.scheme != ''
-        except Exception:
-            is_ref = False
     return is_ref
 
 

--- a/tests/test_wps.py
+++ b/tests/test_wps.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from tests.utils import resource_file
-from owslib.wps import WebProcessingService, WPSExecution, Process
+from owslib.wps import WebProcessingService, WPSExecution, Process, is_reference
 from owslib.etree import etree
 
 
@@ -75,3 +75,10 @@ def test_wps_response_with_lineage():
     assert outp.title == 'Test Report'
     assert outp.abstract == 'Compliance checker test report.'
     assert outp.reference.startswith('http://localhost:8090/wpsoutputs')
+
+
+def test_is_reference():
+    assert is_reference('http://testing.org')
+    assert is_reference(b'http://testing.org')
+    assert not is_reference('mumbo jumbo')
+    assert not is_reference(b'mumbo jumbo')


### PR DESCRIPTION
Adds a check for binary types in `is_reference`.

Fixes #541 

TODO: Add a test