### PR TITLE
use pytest>=3.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 flake8
-pytest
+pytest>=3.6
 pytest-cov
 Pillow
 tox


### PR DESCRIPTION
This PR fixes issue #550.

Added version restriction for pywps.