### PR TITLE
Support namespace et get 'crs' and 'diemension' attribute in BoundingBox

### DIFF
--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -235,14 +235,14 @@ class BoundingBox(object):
         self.maxx = None
         self.maxy = None
 
-        val = elem.attrib.get('crs')
+        val = elem.attrib.get('crs') or elem.attrib.get('{{{}}}crs'.format(namespace))
         try:
             self.crs = crs.Crs(val)
         except (AttributeError, ValueError):
             LOGGER.warning('Invalid CRS %r. Expected integer')
             self.crs = None
 
-        val = elem.attrib.get('dimensions')
+        val = elem.attrib.get('dimensions') or elem.attrib.get('{{{}}}dimensions'.format(namespace))
         if val is not None:
             self.dimensions = int(util.testXMLValue(val, True))
         else:  # assume 2
@@ -267,6 +267,7 @@ class BoundingBox(object):
                     self.maxx, self.maxy = xy[1], xy[0]
                 else:
                     self.maxx, self.maxy = xy[0], xy[1]
+
 
 class WGS84BoundingBox(BoundingBox):
     """WGS84 bbox, axis order xy"""

--- a/tests/test_ows.py
+++ b/tests/test_ows.py
@@ -1,6 +1,10 @@
+from owslib.namespaces import Namespaces
+
 from owslib.ows import BoundingBox, DEFAULT_OWS_NAMESPACE
 from owslib import crs
 from owslib.etree import etree
+
+DEFAULT_WPS_NAMESPACE = Namespaces().get_namespace('wps')
 
 
 def test_ows_bbox():
@@ -9,6 +13,24 @@ def test_ows_bbox():
         <ows:LowerCorner>0.0 -90.0</ows:LowerCorner>
         <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
     </ows:BoundingBox>""".format(DEFAULT_OWS_NAMESPACE))
+    bbox = BoundingBox(bbox_elem)
+    assert bbox.crs == crs.Crs('EPSG:4326')
+    assert bbox.crs.axisorder == 'yx'
+    assert bbox.dimensions == 2
+    assert bbox.minx == '-90.0'
+    assert bbox.miny == '0.0'
+    assert bbox.maxx == '90.0'
+    assert bbox.maxy == '180.0'
+
+
+def test_ows_bbox_with_namespaces():
+    """ XML bounding box description as received from a wps request """
+    
+    bbox_elem = etree.fromstring("""
+    <wps:BoundingBoxData xmlns:wps="{}" xmlns:ows="{}" ows:crs="EPSG:4326" ows:dimensions="2">
+        <ows:LowerCorner>0.0 -90.0</ows:LowerCorner>
+        <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+    </wps:BoundingBoxData>""".format(DEFAULT_WPS_NAMESPACE, DEFAULT_OWS_NAMESPACE))
     bbox = BoundingBox(bbox_elem)
     assert bbox.crs == crs.Crs('EPSG:4326')
     assert bbox.crs.axisorder == 'yx'


### PR DESCRIPTION
I resubmit this PR with remarks taken into account (usage of format) and a unit test.

In a wps requests, if attributes 'crs' and 'dimension' are given with namespace in the input boundingBox description, these attributes are not taken into account.
With the proposed fix, 'crs' and 'dimension' attributes are read in both cases (with and without namespace).