### PR TITLE
Add Python 3.7 to Travis CI Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
-  - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 #  - "pypy"
 sudo: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+  - "3.7"
 #  - "pypy"
 sudo: false
 env:

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -323,9 +323,9 @@ TILEMATRIX=6&TILEROW=4&TILECOL=4&FORMAT=image%2Fjpeg'
             msg = 'tilematrix (zoom level) is mandatory (cannot be None)'
             raise ValueError(msg)
         if row is None:
-                raise ValueError("row is mandatory (cannot be None)")
+            raise ValueError("row is mandatory (cannot be None)")
         if column is None:
-                raise ValueError("column is mandatory (cannot be None)")
+            raise ValueError("column is mandatory (cannot be None)")
 
         request = list()
         request.append(('SERVICE', 'WMTS'))

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -826,7 +826,7 @@ class WPSExecution(object):
                     headers=self.headers, verify=self.verify, cert=self.cert)
 
                 # ExecuteResponse contains reference to server-side output
-                if output_content is not b'':
+                if output_content != b'':
                     content = content + output_content
                     if filepath is None:
                         filepath = output.fileName
@@ -839,7 +839,7 @@ class WPSExecution(object):
                         content = content + data
 
             # write out content
-            if content is not '':
+            if content != '':
                 out = open(filepath, 'wb')
                 out.write(content)
                 out.close()
@@ -1335,7 +1335,7 @@ class Output(InputOutput):
             if complexDataElement is not None:
                 self.dataType = "ComplexData"
                 self.mimeType = complexDataElement.get('mimeType')
-                if complexDataElement.text is not None and complexDataElement.text.strip() is not '':
+                if complexDataElement.text is not None and complexDataElement.text.strip() != '':
                     self.data.append(complexDataElement.text.strip())
                 for child in complexDataElement:
                     self.data.append(etree.tostring(child))
@@ -1343,7 +1343,7 @@ class Output(InputOutput):
                 nspath('LiteralData', ns=wpsns))
             if literalDataElement is not None:
                 self.dataType = literalDataElement.get('dataType')
-                if literalDataElement.text is not None and literalDataElement.text.strip() is not '':
+                if literalDataElement.text is not None and literalDataElement.text.strip() != '':
                     self.data.append(literalDataElement.text.strip())
             bboxDataElement = dataElement.find(nspath('BoundingBox', ns=namespaces['ows']))
             if bboxDataElement is not None:
@@ -1401,13 +1401,13 @@ class Output(InputOutput):
         content = self.retrieveData(username, password, headers=headers, verify=verify, cert=cert)
 
         # ExecuteResponse contain embedded output
-        if content is "" and len(self.data) > 0:
+        if content == "" and len(self.data) > 0:
             self.fileName = self.identifier
             for data in self.data:
                 content = content + data
 
         # write out content
-        if content is not "":
+        if content != "":
             if self.fileName == "":
                 self.fileName = self.identifier
             self.filePath = path + self.fileName


### PR DESCRIPTION
This PR adds Python 3.7 to the Travis CI build matrix using Xenial.  (see this issue for context as to why Xenial must be used - https://github.com/travis-ci/travis-ci/issues/9815).  I've also resolved the flake8 issues so that this build, and the other open PRs can pass.   