### PR TITLE
dataType using value, then parse reference as needed

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1080,9 +1080,11 @@ class InputOutput(object):
                     self.dataType = sub_element.text
                     if not self.dataType:
                         reference = sub_element.get(nspath("reference", ns=subns))
+                        # backward search of first non-alpha character (:, #, /, etc.)
                         pos = len(reference) - 1
                         while pos >= 0 and reference[pos].isalpha():
                             pos -= 1
+                        # obtain substring after found non-alpha character position
                         self.dataType = reference[pos + 1:]
 
             for sub_element in literal_data_element:

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1077,9 +1077,13 @@ class InputOutput(object):
             for sub_element in literal_data_element:
                 subns = getNamespace(sub_element)
                 if sub_element.tag.endswith('DataType'):
-                    reference = sub_element.get(nspath("reference", ns=subns)) or sub_element.text
-                    if reference and ':' in reference:
-                        self.dataType = reference.split(':')[-1]
+                    self.dataType = sub_element.text
+                    if not self.dataType:
+                        reference = sub_element.get(nspath("reference", ns=subns))
+                        pos = len(reference) - 1
+                        while pos >= 0 and reference[pos].isalpha():
+                            pos -= 1
+                        self.dataType = reference[pos + 1:]
 
             for sub_element in literal_data_element:
 

--- a/tests/resources/wps_inout_parsing.xml
+++ b/tests/resources/wps_inout_parsing.xml
@@ -16,7 +16,7 @@
         <ows:Identifier>input2</ows:Identifier>
         <ows:Title>Input 2</ows:Title>
         <LiteralData>
-            <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#string">string</ows:DataType>
+            <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#string" />
             <ows:AllowedValues>
                 <ows:Value>YS</ows:Value>
                 <ows:Value>MS</ows:Value>
@@ -30,7 +30,7 @@
         <ows:Identifier>input3</ows:Identifier>
         <ows:Title>Input 3</ows:Title>
         <LiteralData>
-            <ows:DataType ows:reference="urn:ogc:def:dataType:OGC:1.1:string">string</ows:DataType>
+            <ows:DataType ows:reference="urn:ogc:def:dataType:OGC:1.1:string" />
             <ows:AnyValue />
         </LiteralData>
     </Input>
@@ -42,4 +42,26 @@
             <ows:AnyValue />
         </LiteralData>
      </Input>
+        <Input minOccurs="1" maxOccurs="1">
+        <ows:Identifier>input5</ows:Identifier>
+        <ows:Title>Input 5</ows:Title>
+        <LiteralData>
+            <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#string">string</ows:DataType>
+            <ows:AllowedValues>
+                <ows:Value>YS</ows:Value>
+                <ows:Value>MS</ows:Value>
+                <ows:Value>QS-DEC</ows:Value>
+                <ows:Value>AS-JUL</ows:Value>
+            </ows:AllowedValues>
+            <DefaultValue>YS</DefaultValue>
+        </LiteralData>
+    </Input>
+    <Input minOccurs="1" maxOccurs="1">
+        <ows:Identifier>input6</ows:Identifier>
+        <ows:Title>Input 6</ows:Title>
+        <LiteralData>
+            <ows:DataType ows:reference="urn:ogc:def:dataType:OGC:1.1:string">string</ows:DataType>
+            <ows:AnyValue />
+        </LiteralData>
+    </Input>
 </DataInputs>

--- a/tests/resources/wps_inout_parsing.xml
+++ b/tests/resources/wps_inout_parsing.xml
@@ -1,0 +1,45 @@
+<DataInputs xmlns:ows="http://www.opengis.net/ows/1.1">
+    <Input minOccurs="1" maxOccurs="1000">
+        <ows:Identifier>input1</ows:Identifier>
+        <ows:Title>Input 1</ows:Title>
+        <LiteralData>
+            <ows:DataType ows:reference="xs:string" xmlns:ows="http://www.opengis.net/ows/1.1" />
+            <ows:AllowedValues xmlns:ows="http://www.opengis.net/ows/1.1">
+                <ows:Value>COMMA</ows:Value>
+                <ows:Value>TAB</ows:Value>
+                <ows:Value>SPACE</ows:Value>
+            </ows:AllowedValues>
+            <DefaultValue>COMMA</DefaultValue>
+        </LiteralData>
+    </Input>
+    <Input minOccurs="1" maxOccurs="1">
+        <ows:Identifier>input2</ows:Identifier>
+        <ows:Title>Input 2</ows:Title>
+        <LiteralData>
+            <ows:DataType ows:reference="http://www.w3.org/TR/xmlschema-2/#string">string</ows:DataType>
+            <ows:AllowedValues>
+                <ows:Value>YS</ows:Value>
+                <ows:Value>MS</ows:Value>
+                <ows:Value>QS-DEC</ows:Value>
+                <ows:Value>AS-JUL</ows:Value>
+            </ows:AllowedValues>
+            <DefaultValue>YS</DefaultValue>
+        </LiteralData>
+    </Input>
+    <Input minOccurs="1" maxOccurs="1">
+        <ows:Identifier>input3</ows:Identifier>
+        <ows:Title>Input 3</ows:Title>
+        <LiteralData>
+            <ows:DataType ows:reference="urn:ogc:def:dataType:OGC:1.1:string">string</ows:DataType>
+            <ows:AnyValue />
+        </LiteralData>
+    </Input>
+    <Input minOccurs="1" maxOccurs="1">
+        <ows:Identifier>input4</ows:Identifier>
+        <ows:Title>Input 4</ows:Title>
+        <LiteralData>
+            <ows:DataType>string</ows:DataType>
+            <ows:AnyValue />
+        </LiteralData>
+     </Input>
+</DataInputs>

--- a/tests/test_wps.py
+++ b/tests/test_wps.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from tests.utils import resource_file
-from owslib.wps import WebProcessingService, WPSExecution, Process, is_reference
+from owslib.wps import WebProcessingService, WPSExecution, Process, is_reference, Input
 from owslib.etree import etree
 
 
@@ -45,10 +45,19 @@ def test_wps_process_properties(wps):
     assert p.storeSupported is None
 
 
-def test_wps_process_with_invalid_identifer():
+def test_wps_process_with_invalid_identifier():
     p = Process(etree.Element('invalid'))
     assert repr(p) == '<owslib.wps.Process >'
     assert str(p) == 'WPS Process: , title='
+
+
+def test_wps_literal_data_input_parsing_references():
+    xml = open(resource_file('wps_inout_parsing.xml'), 'r').read()
+    inputs = etree.fromstring(xml)
+    for i, i_elem in enumerate(inputs):
+        wps_in = Input(i_elem)
+        assert wps_in.identifier == 'input{}'.format(i + 1)
+        assert wps_in.dataType == 'string'
 
 
 def test_wps_response_with_lineage():


### PR DESCRIPTION
Executes a better parsing of `DataType` using first the value if provided, and then `reference` parsing if provided to attempt finding the underlying data type.
Doesn't only use the `:` split to avoid errors from references specified as literal URL.

ref #383
fix for crim-ca/weaver#11