### PR TITLE
Remove Python 3.4 From Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
@@ -8,7 +9,6 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-#  - "pypy"
 sudo: false
 env:
   - LXML=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.6"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+      env: LMXL=true
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: LMXL=false
 sudo: false
 env:
   - LXML=true


### PR DESCRIPTION
Python 3.4 has reached it's end of life, remove it from the build matrix so that the Travis CI tests can pass.  