### PR TITLE
fix wps.describeprocess

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -287,8 +287,11 @@ class WebProcessingService(object):
 
         if identifier == 'all':
             return processes
-        else:
-            return processes[0]
+        # return process with given identifier
+        for process in processes:
+            if process.identifier == identifier:
+                return process
+        raise ValueError('process with identifier {} not found'.format(identifier))
 
     def execute(self, identifier, inputs, output=None, mode=ASYNC, lineage=False, request=None, response=None):
         """

--- a/tests/test_wmts.py
+++ b/tests/test_wmts.py
@@ -24,7 +24,7 @@ def test_wmts():
     assert wmts.provider.url == 'https://earthdata.nasa.gov/'
     # Available Layers:
     assert len(wmts.contents.keys()) > 0
-    assert sorted(list(wmts.contents))[0] == 'AIRS_All_Sky_Outgoing_Longwave_Radiation_Daily_Day'
+    assert sorted(list(wmts.contents))[0] == 'AIRS_CO_Total_Column_Day'
     # Fetch a tile (using some defaults):
     tile = wmts.gettile(layer='MODIS_Terra_CorrectedReflectance_TrueColor',
                         tilematrixset='EPSG4326_250m', tilematrix='0',

--- a/tests/test_wps_describeprocess_ceda.py
+++ b/tests/test_wps_describeprocess_ceda.py
@@ -7,7 +7,7 @@ def test_wps_describeprocess_ceda():
     wps = WebProcessingService('http://ceda-wps2.badc.rl.ac.uk/wps', skip_caps=True)
     # Execute fake invocation of DescribeProcess operation by parsing cached response from CEDA service
     xml = open(resource_file('wps_CEDADescribeProcess.xml'), 'rb').read()
-    process = wps.describeprocess('Doubleit', xml=xml)
+    process = wps.describeprocess('DoubleIt', xml=xml)
     # Check process description
     assert process.identifier == 'DoubleIt'
     assert process.title == 'Doubles the input number and returns value'


### PR DESCRIPTION
This PR fixes `wps.describeprocess`. It filters the requested process from the available process list (before it returned just the first one). This is needed when an xml response document is given with several process descriptions in test cases.