### PR TITLE
Remove malware link from documentation

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -21,7 +21,7 @@ Introduction
 
 OWSLib is a Python package for client programming with `Open Geospatial Consortium`_ (OGC) web service (hence OWS) interface standards, and their related content models.
 
-OWSLib was buried down inside PCL, but has been brought out as a separate project in `r481 <http://trac.gispython.org/lab/changeset/481>`_.
+OWSLib was buried down inside PCL, but has been brought out as a separate project.
 
 Features
 ========

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -21,7 +21,7 @@ Introduction
 
 OWSLib is a Python package for client programming with `Open Geospatial Consortium`_ (OGC) web service (hence OWS) interface standards, and their related content models.
 
-OWSLib was buried down inside PCL, but has been brought out as a separate project.
+OWSLib was buried down inside PCL (Python Cartography Library), but has been brought out as a separate project.
 
 Features
 ========


### PR DESCRIPTION
The documentation provides an old link to a dead site and the domain now points to fake virus warning pages. This pull request removes the offensive link and adds an explanation for the acronym "PCL".