### PR TITLE
WFS 2.0 URL building

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -9,6 +9,7 @@ import logging
 
 from urllib.parse import urlencode
 from owslib.crs import Crs
+from owslib.util import log, Authentication, build_get_url
 from owslib.util import Authentication
 from owslib.feature.schema import get_schema
 from owslib.feature.postrequest import PostRequest_1_1_0, PostRequest_2_0_0
@@ -209,7 +210,6 @@ class WebFeatureService_(object):
                 if m.get("type").lower() == method.lower()
             )
         )
-        base_url = base_url if base_url.endswith("?") else base_url + "?"
 
         request = {"service": "WFS", "version": self.version, "request": "GetFeature"}
 
@@ -248,9 +248,7 @@ class WebFeatureService_(object):
         if outputFormat is not None:
             request["outputFormat"] = outputFormat
 
-        data = urlencode(request, doseq=True)
-
-        return base_url + data
+        return build_get_url(base_url, request)
 
     def getPOSTGetFeatureRequest(
         self,

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -9,8 +9,7 @@ import logging
 
 from urllib.parse import urlencode
 from owslib.crs import Crs
-from owslib.util import log, Authentication, build_get_url
-from owslib.util import Authentication
+from owslib.util import Authentication, build_get_url
 from owslib.feature.schema import get_schema
 from owslib.feature.postrequest import PostRequest_1_1_0, PostRequest_2_0_0
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -566,7 +566,7 @@ def getNamespace(element):
         return ""
 
 
-def build_get_url(base_url, params, overwrite=False):
+def build_get_url(base_url, params, overwrite=False, doseq=False):
     ''' Utility function to build a full HTTP GET URL from the service base URL and a dictionary of HTTP parameters.
 
     TODO: handle parameters case-insensitive?
@@ -598,7 +598,7 @@ def build_get_url(base_url, params, overwrite=False):
         if key not in pars:
             qs.append((key, value))
 
-    urlqs = urlencode(tuple(qs))
+    urlqs = urlencode(tuple(qs), doseq=doseq)
     return base_url.split('?')[0] + '?' + urlqs
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,6 +28,7 @@ def test_clean_ows_url():
 def test_build_get_url():
     assert build_get_url("http://example.org/wps", {'service': 'WPS'}) == 'http://example.org/wps?service=WPS'
     assert build_get_url("http://example.org/wms", {'SERVICE': 'wms'}) == 'http://example.org/wms?SERVICE=wms'
+    assert build_get_url("http://example.org/wms?map=/path/to/foo.map&", {'SERVICE': 'wms'}) == 'http://example.org/wms?map=%2Fpath%2Fto%2Ffoo.map&SERVICE=wms'
     assert build_get_url("http://example.org/wps?service=WPS", {'request': 'GetCapabilities'}) == \
         'http://example.org/wps?service=WPS&request=GetCapabilities'
     assert build_get_url("http://example.org/wps?service=WPS", {'request': 'GetCapabilities'}) == \
@@ -38,6 +39,12 @@ def test_build_get_url():
     # Parameter is case-senstive
     assert build_get_url("http://example.org/ows?SERVICE=WPS", {'service': 'WMS'}) == \
         'http://example.org/ows?SERVICE=WPS&service=WMS'
+    # Test with trailing ampersand and doseq False (default)
+    assert build_get_url("http://example.org/ows?SERVICE=WFS&", {'typename': 'test', 'keys': [1,2]}, doseq=False) == \
+        'http://example.org/ows?SERVICE=WFS&typename=test&keys=%5B1%2C+2%5D'
+    # Test with trailing ampersand and doseq True
+    assert build_get_url("http://example.org/ows?SERVICE=WFS&", {'typename': 'test', 'keys': [1,2]}, doseq=True) == \
+        'http://example.org/ows?SERVICE=WFS&typename=test&keys=1&keys=2'
 
 
 def test_build_get_url_overwrite():


### PR DESCRIPTION
In WFS 2.0 GetFeature requests currently fail for MapServer URLs containing `?map=path/my.map&`
This is the same issue as #533 - and unfortunately I missed that there was also an open pull request at #534 from @samtux
The approach in this pull request is slightly different - it reuses the `build_get_url` function from utils. 

A few other notes:

- There is a warning about `owslib\util.py:561: DeprecationWarning: cgi.parse_qsl is deprecated, use urllib.parse.parse_qsl instead` so this has been updated
- the WFS GetFeature URL building allowed for the [doseq](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode)parameter to be used (I'm not sure when this applies to WFS requests, but I added it to avoid any breaking changes). It allows for automatic duplicate keys for sequences e.g.

```python
>>> urllib.urlencode({'keys': [1,2]}, doseq=True)
>>> 'keys=1&keys=2'
>>> urllib.urlencode({'keys': [1,2]}, doseq=False)
>>> 'keys=%5B1%2C+2%5D'
```
- I 've also added tests for the `doseq` and URLs with ampersands

