### PR TITLE
#587 pass HTTP headers for WMS,WFS,WMTS,TMS + fix WFS3 test

### DIFF
--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -21,8 +21,9 @@ class WFSCapabilitiesReader(object):
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version="1.0", username=None, password=None, auth=None):
+    def __init__(self, version="1.0", username=None, password=None, headers=None, auth=None):
         """Initialize"""
+        self.headers = headers
         if auth:
             if username:
                 auth.username = username
@@ -63,7 +64,7 @@ class WFSCapabilitiesReader(object):
             A timeout value (in seconds) for the request.
         """
         request = self.capabilities_url(url)
-        u = openURL(request, timeout=timeout, auth=self.auth)
+        u = openURL(request, timeout=timeout, headers=self.headers, auth=self.auth)
         return etree.fromstring(u.read())
 
     def readString(self, st):
@@ -80,8 +81,9 @@ class WFSCapabilitiesReader(object):
 
 
 class AbstractContentMetadata(object):
-    def __init__(self, auth=None):
+    def __init__(self, headers=None, auth=None):
         self.auth = auth or Authentication()
+        self.headers = headers
 
     def get_metadata(self):
         return [

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -26,7 +26,7 @@ GML_NAMESPACES = (
 
 
 def get_schema(
-    url, typename, version="1.0.0", timeout=30, username=None, password=None, auth=None
+    url, typename, version="1.0.0", timeout=30, headers=None, username=None, password=None, auth=None
 ):
     """Parses DescribeFeatureType response and creates schema compatible
     with :class:`fiona`
@@ -47,7 +47,7 @@ def get_schema(
     else:
         auth = Authentication(username, password)
     url = _get_describefeaturetype_url(url, version, typename)
-    res = openURL(url, timeout=timeout, auth=auth)
+    res = openURL(url, timeout=timeout, headers=headers, auth=auth)
     root = etree.fromstring(res.read())
 
     if ":" in typename:

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -71,6 +71,7 @@ class WebFeatureService_1_0_0(object):
         xml,
         parse_remote_metadata=False,
         timeout=30,
+        headers=None,
         username=None,
         password=None,
         auth=None,
@@ -83,6 +84,7 @@ class WebFeatureService_1_0_0(object):
         @param xml: elementtree object
         @type parse_remote_metadata: boolean
         @param parse_remote_metadata: whether to fully process MetadataURL elements
+        @param headers: HTTP headers to send with requests
         @param timeout: time (in seconds) after which requests should timeout
         @param username: service authentication username
         @param password: service authentication password
@@ -96,6 +98,7 @@ class WebFeatureService_1_0_0(object):
             xml,
             parse_remote_metadata,
             timeout,
+            headers=headers,
             username=username,
             password=password,
             auth=auth,
@@ -116,6 +119,7 @@ class WebFeatureService_1_0_0(object):
         xml=None,
         parse_remote_metadata=False,
         timeout=30,
+        headers=None,
         username=None,
         password=None,
         auth=None,
@@ -129,9 +133,10 @@ class WebFeatureService_1_0_0(object):
         self.url = url
         self.version = version
         self.timeout = timeout
+        self.headers = headers
         self.auth = auth or Authentication(username, password)
         self._capabilities = None
-        reader = WFSCapabilitiesReader(self.version, auth=self.auth)
+        reader = WFSCapabilitiesReader(self.version, headers=self.headers, auth=self.auth)
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -178,7 +183,8 @@ class WebFeatureService_1_0_0(object):
         NOTE: this is effectively redundant now"""
         reader = WFSCapabilitiesReader(self.version, auth=self.auth)
         return openURL(
-            reader.capabilities_url(self.url), timeout=self.timeout, auth=self.auth
+            reader.capabilities_url(self.url), timeout=self.timeout,
+            headers=self.headers, auth=self.auth
         )
 
     def items(self):
@@ -279,7 +285,8 @@ class WebFeatureService_1_0_0(object):
 
         data = urlencode(request)
         log.debug("Making request: %s?%s" % (base_url, data))
-        u = openURL(base_url, data, method, timeout=self.timeout, auth=self.auth)
+        u = openURL(base_url, data, method, timeout=self.timeout,
+                    headers=self.headers, auth=self.auth)
 
         # check for service exceptions, rewrap, and return
         # We're going to assume that anything with a content-length > 32k
@@ -441,7 +448,7 @@ class ContentMetadata(AbstractContentMetadata):
             ):
                 try:
                     content = openURL(
-                        metadataUrl["url"], timeout=timeout, auth=self.auth
+                        metadataUrl["url"], timeout=timeout, headers=self.headers, auth=self.auth
                     )
                     doc = etree.fromstring(content.read())
                     if metadataUrl["type"] == "FGDC":

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -19,7 +19,7 @@ from .util import clean_ows_url, Authentication
 
 def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
                       parse_remote_metadata=False, timeout=30, username=None,
-                      password=None, auth=None):
+                      password=None, headers=None, auth=None):
     ''' wfs factory function, returns a version specific WebFeatureService object
 
     @type url: string
@@ -28,6 +28,7 @@ def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
     @param xml: elementtree object
     @type parse_remote_metadata: boolean
     @param parse_remote_metadata: whether to fully process MetadataURL elements
+    @param headers: HTTP headers to send with requests
     @param timeout: time (in seconds) after which requests should timeout
     @param username: service authentication username
     @param password: service authentication password
@@ -45,13 +46,17 @@ def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
 
     if version in ['1.0', '1.0.0']:
         return wfs100.WebFeatureService_1_0_0(
-            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
+            clean_url, version, xml, parse_remote_metadata,
+            timeout=timeout, headers=headers, auth=auth)
     elif version in ['1.1', '1.1.0']:
         return wfs110.WebFeatureService_1_1_0(
-            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
+            clean_url, version, xml, parse_remote_metadata,
+            timeout=timeout, headers=headers, auth=auth)
     elif version in ['2.0', '2.0.0']:
         return wfs200.WebFeatureService_2_0_0(
-            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
+            clean_url, version, xml, parse_remote_metadata,
+            timeout=timeout, headers=headers, auth=auth)
     elif version in ['3.0', '3.0.0']:
         return wfs300.WebFeatureService_3_0_0(
-            clean_url, version, json_, timeout=timeout, auth=auth)
+            clean_url, version, json_, timeout=timeout,
+            headers=headers, auth=auth)

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -30,6 +30,7 @@ def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
     @param xml: elementtree object
     @type parse_remote_metadata: boolean
     @param parse_remote_metadata: whether to fully process MetadataURL elements
+    @param headers: HTTP headers to send with requests
     @param timeout: time (in seconds) after which requests should timeout
     @param username: service authentication username
     @param password: service authentication password
@@ -48,7 +49,7 @@ def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
     if version in ['1.1.1']:
         return wms111.WebMapService_1_1_1(
             clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,
-            timeout=timeout, auth=auth)
+            timeout=timeout, headers=headers, auth=auth)
     elif version in ['1.3.0']:
         return wms130.WebMapService_1_3_0(
             clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,

--- a/tests/test_wfs3_pygeoapi.py
+++ b/tests/test_wfs3_pygeoapi.py
@@ -34,7 +34,11 @@ def test_wfs3_pygeoapi():
     assert lakes['title'] == 'Large Lakes'
     assert lakes['description'] == 'lakes of the world, public domain'
 
+    # Minimum of limit param is 1
     lakes_query = w.collection_items('lakes', limit=0)
+    assert lakes_query['code'] == 'InvalidParameterValue'
+
+    lakes_query = w.collection_items('lakes', limit=1)
     assert lakes_query['numberMatched'] == 25
-    assert lakes_query['numberReturned'] == 0
-    assert len(lakes_query['features']) == 0
+    assert lakes_query['numberReturned'] == 1
+    assert len(lakes_query['features']) == 1


### PR DESCRIPTION
* WMS was missing HTTP header passing for v 1.1.1. 
* added WFS,WMTS,TMS HTTP header passing (was absent)
* WFS3 needed small fix because of [recent commit](https://github.com/geopython/pygeoapi/commit/4ff32fdfc5629cb6f0356c1d435156a9157753f1) for `limit` param