### PR TITLE
#614 fix broken TileMapService constructor

### DIFF
--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -47,6 +47,8 @@ class TileMapService(object):
             if password:
                 auth.password = password
         self.url = url
+        self.username = username
+        self.password = password
         self.auth = auth or Authentication(username, password)
         self.version = version
         self.timeout = timeout


### PR DESCRIPTION
Assign both `username` and `password` to `self` as these are referred to within `TMSCapabilitiesReader` and in `_getcapproperty()`.