### PR TITLE
add resolution and size params to WCS GetCoverage requests

### DIFF
--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -29,7 +29,7 @@ import errno
 import dateutil.parser as parser
 from datetime import timedelta
 import logging
-from owslib.util import log, datetime_from_ansi, datetime_from_iso
+from owslib.util import log, datetime_from_ansi, datetime_from_iso, param_list_to_url_string
 
 
 #  function to save writing out WCS namespace in full each time
@@ -128,6 +128,8 @@ class WebCoverageService_2_0_0(WCSBase):
         time=None,
         format=None,
         subsets=None,
+        resolutions=None,
+        sizes=None,
         crs=None,
         width=None,
         height=None,
@@ -211,26 +213,13 @@ class WebCoverageService_2_0_0(WCSBase):
         # encode and request
         data = urlencode(request)
         if subsets:
-            for subset in subsets:
-                if len(subset) > 2:
-                    if not self.is_number(subset[1]):
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + '("' + self.__makeString(subset[1]) + '","' + self.__makeString(subset[2]) + '")'})  # noqa
-                        )
-                    else:
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + "(" + self.__makeString(subset[1]) + "," + self.__makeString(subset[2]) + ")"})  # noqa
-                        )
-                else:
-                    if not self.is_number(subset[1]):
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + '("' + self.__makeString(subset[1]) + '")'})
-                        )
-                    else:
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + "(" + self.__makeString(subset[1]) + ")"})
-                        )
-
+            data += param_list_to_url_string(subsets, 'subset')
+        if resolutions:
+            log.debug('Adding vendor-specific RESOLUTION parameter.')
+            data += param_list_to_url_string(resolutions, 'resolution')
+        if sizes:
+            log.debug('Adding vendor-specific SIZE parameter.')
+            data += param_list_to_url_string(sizes, 'size')
         if log.isEnabledFor(logging.DEBUG):
             log.debug("WCS 2.0.0 DEBUG: Second part of URL: %s" % data)
 

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -29,7 +29,7 @@ import errno
 import dateutil.parser as parser
 from datetime import timedelta
 import logging
-from owslib.util import log, datetime_from_ansi, datetime_from_iso
+from owslib.util import log, datetime_from_ansi, datetime_from_iso, param_list_to_url_string
 
 
 #  function to save writing out WCS namespace in full each time
@@ -128,6 +128,8 @@ class WebCoverageService_2_0_1(WCSBase):
         time=None,
         format=None,
         subsets=None,
+        resolutions=None,
+        sizes=None,
         crs=None,
         width=None,
         height=None,
@@ -211,25 +213,13 @@ class WebCoverageService_2_0_1(WCSBase):
         # encode and request
         data = urlencode(request)
         if subsets:
-            for subset in subsets:
-                if len(subset) > 2:
-                    if not self.is_number(subset[1]):
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + '("' + self.__makeString(subset[1]) + '","' + self.__makeString(subset[2]) + '")'})  # noqa
-                        )
-                    else:
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + "(" + self.__makeString(subset[1]) + "," + self.__makeString(subset[2]) + ")"})  # noqa
-                        )
-                else:
-                    if not self.is_number(subset[1]):
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + '("' + self.__makeString(subset[1]) + '")'})
-                        )
-                    else:
-                        data = (
-                            data + "&" + urlencode({"subset": subset[0] + "(" + self.__makeString(subset[1]) + ")"})
-                        )
+            data += param_list_to_url_string(subsets, 'subset')
+        if resolutions:
+            log.debug('Adding vendor-specific RESOLUTION parameter.')
+            data += param_list_to_url_string(resolutions, 'resolution')
+        if sizes:
+            log.debug('Adding vendor-specific SIZE parameter.')
+            data += param_list_to_url_string(sizes, 'size')
 
         if log.isEnabledFor(logging.DEBUG):
             log.debug("WCS 2.0.1 DEBUG: Second part of URL: %s" % data)

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -787,6 +787,25 @@ def datetime_from_ansi(ansi):
     return datumOrigin + timedelta(ansi)
 
 
+def param_list_to_url_string(self, param_list, param_name):
+    """Converts list of tuples for certain WCS GetCoverage keyword arguments (subsets, resolutions, sizes) to a url-enconded
+    string
+    """
+    string = ''
+    for param in param_list:
+        if len(param) > 2:
+            if not self.is_number(param[1]):
+                string += "&" + urlencode({param_name: param[0] + '("' + self.__makeString(param[1]) + '","' + self.__makeString(param[2]) + '")'})  # noqa
+            else:
+                string += "&" + urlencode({param_name: param[0] + "(" + self.__makeString(param[1]) + "," + self.__makeString(param[2]) + ")"})  # noqa
+        else:
+            if not self.is_number(param[1]):
+                string += "&" + urlencode({param_name: param[0] + '("' + self.__makeString(param[1]) + '")'})
+            else:
+                string += "&" + urlencode({param_name: param[0] + "(" + self.__makeString(param[1]) + ")"})
+    return string
+
+
 def is_vector_grid(grid_elem):
     pass
 


### PR DESCRIPTION
This PR adds SIZE and RESOLUTION parameter support for WCS GetCoverage requests, similar to the existing SUBSET parameter implementation.

Example:
```python
wcs = WebCoverageService('https://geo.weather.gc.ca/geomet/', version='2.0.1')

gc = wcs.getCoverage(identifier=['WEATHERADIO'], subsettingcrs='epsg:4326',
                                              subsets=[('x', -180, 180), ('y', -90, 90)],
                                              resolutions=[('x', 0.1), ('y', 0.1)],
                                              format='image/tiff')
```

Results in the following URL:
https://geo.weather.gc.ca/geomet?version=2.0.1&request=GetCoverage&service=WCS&CoverageID=WEATHERADIO&format=image/tiff&subsettingcrs=epsg:4326&subset=x(-180,180)&subset=y(-90,90)&resolution=x(0.1)&resolution=y(0.1)

Related to #632
