### PR TITLE
Add python_requires to prevent pip installing this on py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name              = 'OWSLib',
       maintainer_email  = 'tomkralidis@gmail.com',
       url               = 'https://geopython.github.io/OWSLib',
       install_requires  = reqs,
+      python_requires   = '>=3.5',
       cmdclass          = {'test': PyTest},
       packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
       classifiers       = [


### PR DESCRIPTION
owslib 0.19.0 successfully installs on unsupported pythons, and errors later because it only supports python 3. 

This PR adds a conservative `python_requires` for 3.4.

Usage:

```
$ pip2 install .
Processing /Users/craigds/checkout/OWSLib
ERROR: OWSLib requires Python '>=3.4' but the running Python is 2.7.16
```