### PR TITLE
Py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.8"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
   - "3.8"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: LMXL=true
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env: LMXL=false
 sudo: false
 env:
   - LXML=true

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -9,9 +9,8 @@
 # Contact email: d.lowe@rl.ac.uk
 # =============================================================================
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 from owslib.etree import etree
-import cgi
 from owslib.util import Authentication, openURL
 
 
@@ -85,7 +84,7 @@ class WCSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 
@@ -145,7 +144,7 @@ class DescribeCoverageReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -1,9 +1,8 @@
-import cgi
 from io import StringIO
 from owslib.etree import etree
 from owslib.util import Authentication, openURL
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 
 
 def makeStringIO(strval):
@@ -38,7 +37,7 @@ class WFSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find("?") != -1:
-            qs = cgi.parse_qsl(service_url.split("?")[1])
+            qs = parse_qsl(service_url.split("?")[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -9,9 +9,8 @@ Set of functions, which are suitable for DescribeFeatureType parsing and
 generating layer schema description compatible with `fiona`
 """
 
-import cgi
 import sys
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 from owslib.etree import etree
 from owslib.namespaces import Namespaces
 from owslib.util import which_etree, findall, Authentication, openURL
@@ -145,7 +144,7 @@ def _get_describefeaturetype_url(url, version, typename):
 
     query_string = []
     if url.find("?") != -1:
-        query_string = cgi.parse_qsl(url.split("?")[1])
+        query_string = parse_qsl(url.split("?")[1])
 
     params = [x[0] for x in query_string]
 

--- a/owslib/map/common.py
+++ b/owslib/map/common.py
@@ -1,5 +1,4 @@
-import cgi
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 
 from owslib.etree import etree
 from owslib.util import strip_bom, Authentication, openURL
@@ -38,7 +37,7 @@ class WMSCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -1,7 +1,6 @@
-import cgi
 from owslib.etree import etree
 from datetime import datetime
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities
@@ -290,7 +289,7 @@ class SosCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -1,6 +1,5 @@
-import cgi
 from owslib.etree import etree
-from urllib.parse import urlencode
+from urllib.parse import urlencode, parse_qsl
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities200
@@ -307,7 +306,7 @@ class SosCapabilitiesReader(object):
         """
         qs = []
         if service_url.find('?') != -1:
-            qs = cgi.parse_qsl(service_url.split('?')[1])
+            qs = parse_qsl(service_url.split('?')[1])
 
         params = [x[0] for x in qs]
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -15,12 +15,11 @@ from datetime import datetime, timedelta
 import pytz
 from owslib.etree import etree, ParseError
 from owslib.namespaces import Namespaces
-from urllib.parse import urlsplit, urlencode, urlparse, parse_qs, urlunparse
+from urllib.parse import urlsplit, urlencode, urlparse, parse_qs, urlunparse, parse_qsl
 import copy
 
 from io import StringIO, BytesIO
 
-import cgi
 import re
 from copy import deepcopy
 import warnings
@@ -558,7 +557,7 @@ def build_get_url(base_url, params, overwrite=False):
 
     qs_base = []
     if base_url.find('?') != -1:
-        qs_base = cgi.parse_qsl(base_url.split('?')[1])
+        qs_base = parse_qsl(base_url.split('?')[1])
 
     qs_params = []
     for key, value in list(params.items()):


### PR DESCRIPTION
Added py38 to the test matrix and fixed `cgi.parse_qsl` deprecation.

Note that the current code is broken on Python 3.8 without these changes.