### PR TITLE
[Issue GeoNode/geonode#4276] try import xml before lxml

### DIFF
--- a/owslib/etree.py
+++ b/owslib/etree.py
@@ -26,15 +26,15 @@ def patch_well_known_namespaces(etree_module):
 
 # try to find lxml or elementtree
 try:
-    from lxml import etree
-    from lxml.etree import ParseError
-    ElementType = etree._Element
-except ImportError:
     import xml.etree.ElementTree as etree
     ElementType = etree.Element
     try:
         from xml.etree.ElementTree import ParseError
     except ImportError:
         from xml.parsers.expat import ExpatError as ParseError
+except ImportError:
+    from lxml import etree
+    from lxml.etree import ParseError
+    ElementType = etree._Element
 
 patch_well_known_namespaces(etree)


### PR DESCRIPTION
PR to resolve a test case in GeoNode as part of https://github.com/GeoNode/geonode/issues/4276. Changing the import order precedence of `xml.etree.ElementTree` to be ahead of `lxml.etree` fixes the issue where `lxml.etree._ElementTree` objects could not be pickled.