### PR TITLE
Remove redundant check on logging level

### DIFF
--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -126,8 +126,7 @@ class WebCoverageService_1_0_0(WCSBase):
         except StopIteration:
             base_url = self.url
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: base url of server: %s' % base_url)
+        log.debug('WCS 1.0.0 DEBUG: base url of server: %s' % base_url)
 
         # process kwargs
         request = {'version': self.version, 'request': 'GetCoverage', 'service': 'WCS'}
@@ -161,8 +160,7 @@ class WebCoverageService_1_0_0(WCSBase):
 
         # encode and request
         data = urlencode(request)
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s' % data)
+        log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s' % data)
 
         u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -190,8 +190,7 @@ class WebCoverageService_2_0_0(WCSBase):
         except StopIteration:
             base_url = self.url
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("WCS 2.0.0 DEBUG: base url of server: %s" % base_url)
+        log.debug("WCS 2.0.0 DEBUG: base url of server: %s" % base_url)
 
         request = {"version": self.version, "request": "GetCoverage", "service": "WCS"}
         assert len(identifier) > 0
@@ -220,8 +219,7 @@ class WebCoverageService_2_0_0(WCSBase):
         if sizes:
             log.debug('Adding vendor-specific SIZE parameter.')
             data += param_list_to_url_string(sizes, 'size')
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("WCS 2.0.0 DEBUG: Second part of URL: %s" % data)
+        log.debug("WCS 2.0.0 DEBUG: Second part of URL: %s" % data)
 
         u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -190,8 +190,7 @@ class WebCoverageService_2_0_1(WCSBase):
         except StopIteration:
             base_url = self.url
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("WCS 2.0.1 DEBUG: base url of server: %s" % base_url)
+        log.debug("WCS 2.0.1 DEBUG: base url of server: %s" % base_url)
 
         request = {"version": self.version, "request": "GetCoverage", "service": "WCS"}
         assert len(identifier) > 0
@@ -221,8 +220,7 @@ class WebCoverageService_2_0_1(WCSBase):
             log.debug('Adding vendor-specific SIZE parameter.')
             data += param_list_to_url_string(sizes, 'size')
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("WCS 2.0.1 DEBUG: Second part of URL: %s" % data)
+        log.debug("WCS 2.0.1 DEBUG: Second part of URL: %s" % data)
 
         u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -115,8 +115,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         else:
             auth = Authentication()
         super(WebFeatureService_2_0_0, self).__init__(auth)
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("building WFS %s" % url)
+        log.debug("building WFS %s" % url)
         self.url = url
         self.version = version
         self.timeout = timeout
@@ -288,8 +287,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 startindex,
                 sortby,
             )
-            if log.isEnabledFor(logging.DEBUG):
-                log.debug("GetFeature WFS GET url %s" % url)
+            log.debug("GetFeature WFS GET url %s" % url)
         else:
             (url, data) = self.getPOSTGetFeatureRequest()
 


### PR DESCRIPTION
log.debug will itself check the logging level. For one line logging it seems a bit redundant to do the check again.