### PR TITLE
Fix WFS get_schema when typename doubles as attributename

### DIFF
--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -51,12 +51,7 @@ def get_schema(
 
     if ":" in typename:
         typename = typename.split(":")[1]
-    type_element = findall(
-        root,
-        "{%s}element" % XS_NAMESPACE,
-        attribute_name="name",
-        attribute_value=typename,
-    )[0]
+    type_element = root.find("./{%s}element" % XS_NAMESPACE)
     complex_type = type_element.attrib["type"].split(":")[1]
     elements = _get_elements(complex_type, root)
     nsmap = None

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -46,8 +46,8 @@ def get_schema(
     else:
         auth = Authentication(username, password)
     url = _get_describefeaturetype_url(url, version, typename)
-    res = openURL(url, timeout=timeout, headers=headers, auth=auth)
-    root = etree.fromstring(res.read())
+    root = _get_remote_describefeaturetype(url, timeout=timeout,
+                                          headers=headers, auth=auth)
 
     if ":" in typename:
         typename = typename.split(":")[1]
@@ -159,3 +159,16 @@ def _get_describefeaturetype_url(url, version, typename):
 
     urlqs = urlencode(tuple(query_string))
     return url.split("?")[0] + "?" + urlqs
+
+
+def _get_remote_describefeaturetype(url, timeout, headers, auth):
+    """Gets the DescribeFeatureType response from the remote server.
+
+    :param str url: url of the service
+    :param int timeout: request timeout
+    :param Authentication auth: instance of owslib.util.Authentication
+
+    :return etree.Element with the root of the DescribeFeatureType response
+    """
+    res = openURL(url, timeout=timeout, headers=headers, auth=auth)
+    return etree.fromstring(res.read())

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -47,7 +47,7 @@ def get_schema(
         auth = Authentication(username, password)
     url = _get_describefeaturetype_url(url, version, typename)
     root = _get_remote_describefeaturetype(url, timeout=timeout,
-                                          headers=headers, auth=auth)
+                                           headers=headers, auth=auth)
 
     if ":" in typename:
         typename = typename.split(":")[1]

--- a/tests/resources/wfs_schema_dov_boringen.xml
+++ b/tests/resources/wfs_schema_dov_boringen.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:dov-pub="http://dov.vlaanderen.be/ocdov/dov-pub" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" targetNamespace="http://dov.vlaanderen.be/ocdov/dov-pub">
+  <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="https://www.dov.vlaanderen.be/geoserver/schemas/gml/3.1.1/base/gml.xsd"/>
+  <xsd:complexType name="BoringenType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="id" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="boornummer" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="fiche" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="rapport" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="diepte_tot_m" nillable="true" type="xsd:decimal"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="datum_aanvang" nillable="true" type="xsd:date"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="namen" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="putnummer" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="X_mL72" nillable="true" type="xsd:double"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="Y_mL72" nillable="true" type="xsd:double"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="Z_mTAW" nillable="true" type="xsd:decimal"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="gemeente" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="uitvoerder" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="doel" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="methode" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="erkenning" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="opdrachtgever" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="informele_stratigrafie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="formele_stratigrafie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="lithologische_beschrijving" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="gecodeerde_lithologie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="hydrogeologische_stratigrafie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="quartaire_stratigrafie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geotechnische_codering" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="informele_hydrostratigrafie" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="doorheen_quartair" nillable="true" type="xsd:boolean"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="dikte_quartair" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="tertiair_onder_quartair" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="opdrachten" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geom" nillable="true" type="gml:PointPropertyType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="Boringen" substitutionGroup="gml:_Feature" type="dov-pub:BoringenType"/>
+</xsd:schema>

--- a/tests/resources/wfs_schema_dov_hhz.xml
+++ b/tests/resources/wfs_schema_dov_hhz.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" xmlns:gw_varia="http://dov.vlaanderen.be/grondwater/gw_varia" elementFormDefault="qualified" targetNamespace="http://dov.vlaanderen.be/grondwater/gw_varia">
+  <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="https://www.dov.vlaanderen.be/geoserver/schemas/gml/3.1.1/base/gml.xsd"/>
+  <xsd:complexType name="hhzType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="id" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="hhz_naam" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="opp_m2" nillable="true" type="xsd:long"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="hhz" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geom" nillable="true" type="gml:GeometryPropertyType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="hhz" substitutionGroup="gml:_Feature" type="gw_varia:hhzType"/>
+</xsd:schema>

--- a/tests/test_wfs_schema.py
+++ b/tests/test_wfs_schema.py
@@ -1,0 +1,167 @@
+import pytest
+
+import owslib
+from owslib.etree import etree
+from owslib.wfs import WebFeatureService
+from tests.utils import service_ok
+
+WFS_SERVICE_URL = 'https://www.dov.vlaanderen.be/geoserver/wfs?request=GetCapabilities'
+
+
+@pytest.fixture
+def mp_wfs_110(monkeypatch):
+    """Monkeypatch the call to the remote GetCapabilities request of WFS
+    version 1.1.0.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+
+    """
+    def read(*args, **kwargs):
+        with open('tests/resources/wfs_dov_getcapabilities_110.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(
+        owslib.feature.common.WFSCapabilitiesReader, 'read', read)
+
+
+@pytest.fixture()
+def mp_remote_describefeaturetype(monkeypatch):
+    """Monkeypatch the call to the remote DescribeFeatureType request.
+
+    Returns a standard DescribeFeatureType response.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+
+    """
+    def __remote_describefeaturetype(*args, **kwargs):
+        with open('tests/resources/wfs_schema_dov_boringen.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(owslib.feature.schema,
+                        '_get_remote_describefeaturetype',
+                        __remote_describefeaturetype)
+
+
+@pytest.fixture()
+def mp_remote_describefeaturetype_typename_eq_attribute(monkeypatch):
+    """Monkeypatch the call to the remote DescribeFeatureType request.
+
+    Returns a DescribeFeatureType response where the typeName equals one of
+    the attributes.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+
+    """
+    def __remote_describefeaturetype(*args, **kwargs):
+        with open('tests/resources/wfs_schema_dov_hhz.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(owslib.feature.schema,
+                        '_get_remote_describefeaturetype',
+                        __remote_describefeaturetype)
+
+
+class TestOnline(object):
+    """Class grouping online tests for the WFS get_schema method."""
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(WFS_SERVICE_URL),
+                        reason="WFS service is unreachable")
+    @pytest.mark.parametrize("wfs_version", ["1.0.0", "1.1.0", "2.0.0"])
+    def test_get_schema(self, wfs_version):
+        """Test the get_schema method for a standard schema."""
+        wfs = WebFeatureService(WFS_SERVICE_URL, version=wfs_version)
+        schema = wfs.get_schema('dov-pub:Boringen')
+
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(WFS_SERVICE_URL),
+                        reason="WFS service is unreachable")
+    @pytest.mark.parametrize("wfs_version", ["1.0.0", "1.1.0", "2.0.0"])
+    def test_schema_result(self, wfs_version):
+        """Test whether the output from get_schema is a wellformed dictionary."""
+        wfs = WebFeatureService(WFS_SERVICE_URL, version=wfs_version)
+        schema = wfs.get_schema('dov-pub:Boringen')
+        assert isinstance(schema, dict)
+
+        assert 'properties' in schema or 'geometry' in schema
+
+        if 'geometry' in schema:
+            assert 'geometry_column' in schema
+
+        if 'properties' in schema:
+            assert isinstance(schema['properties'], dict)
+
+
+class TestOffline(object):
+    """Class grouping offline tests for the WFS get_schema method."""
+    def test_get_schema(self, mp_wfs_110, mp_remote_describefeaturetype):
+        """Test the get_schema method for a standard schema.
+
+        Parameters
+        ----------
+        mp_wfs_110 : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to the remote DescribeFeatureType request.
+        """
+        wfs110 = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
+        schema = wfs110.get_schema('dov-pub:Boringen')
+
+    def test_schema_result(self, mp_wfs_110, mp_remote_describefeaturetype):
+        """Test whether the output from get_schema is a wellformed dictionary.
+
+        Parameters
+        ----------
+        mp_wfs_110 : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to the remote DescribeFeatureType request.
+        """
+        wfs110 = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
+        schema = wfs110.get_schema('dov-pub:Boringen')
+        assert isinstance(schema, dict)
+
+        assert 'properties' in schema or 'geometry' in schema
+
+        if 'geometry' in schema:
+            assert 'geometry_column' in schema
+
+        if 'properties' in schema:
+            assert isinstance(schema['properties'], dict)
+
+    def test_get_schema_typename_eq_attribute(
+            self, mp_wfs_110,
+            mp_remote_describefeaturetype_typename_eq_attribute):
+        """Test the get_schema method for a schema where the typeName equals
+        one of the attributes.
+
+        Parameters
+        ----------
+        mp_wfs_110 : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to the remote DescribeFeatureType
+            request.
+        """
+        wfs110 = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
+        schema = wfs110.get_schema('gw_varia:hhz')


### PR DESCRIPTION
The type_element we want is the one directly under the schema root. The first result from findall() where 'name="typename"' can give a wrong result when the typename doubles as the name of an attribute.

Includes tests for both the normal case as well as this corner case.

Fixes #645 