### PR TITLE
Tests: replace service URLs with working versions.

### DIFF
--- a/tests/test_remote_metadata.py
+++ b/tests/test_remote_metadata.py
@@ -7,8 +7,11 @@ from owslib.wms import WebMapService
 from tests.utils import service_ok
 
 
-WMS_SERVICE_URL = 'https://www.dov.vlaanderen.be/geoserver/gw_meetnetten/wms'
-WFS_SERVICE_URL = 'https://www.dov.vlaanderen.be/geoserver/gw_meetnetten/wfs'
+WMS_SERVICE_URL = 'https://www.dov.vlaanderen.be/geoserver/gw_meetnetten/' \
+                  'wms?request=GetCapabilities'
+
+WFS_SERVICE_URL = 'https://www.dov.vlaanderen.be/geoserver/gw_meetnetten/' \
+                  'wfs?request=GetCapabilities'
 
 
 @pytest.fixture


### PR DESCRIPTION
The response code from resolving the base endpoint (400) resulted in the
service wrongly being marked as unavailable.