### PR TITLE
Tests: use HEAD instead of GET in service_ok

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,7 +83,7 @@ def sorted_url_query(url):
 
 def service_ok(url, timeout=5):
     try:
-        resp = requests.get(url, timeout=timeout)
+        resp = requests.head(url, allow_redirects=True, timeout=timeout)
         if 'html' in resp.headers['content-type']:
             ok = False
         else:


### PR DESCRIPTION
Since we only rely on the status code and the headers to determine if a service is working or not, it is not needed to perform a GET (resulting in downloads of data we don't need).

Instead we could use a HEAD request. Since Requests does not follow redirects by default when using HEAD [[1]], we enable it explicitly using allow_redirects.

[1]: https://2.python-requests.org/en/master/user/quickstart/#redirection-and-history