### PR TITLE
[OGC API - Common] fix api media type handling (#625) (#630)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dateutil>=1.5
 pytz
 requests>=1.0
 pyproj
+pyyaml

--- a/tests/test_ogcapi_features_ldproxy.py
+++ b/tests/test_ogcapi_features_ldproxy.py
@@ -19,6 +19,8 @@ def test_ogcapi_features_ldproxy():
     conformance = w.conformance()
     assert len(conformance['conformsTo']) == 5
 
-    api = w.api()
-    assert api['components']['parameters'] is not None
-    assert api['paths'] is not None
+    # TODO: remove pytest.raises once ldproxy is fixed/updated
+    with pytest.raises(RuntimeError):
+        api = w.api()
+        assert api['components']['parameters'] is not None
+        assert api['paths'] is not None

--- a/tests/test_ogcapi_features_ldproxy.py
+++ b/tests/test_ogcapi_features_ldproxy.py
@@ -8,7 +8,6 @@ SERVICE_URL = 'https://www.ldproxy.nrw.de/rest/services/kataster/?f=json'
 
 
 @pytest.mark.online
-@pytest.mark.skip(reason='api() call fails. See issue #625')
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason='service is unreachable')
 def test_ogcapi_features_ldproxy():


### PR DESCRIPTION
cc @justb4 

Fixes #630 and #625 

@cehbrecht Note: running the relevant test against `tests/test_ogcapi_features_*.py` yields no errors, but warns:

```
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.7.4, pytest-5.3.2, py-1.8.1, pluggy-0.13.1 -- /Users/tomkralidis/Dev/OWSLib/bin/python3
cachedir: .pytest_cache
rootdir: /Users/tomkralidis/Dev/OWSLib/OWSLib, inifile: tox.ini
plugins: cov-2.8.1
collected 1 item                                                                                                                                                                                           

tests/test_ogcapi_features_pygeoapi.py::test_ogcapi_features_pygeoapi PASSED

============================================================================================= warnings summary =============================================================================================
/Users/tomkralidis/Dev/OWSLib/lib/python3.7/site-packages/_pytest/mark/structures.py:327
  /Users/tomkralidis/Dev/OWSLib/lib/python3.7/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.online - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```