### PR TITLE
WPS: support multiple languages

### DIFF
--- a/tests/test_wps_describeprocess_language.py
+++ b/tests/test_wps_describeprocess_language.py
@@ -1,0 +1,18 @@
+from owslib.wps import WebProcessingService
+import owslib.wps
+
+
+def test_wps_describeprocess_language(monkeypatch):
+
+    def mock_open_url(*args, **kwargs):
+        assert 'language=fr-CA' in args[1]
+
+        class FakeResponse:
+            def read(self):
+                return b'<xml></xml>'
+
+        return FakeResponse()
+
+    monkeypatch.setattr(owslib.wps, "openURL", mock_open_url)
+    wps = WebProcessingService('http://www.example.com', language='fr-CA', skip_caps=True)
+    wps.describeprocess('all')

--- a/tests/test_wps_execute_language.py
+++ b/tests/test_wps_execute_language.py
@@ -1,0 +1,31 @@
+from owslib.wps import WebProcessingService
+import owslib.wps
+
+
+def test_wps_execute_language(monkeypatch):
+
+    def raise_on_log_error(*a):
+        """Make sure the errors are raised, not only caught and logged"""
+        raise AssertionError
+
+    monkeypatch.setattr(owslib.wps.log, "error", raise_on_log_error)
+
+    monkeypatch.setattr(owslib.wps.WPSExecution, "parseResponse", lambda *a: None)
+    wps = WebProcessingService('http://www.example.com', language='fr-CA', skip_caps=True)
+    execution = wps.execute('test', [], response=b'<xml></xml>')
+
+    assert b'language="fr-CA"' in execution.request
+
+    def mock_open_url(*args, **kwargs):
+        assert 'language=fr-CA' in args[1]
+
+        class FakeResponse:
+            def read(self):
+                return b'<xml></xml>'
+
+        return FakeResponse()
+
+    monkeypatch.setattr(owslib.wps, "openURL", mock_open_url)
+
+    execution.status = 'ProcessSucceeded'
+    execution.checkStatus(url='http://www.example.com', response=None, sleepSecs=0)

--- a/tests/test_wps_getcapabilities_language.py
+++ b/tests/test_wps_getcapabilities_language.py
@@ -1,0 +1,17 @@
+from owslib.wps import WebProcessingService
+import owslib.wps
+
+
+def test_wps_getcapabilities_language(monkeypatch):
+
+    def mock_open_url(*args, **kwargs):
+        assert 'language=fr-CA' in args[1]
+
+        class FakeResponse:
+            def read(self):
+                return b'<xml></xml>'
+
+        return FakeResponse()
+
+    monkeypatch.setattr(owslib.wps, "openURL", mock_open_url)
+    WebProcessingService('http://www.example.com', language='fr-CA')


### PR DESCRIPTION
Add a language parameter to the `owslib.wps.WebProcessingService` class. 

This parameter is used in GetCapabilities, DescribeProcess and Execute requests to include the `language` attribute in the query string and the xml POST requests.