### PR TITLE
wps: parse Languages section in GetCapabilities

### DIFF
--- a/tests/test_wps_getcapabilities_language.py
+++ b/tests/test_wps_getcapabilities_language.py
@@ -1,5 +1,6 @@
 from owslib.wps import WebProcessingService
 import owslib.wps
+from owslib.etree import etree
 
 
 def test_wps_getcapabilities_language(monkeypatch):
@@ -15,3 +16,21 @@ def test_wps_getcapabilities_language(monkeypatch):
 
     monkeypatch.setattr(owslib.wps, "openURL", mock_open_url)
     WebProcessingService('http://www.example.com', language='fr-CA')
+
+
+def test_wps_getcapabilities_parse_languages():
+    xml = """
+    <wps:Languages xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows">
+        <wps:Default>
+            <ows:Language>en-US</ows:Language>
+        </wps:Default>
+        <wps:Supported>
+            <ows:Language>en-US</ows:Language>
+            <ows:Language>fr-CA</ows:Language>
+        </wps:Supported>
+    </wps:Languages>
+    """
+    element = etree.fromstring(xml)
+    languages = owslib.wps.Languages(element)
+    assert languages.default == 'en-US'
+    assert languages.supported == ['en-US', 'fr-CA']


### PR DESCRIPTION
An example of using the added `WebProcessingService.languages` attribute:

```python
>>> from owslib.wps import WebProcessingService
>>> wps = WebProcessingService(url='...')
>>> wps.language is None  # language is None when not specified (current behaviour)
True
>>> wps.languages.default  # check the default language
'en-US'
>>> wps.languages.supported  # check the supported languages
['en-US', 'fr-CA']
>>> wps.language = 'fr-CA'  # set from the supported languages list
```