### PR TITLE
fix for cartopy/wmts examples, solves #619

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -639,7 +639,7 @@ class TileMatrixSetLink(object):
                         if tml.tilematrix in tilematrixlimits:
                             msg = ('TileMatrixLimits with tileMatrix "%s" '
                                    'already exists' % tml.tilematrix)
-                            raise KeyError(msg)
+                            warnings.warn(msg, RuntimeWarning)
                         tilematrixlimits[tml.tilematrix] = tml
 
                 links.append(TileMatrixSetLink(uri, tilematrixlimits))


### PR DESCRIPTION
lot of examples out there making use of NASA's service (https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi) are broken. Based on chronology, I think it's related to changes in the WMTS service.
The problem OWSLib code is 5 years old and examples broke a few month ago.

Replacing the error by a warning solved the problem and gives the expected results.