### PR TITLE
drop last bits of python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -1,19 +1,7 @@
-from io import StringIO
 from owslib.etree import etree
 from owslib.util import Authentication, openURL
 
 from urllib.parse import urlencode, parse_qsl
-
-
-def makeStringIO(strval):
-    """
-    Helper method to make sure the StringIO being returned will work.
-
-    Differences between Python 2.7/3.x mean we have a lot of cases to handle.
-
-    TODO: skipped Python 2.x support. Is this still necessary?
-    """
-    return StringIO(strval.decode())
 
 
 class WFSCapabilitiesReader(object):

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -8,6 +8,7 @@
 
 from owslib import util
 
+from io import BytesIO
 from urllib.parse import urlencode
 from owslib.util import (
     testXMLValue,
@@ -27,7 +28,6 @@ from owslib.feature.schema import get_schema
 from owslib.feature.common import (
     WFSCapabilitiesReader,
     AbstractContentMetadata,
-    makeStringIO,
 )
 
 import pyproj
@@ -308,16 +308,16 @@ class WebFeatureService_1_0_0(object):
                 tree = etree.fromstring(data)
             except BaseException:
                 # Not XML
-                return makeStringIO(data)
+                return BytesIO(data)
             else:
                 if tree.tag == "{%s}ServiceExceptionReport" % OGC_NAMESPACE:
                     se = tree.find(nspath("ServiceException", OGC_NAMESPACE))
                     raise ServiceException(str(se.text).strip())
                 else:
-                    return makeStringIO(data)
+                    return BytesIO(data)
         else:
             if have_read:
-                return makeStringIO(data)
+                return BytesIO(data)
             return u
 
     def getOperationByName(self, name):

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -7,6 +7,7 @@
 # Contact email: tomkralidis@gmail.com
 # =============================================================================
 
+from io import BytesIO
 from urllib.parse import urlencode
 from owslib.util import (
     testXMLValue,
@@ -33,7 +34,6 @@ from owslib.feature import WebFeatureService_
 from owslib.feature.common import (
     WFSCapabilitiesReader,
     AbstractContentMetadata,
-    makeStringIO,
 )
 from owslib.namespaces import Namespaces
 from owslib.util import log, openURL
@@ -346,16 +346,16 @@ class WebFeatureService_1_1_0(WebFeatureService_):
                 tree = etree.fromstring(data)
             except BaseException:
                 # Not XML
-                return makeStringIO(data)
+                return BytesIO(data)
             else:
                 if tree.tag == "{%s}ServiceExceptionReport" % namespaces["ogc"]:
                     se = tree.find(nspath_eval("ServiceException", namespaces["ogc"]))
                     raise ServiceException(str(se.text).strip())
                 else:
-                    return makeStringIO(data)
+                    return BytesIO(data)
         else:
             if have_read:
-                return makeStringIO(data)
+                return BytesIO(data)
             return u
 
     def getOperationByName(self, name):

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -18,11 +18,11 @@ from owslib.feature import WebFeatureService_
 from owslib.feature.common import (
     WFSCapabilitiesReader,
     AbstractContentMetadata,
-    makeStringIO,
 )
 from owslib.namespaces import Namespaces
 
 # other imports
+from io import BytesIO
 from urllib.parse import urlencode
 
 import logging
@@ -313,16 +313,16 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 tree = etree.fromstring(data)
             except BaseException:
                 # Not XML
-                return makeStringIO(data)
+                return BytesIO(data)
             else:
                 if tree.tag == "{%s}ServiceExceptionReport" % OGC_NAMESPACE:
                     se = tree.find(nspath("ServiceException", OGC_NAMESPACE))
                     raise ServiceException(str(se.text).strip())
                 else:
-                    return makeStringIO(data)
+                    return BytesIO(data)
         else:
             if have_read:
-                return makeStringIO(data)
+                return BytesIO(data)
             return u
 
     def getpropertyvalue(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,3 @@ pytest>=3.6
 pytest-cov
 Pillow
 tox
-# install libraries to stop SSL related InsecurePlatformWarning
-pyopenssl        ; python_version < '2.7.9'
-ndg-httpsclient  ; python_version < '2.7.9'
-pyasn1           ; python_version < '2.7.9'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name              = 'OWSLib',
       maintainer_email  = 'tomkralidis@gmail.com',
       url               = 'https://geopython.github.io/OWSLib',
       install_requires  = reqs,
-      python_requires   = '>=3.5',
+      python_requires   = '>=3.6',
       cmdclass          = {'test': PyTest},
       packages          = find_packages(exclude=["docs", "etc", "examples", "tests"]),
       classifiers       = [

--- a/tests/doctests/wfs_MapServerWFSFeature.txt
+++ b/tests/doctests/wfs_MapServerWFSFeature.txt
@@ -7,7 +7,7 @@ Test the getfeature method
 
     >>> wfs = WebFeatureService('http://nsidc.org/cgi-bin/atlas_south?', version='1.0.0')
     >>> response = wfs.getfeature(typename=['glaciers'], maxfeatures=5)
-    >>> response.read().find('<wfs:FeatureCollection') > 0
+    >>> response.read().find(b'<wfs:FeatureCollection') > 0
     True
 
 Handle service exception


### PR DESCRIPTION
This PR is a bit more complicated than it looks and you may delay the merge until OWSLib is ready to drop Python 3.5 support too.

The reason is that, with this PR, some responses are no longer converted to `str`. The main advantage is that everything is bytes in a way we expected from Python 3. The downside is that Python 3.5 `json` module cannot handle bytes, that started in 3.6, and some users may still expect `str` rather than bytes in their workflow. (See the docs test where I had to add the `b""` as an example of that.)