### PR TITLE
Fix pyproj deprecation

### DIFF
--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -395,14 +395,16 @@ class ContentMetadata(AbstractContentMetadata):
         self.boundingBoxWGS84 = None
 
         if b is not None and srs is not None:
-            wgs84 = pyproj.Proj(init="epsg:4326")
+            wgs84 = pyproj.Proj("epsg:4326")
             try:
-                src_srs = pyproj.Proj(init=srs.text)
+                src_srs = pyproj.Proj(srs.text)
                 mincorner = pyproj.transform(
-                    src_srs, wgs84, b.attrib["minx"], b.attrib["miny"]
+                    src_srs, wgs84, b.attrib["minx"], b.attrib["miny"],
+                    always_xy=True,
                 )
                 maxcorner = pyproj.transform(
-                    src_srs, wgs84, b.attrib["maxx"], b.attrib["maxy"]
+                    src_srs, wgs84, b.attrib["maxx"], b.attrib["maxy"],
+                    always_xy=True,
                 )
 
                 self.boundingBoxWGS84 = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil>=1.5
 pytz
 requests>=1.0
-pyproj
+pyproj >=2
 pyyaml


### PR DESCRIPTION
In this PR:

- fixed the deprecated syntax in pyproj to avoid future breakages;
- be explicit about `always_xy=True` to prevent lat, lon vs lon, lat confusions;
- drop pyproj <2 to make it easier to support modern pyproj and proj without workaround.

If supporting pyproj 1.9.* is important we can add a few if-clauses here.