### PR TITLE
fix param_list_to_url_string() util function and refactor

### DIFF
--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -18,7 +18,7 @@ import os
 import errno
 
 import logging
-from owslib.util import log
+from owslib.util import log, makeString
 
 
 #  function to save writing out WCS namespace in full each time
@@ -94,14 +94,6 @@ class WebCoverageService_1_0_0(WCSBase):
             items.append((item, self.contents[item]))
         return items
 
-    def __makeString(self, value):
-        # using repr unconditionally breaks things in some circumstances if a value is already a string
-        if type(value) is not str:
-            sval = repr(value)
-        else:
-            sval = value
-        return sval
-
     def getCoverage(self, identifier=None, bbox=None, time=None, format=None, crs=None, width=None, height=None,
                     resx=None, resy=None, resz=None, parameter=None, method='Get', **kwargs):
         """Request and return a coverage from the WCS as a file-like object
@@ -134,7 +126,7 @@ class WebCoverageService_1_0_0(WCSBase):
         request['Coverage'] = identifier
         # request['identifier'] = ','.join(identifier)
         if bbox:
-            request['BBox'] = ','.join([self.__makeString(x) for x in bbox])
+            request['BBox'] = ','.join([makeString(x) for x in bbox])
         else:
             request['BBox'] = None
         if time:

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -113,14 +113,6 @@ class WebCoverageService_2_0_0(WCSBase):
             items.append((item, self.contents[item]))
         return items
 
-    def __makeString(self, value):
-        # using repr unconditionally breaks things in some circumstances if a value is already a string
-        if type(value) is not str:
-            sval = repr(value)
-        else:
-            sval = value
-        return sval
-
     def getCoverage(
         self,
         identifier=None,
@@ -223,16 +215,6 @@ class WebCoverageService_2_0_0(WCSBase):
 
         u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
-
-    def is_number(self, s):
-        """simple helper to test if value is number as requests with numbers dont
-        need quote marks
-        """
-        try:
-            float(s)
-            return True
-        except ValueError:
-            return False
 
     def getOperationByName(self, name):
         """Return a named operation item."""

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -113,14 +113,6 @@ class WebCoverageService_2_0_1(WCSBase):
             items.append((item, self.contents[item]))
         return items
 
-    def __makeString(self, value):
-        # using repr unconditionally breaks things in some circumstances if a value is already a string
-        if type(value) is not str:
-            sval = repr(value)
-        else:
-            sval = value
-        return sval
-
     def getCoverage(
         self,
         identifier=None,
@@ -224,16 +216,6 @@ class WebCoverageService_2_0_1(WCSBase):
 
         u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
-
-    def is_number(self, s):
-        """simple helper to test if value is number as requests with numbers dont
-        need quote marks
-        """
-        try:
-            float(s)
-            return True
-        except ValueError:
-            return False
 
     def getOperationByName(self, name):
         """Return a named operation item."""

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -786,22 +786,43 @@ def datetime_from_ansi(ansi):
     return datumOrigin + timedelta(ansi)
 
 
-def param_list_to_url_string(self, param_list, param_name):
-    """Converts list of tuples for certain WCS GetCoverage keyword arguments (subsets, resolutions, sizes) to a url-enconded
-    string
+def is_number(s):
+    """simple helper to test if value is number as requests with numbers don't
+    need quote marks
+    """
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def makeString(value):
+    # using repr unconditionally breaks things in some circumstances if a
+    # value is already a string
+    if type(value) is not str:
+        sval = repr(value)
+    else:
+        sval = value
+    return sval
+
+
+def param_list_to_url_string(param_list, param_name):
+    """Converts list of tuples for certain WCS GetCoverage keyword arguments
+    (subsets, resolutions, sizes) to a url-encoded string
     """
     string = ''
     for param in param_list:
         if len(param) > 2:
-            if not self.is_number(param[1]):
-                string += "&" + urlencode({param_name: param[0] + '("' + self.__makeString(param[1]) + '","' + self.__makeString(param[2]) + '")'})  # noqa
+            if not is_number(param[1]):
+                string += "&" + urlencode({param_name: param[0] + '("' + makeString(param[1]) + '","' + makeString(param[2]) + '")'})  # noqa
             else:
-                string += "&" + urlencode({param_name: param[0] + "(" + self.__makeString(param[1]) + "," + self.__makeString(param[2]) + ")"})  # noqa
+                string += "&" + urlencode({param_name: param[0] + "(" + makeString(param[1]) + "," + makeString(param[2]) + ")"})  # noqa
         else:
-            if not self.is_number(param[1]):
-                string += "&" + urlencode({param_name: param[0] + '("' + self.__makeString(param[1]) + '")'})
+            if not is_number(param[1]):
+                string += "&" + urlencode({param_name: param[0] + '("' + makeString(param[1]) + '")'})  # noqa
             else:
-                string += "&" + urlencode({param_name: param[0] + "(" + self.__makeString(param[1]) + ")"})
+                string += "&" + urlencode({param_name: param[0] + "(" + makeString(param[1]) + ")"})  # noqa
     return string
 
 


### PR DESCRIPTION
The `params_list_to_url_string` in `owslib/util.py` contains an reference to `self` in its arguments and within the function itself. This was a remnant of when the function was a method of the `WebCoverageService_2_0_1` class during my initial implementation.

This PR removes this error and also moves some of the helper methods in the various WCS implementations into `owslib/util.py` in order to avoid code repetition between the different WCS versions.

See also #662.
 
cc @tomkralidis.