### PR TITLE
Fix reading style in getCap

### DIFF
--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -582,7 +582,7 @@ class ContentMetadata(AbstractContentMetadata):
             name = s.find(nspath('Name', WMS_NAMESPACE))
             title = s.find(nspath('Title', WMS_NAMESPACE))
             if name is None or title is None:
-                #raise ValueError('%s missing name or title' % (s,))
+                # raise ValueError('%s missing name or title' % (s,))
                 continue
             style = {'title': title.text}
             # legend url

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -582,7 +582,8 @@ class ContentMetadata(AbstractContentMetadata):
             name = s.find(nspath('Name', WMS_NAMESPACE))
             title = s.find(nspath('Title', WMS_NAMESPACE))
             if name is None or title is None:
-                raise ValueError('%s missing name or title' % (s,))
+                #raise ValueError('%s missing name or title' % (s,))
+                continue
             style = {'title': title.text}
             # legend url
             legend = s.find(nspath('LegendURL/OnlineResource', WMS_NAMESPACE))


### PR DESCRIPTION
When a style is found without "title" or "name", a ValueError is raised 

However, the style should only be ignored, otherwise it's too restrictive for some services
(ex : https://inspire.cadastre.gouv.fr/scpc/31555.wms?service=WMS&request=GetCapabilities)