### PR TITLE
Add possibility to specify headers for WCS requests

### DIFF
--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -38,8 +38,8 @@ class WebCoverageService_1_0_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self, url, xml, cookies, auth=None):
-        super(WebCoverageService_1_0_0, self).__init__(auth)
+    def __init__(self, url, xml, cookies, auth=None, headers=None):
+        super(WebCoverageService_1_0_0, self).__init__(auth=auth, headers=headers)
         self.version = '1.0.0'
         self.url = url
         self.cookies = cookies

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -51,8 +51,8 @@ class WebCoverageService_1_1_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self, url, xml, cookies, auth=None):
-        super(WebCoverageService_1_1_0, self).__init__(auth=auth)
+    def __init__(self, url, xml, cookies, auth=None, headers=None):
+        super(WebCoverageService_1_1_0, self).__init__(auth=auth, headers=headers)
 
         self.url = url
         self.cookies = cookies

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -53,8 +53,8 @@ class WebCoverageService_2_0_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self, url, xml, cookies, auth=None):
-        super(WebCoverageService_2_0_0, self).__init__(auth=auth)
+    def __init__(self, url, xml, cookies, auth=None, headers=None):
+        super(WebCoverageService_2_0_0, self).__init__(auth=auth, headers=headers)
         self.version = "2.0.0"
         self.url = url
         self.cookies = cookies

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -53,14 +53,14 @@ class WebCoverageService_2_0_1(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self, url, xml, cookies, auth=None):
-        super(WebCoverageService_2_0_1, self).__init__(auth=auth)
+    def __init__(self, url, xml, cookies, auth=None, headers=None):
+        super(WebCoverageService_2_0_1, self).__init__(auth=auth, headers=headers)
         self.version = "2.0.1"
         self.url = url
         self.cookies = cookies
         self.ows_common = OwsCommon(version="2.0.1")
         # initialize from saved capability document or access the server
-        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth)
+        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth, self.headers)
         if xml:
             self._capabilities = reader.readString(xml)
         else:

--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -33,7 +33,7 @@ class ServiceException(Exception):
 class WCSBase(object):
     """Base class to be subclassed by version dependent WCS classes. Provides 'high-level'
     version independent methods"""
-    def __new__(self, url, xml, cookies, auth=None):
+    def __new__(self, url, xml, cookies, auth=None, headers=None):
         """ overridden __new__ method
 
         @type url: string
@@ -44,12 +44,13 @@ class WCSBase(object):
         @return: inititalised WCSBase object
         """
         obj = object.__new__(self)
-        obj.__init__(url, xml, cookies, auth=auth)
+        obj.__init__(url, xml, cookies, auth=auth, headers=headers)
         self.cookies = cookies
         self._describeCoverage = {}  # cache for DescribeCoverage responses
         return obj
 
-    def __init__(self, auth=None):
+    def __init__(self, auth=None, headers=None):
+        self.headers = headers
         self.auth = auth or Authentication()
 
     def getDescribeCoverage(self, identifier):
@@ -65,7 +66,7 @@ class WCSCapabilitiesReader(object):
     """Read and parses WCS capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version=None, cookies=None, auth=None):
+    def __init__(self, version=None, cookies=None, auth=None, headers=None):
         """Initialize
         @type version: string
         @param version: WCS Version parameter e.g '1.0.0'
@@ -73,6 +74,7 @@ class WCSCapabilitiesReader(object):
         self.version = version
         self._infoset = None
         self.cookies = cookies
+        self.headers = headers
         self.auth = auth or Authentication()
 
     def capabilities_url(self, service_url):
@@ -109,7 +111,7 @@ class WCSCapabilitiesReader(object):
         @return: An elementtree tree representation of the capabilities document
         """
         request = self.capabilities_url(service_url)
-        u = openURL(request, timeout=timeout, cookies=self.cookies, auth=self.auth)
+        u = openURL(request, timeout=timeout, cookies=self.cookies, auth=self.auth, headers=self.headers)
         return etree.fromstring(u.read())
 
     def readString(self, st):
@@ -124,7 +126,7 @@ class DescribeCoverageReader(object):
     """Read and parses WCS DescribeCoverage document into a lxml.etree infoset
     """
 
-    def __init__(self, version, identifier, cookies, auth=None):
+    def __init__(self, version, identifier, cookies, auth=None, headers=None):
         """Initialize
         @type version: string
         @param version: WCS Version parameter e.g '1.0.0'
@@ -133,6 +135,7 @@ class DescribeCoverageReader(object):
         self._infoset = None
         self.identifier = identifier
         self.cookies = cookies
+        self.headers = headers
         self.auth = auth or Authentication()
 
     def descCov_url(self, service_url):
@@ -186,5 +189,5 @@ class DescribeCoverageReader(object):
         """
 
         request = self.descCov_url(service_url)
-        u = openURL(request, cookies=self.cookies, timeout=timeout, auth=self.auth)
+        u = openURL(request, cookies=self.cookies, timeout=timeout, auth=self.auth, headers=self.headers)
         return etree.fromstring(u.read())

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -18,7 +18,7 @@ from .coverage import wcs100, wcs110, wcs111, wcsBase, wcs200, wcs201
 from owslib.util import clean_ows_url, Authentication, openURL
 
 
-def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30, auth=None):
+def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30, auth=None, headers=None):
     ''' wcs factory function, returns a version specific WebCoverageService object '''
 
     if not auth:
@@ -51,4 +51,4 @@ def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30, au
             wcs200.WebCoverageService_2_0_0, url, xml, cookies, auth=auth)
     elif version == '2.0.1':
         return wcs201.WebCoverageService_2_0_1.__new__(
-            wcs201.WebCoverageService_2_0_1, url, xml, cookies, auth=auth)
+            wcs201.WebCoverageService_2_0_1, url, xml, cookies, auth=auth, headers=headers)


### PR DESCRIPTION
Dear maintainer,

I was missing the ability to specify the headers for a WCS request. 
Therefore, I made the necessary modifications to make this work.
Are there other actions I can take that would increase the likelihood that this functionality becomes part of your codebase?

Cheers,
Timo Millenaar