### PR TITLE
Allow requests' AuthBase derived authenticators to be used with OWSLib

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -177,7 +177,11 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
         auth = Authentication(username, password, cert, verify)
     if auth.username and auth.password:
         rkwargs['auth'] = (auth.username, auth.password)
-    rkwargs['cert'] = auth.cert
+    if hasattr(auth, 'cert'):
+        rkwargs['cert'] = auth.cert
+    elif cert:
+        rkwargs['cert'] = cert
+
     rkwargs['verify'] = verify
 
     # FIXUP for WFS in particular, remove xml style namespace

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -24,6 +24,7 @@ import re
 from copy import deepcopy
 import warnings
 import requests
+from requests.auth import AuthBase
 import codecs
 
 """
@@ -162,8 +163,9 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
     rkwargs = {}
 
     rkwargs['timeout'] = timeout
-
-    if auth:
+    if isinstance(auth, AuthBase):
+        rkwargs['auth'] = auth
+    elif auth:
         if username:
             auth.username = username
         if password:


### PR DESCRIPTION
This is a simple PR to allow for Requests Authentication handlers to be given to the URL requests.

- allow AuthBase to be given