### PR TITLE
Allow user to specify timeout on WCS GetCoverage calls.

### DIFF
--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -95,7 +95,7 @@ class WebCoverageService_1_0_0(WCSBase):
         return items
 
     def getCoverage(self, identifier=None, bbox=None, time=None, format=None, crs=None, width=None, height=None,
-                    resx=None, resy=None, resz=None, parameter=None, method='Get', **kwargs):
+                    resx=None, resy=None, resz=None, parameter=None, method='Get', timeout=30, **kwargs):
         """Request and return a coverage from the WCS as a file-like object
         note: additional **kwargs helps with multi-version implementation
         core keyword arguments should be supported cross version
@@ -154,7 +154,7 @@ class WebCoverageService_1_0_0(WCSBase):
         data = urlencode(request)
         log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s' % data)
 
-        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth, timeout=timeout)
         return u
 
     def getOperationByName(self, name):

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -141,7 +141,7 @@ class WebCoverageService_1_1_0(WCSBase):
     # TO DO: Handle rest of the  WCS 1.1.0 keyword parameters e.g. GridCRS etc.
     def getCoverage(self, identifier=None, bbox=None, time=None, format=None, store=False, rangesubset=None,
                     gridbaseCRS=None, gridtype=None, gridCS=None, gridorigin=None, gridoffsets=None,
-                    method='Get', **kwargs):
+                    method='Get', timeout=30, **kwargs):
         """Request and return a coverage from the WCS as a file-like object
         note: additional **kwargs helps with multi-version implementation
         core keyword arguments should be supported cross version
@@ -205,7 +205,7 @@ class WebCoverageService_1_1_0(WCSBase):
         # encode and request
         data = urlencode(request)
 
-        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth, timeout=timeout)
         return u
 
     def getOperationByName(self, name):

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -130,6 +130,7 @@ class WebCoverageService_2_0_0(WCSBase):
         resz=None,
         parameter=None,
         method="Get",
+        timeout=30,
         **kwargs
     ):
         """Request and return a coverage from the WCS as a file-like object
@@ -213,7 +214,7 @@ class WebCoverageService_2_0_0(WCSBase):
             data += param_list_to_url_string(sizes, 'size')
         log.debug("WCS 2.0.0 DEBUG: Second part of URL: %s" % data)
 
-        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth, timeout=timeout)
         return u
 
     def getOperationByName(self, name):

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -130,6 +130,7 @@ class WebCoverageService_2_0_1(WCSBase):
         resz=None,
         parameter=None,
         method="Get",
+        timeout=30,
         **kwargs
     ):
         """Request and return a coverage from the WCS as a file-like object
@@ -214,7 +215,7 @@ class WebCoverageService_2_0_1(WCSBase):
 
         log.debug("WCS 2.0.1 DEBUG: Second part of URL: %s" % data)
 
-        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth, timeout=timeout)
         return u
 
     def getOperationByName(self, name):


### PR DESCRIPTION
Add timeout parameter to getCoverage() methods for all WCS versions and pass through to underlying OpenUrl function. See #713 