### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 sudo: false
 env:
   - LXML=true

--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -539,8 +539,8 @@ class ContentMetadata(AbstractContentMetadata):
                 raise ValueError('%s missing name and title' % (s,))
             if name is None or title is None:
                 warnings.warn('%s missing name or title' % (s,))
-            title_ = title.text if not title is None else name.text
-            name_ = name.text if not name is None else title.text
+            title_ = title.text if title is not None else name.text
+            name_ = name.text if name is not None else title.text
             style = {'title': title_}
             # legend url
             legend = s.find('LegendURL/OnlineResource')

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -585,8 +585,8 @@ class ContentMetadata(AbstractContentMetadata):
                 raise ValueError('%s missing name and title' % (s,))
             if name is None or title is None:
                 warnings.warn('%s missing name or title' % (s,))
-            title_ = title.text if not title is None else name.text
-            name_ = name.text if not name is None else title.text
+            title_ = title.text if title is not None else name.text
+            name_ = name.text if name is not None else title.text
             style = {'title': title_}
             # legend url
             legend = s.find(nspath('LegendURL/OnlineResource', WMS_NAMESPACE))

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -292,7 +292,7 @@ def add_namespaces(root, ns_keys):
         # We can't re-add an existing namespaces.  Get a list of current
         # namespaces in use
         existing_namespaces = set()
-        for elem in root.getiterator():
+        for elem in root.iter():
             if elem.tag[0] == "{":
                 uri, tag = elem.tag[1:].split("}")
                 existing_namespaces.add(namespaces.get_namespace_from_url(uri))

--- a/tests/resources/wfs_dov_getcapabilities_110.xml
+++ b/tests/resources/wfs_dov_getcapabilities_110.xml
@@ -158,7 +158,7 @@
                 </ows:UpperCorner>
             </ows:WGS84BoundingBox>
             <MetadataURL type="19115" format="text/xml">
-                https://www.dov.vlaanderen.be/geonetwork/srv/nl/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5
+                https://www.dov.vlaanderen.be/geonetwork/srv/dut/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5
             </MetadataURL>
             <MetadataURL type="19115" format="text/html">
                 https://www.dov.vlaanderen.be/geonetwork/apps/tabsearch/index.html?hl=dut&amp;uuid=6c39d716-aecc-4fbc-bac8-4f05a49a78d5

--- a/tests/resources/wfs_dov_getcapabilities_200.xml
+++ b/tests/resources/wfs_dov_getcapabilities_200.xml
@@ -281,7 +281,7 @@
                 </ows:UpperCorner>
             </ows:WGS84BoundingBox>
             <MetadataURL
-                    xlink:href="https://www.dov.vlaanderen.be/geonetwork/srv/nl/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5"/>
+                    xlink:href="https://www.dov.vlaanderen.be/geonetwork/srv/dut/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5"/>
             <MetadataURL
                     xlink:href="https://www.dov.vlaanderen.be/geonetwork/apps/tabsearch/index.html?hl=dut&amp;uuid=6c39d716-aecc-4fbc-bac8-4f05a49a78d5"/>
         </FeatureType>

--- a/tests/resources/wms_dov_getcapabilities_130.xml
+++ b/tests/resources/wms_dov_getcapabilities_130.xml
@@ -104,7 +104,7 @@
     </Exception>
     <inspire_vs:ExtendedCapabilities>
       <inspire_common:MetadataUrl>
-        <inspire_common:URL>https://www.dov.vlaanderen.be/geonetwork/srv/nl/csw?request=GetRecordById&amp;ID=eab36660-76ec-11e0-994d-0002a5d5c51b</inspire_common:URL>
+        <inspire_common:URL>https://www.dov.vlaanderen.be/geonetwork/srv/dut/csw?request=GetRecordById&amp;ID=eab36660-76ec-11e0-994d-0002a5d5c51b</inspire_common:URL>
         <inspire_common:MediaType>application/vnd.ogc.csw.GetRecordByIdResponse_xml</inspire_common:MediaType>
       </inspire_common:MetadataUrl>
       <inspire_common:SupportedLanguages>
@@ -167,7 +167,7 @@
         <BoundingBox CRS="EPSG:31370" minx="22512.0" miny="154145.0" maxx="258199.43" maxy="242848.38"/>
         <MetadataURL type="ISO19115:2003">
           <Format>text/xml</Format>
-          <OnlineResource xlink:type="simple" xlink:href="https://www.dov.vlaanderen.be/geonetwork/srv/nl/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5"/>
+          <OnlineResource xlink:type="simple" xlink:href="https://www.dov.vlaanderen.be/geonetwork/srv/dut/csw?Service=CSW&amp;Request=GetRecordById&amp;Version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=6c39d716-aecc-4fbc-bac8-4f05a49a78d5"/>
         </MetadataURL>
         <MetadataURL type="ISO19115:2003">
           <Format>text/html</Format>

--- a/tests/resources/wms_dov_getcapabilities_130_nometadata.xml
+++ b/tests/resources/wms_dov_getcapabilities_130_nometadata.xml
@@ -104,7 +104,7 @@
     </Exception>
     <inspire_vs:ExtendedCapabilities>
       <inspire_common:MetadataUrl>
-        <inspire_common:URL>https://www.dov.vlaanderen.be/geonetwork/srv/nl/csw?request=GetRecordById&amp;ID=eab36660-76ec-11e0-994d-0002a5d5c51b</inspire_common:URL>
+        <inspire_common:URL>https://www.dov.vlaanderen.be/geonetwork/srv/dut/csw?request=GetRecordById&amp;ID=eab36660-76ec-11e0-994d-0002a5d5c51b</inspire_common:URL>
         <inspire_common:MediaType>application/vnd.ogc.csw.GetRecordByIdResponse_xml</inspire_common:MediaType>
       </inspire_common:MetadataUrl>
       <inspire_common:SupportedLanguages>

--- a/tests/test_wmts.py
+++ b/tests/test_wmts.py
@@ -85,7 +85,7 @@ EXAMPLE_SERVICE_URL = "http://tile.informatievlaanderen.be/ws/raadpleegdiensten/
 
 def test_wmts_example_informatievlaanderen():
     wmts = WebMapTileService(EXAMPLE_SERVICE_URL)
-    assert wmts.identification.type == 'OGC WMTS'
+    assert wmts.identification.type == 'OGC:WMTS'
     assert wmts.identification.version == '1.0.0'
     assert wmts.identification.title == 'agentschap Informatie Vlaanderen WMTS service'
     # assert sorted(list(wmts.contents))[:5] == ['abw', 'ferraris', 'frickx', 'grb_bsk', 'grb_bsk_grijs']


### PR DESCRIPTION
This PR is fixing the test suite.

Changes:
* test python 3.9 on travis
* fixed url in wfs tests
* fixed wmts test
* replaced deprecated `getiterator()` method from `xml.etree` for Python 3.9:
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator