### PR TITLE
OWS/ISO metadata updates

### DIFF
--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -325,6 +325,7 @@ class MD_Keywords(object):
 
                 thesaurus = val.find(util.nspath_eval('gmd:title/gco:CharacterString', namespaces))
                 self.thesaurus['title'] = util.testXMLValue(thesaurus)
+                self.thesaurus['url'] = None
 
                 if self.thesaurus['title'] is None:  # try gmx:Anchor
                     t = val.find(util.nspath_eval('gmd:title/gmx:Anchor', namespaces))

--- a/owslib/ows.py
+++ b/owslib/ows.py
@@ -62,6 +62,9 @@ class ServiceIdentification(object):
             if f.text is not None:
                 self.keywords.append(f.text)
 
+        val = self._root.find(util.nspath('Keywords/Type', namespace))
+        self.keywords_type = util.testXMLValue(val)
+
         val = self._root.find(util.nspath('AccessConstraints', namespace))
         self.accessconstraints = util.testXMLValue(val)
 


### PR DESCRIPTION
Minor safeguarding/additions:

- add OWS service metadata keyword type
- safeguard ISO thesaurus type
