### PR TITLE
Handle empty <DataURL>.<Format> element in GetCapabilities

### DIFF
--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -665,9 +665,11 @@ class ContentMetadata(AbstractContentMetadata):
         self.dataUrls = []
         for m in elem.findall(nspath('DataURL', WMS_NAMESPACE)):
             dataUrl = {
-                'format': m.find(nspath('Format', WMS_NAMESPACE)).text.strip(),
+                'format': m.find(nspath('Format', WMS_NAMESPACE)).text,
                 'url': m.find(nspath('OnlineResource', WMS_NAMESPACE)).attrib['{http://www.w3.org/1999/xlink}href']
             }
+            if dataUrl['format'] is not None:
+                dataUrl['format'] = dataUrl['format'].strip()
             self.dataUrls.append(dataUrl)
 
         # FeatureListURLs


### PR DESCRIPTION
An empty `<Format>` element inside a `<DataURL>` element raises an exception when using strip(). Although <Format> is a mandatory element, this was dealt with in the code for v1.1.1: https://github.com/geopython/OWSLib/blob/c8a948cb3f2792b4aed4de3862c353a45339a56d/owslib/map/wms111.py#L585-L590 but not for v1.3.0: https://github.com/geopython/OWSLib/blob/c8a948cb3f2792b4aed4de3862c353a45339a56d/owslib/map/wms130.py#L667-L670

How is testing organized in this project? Do I need to provide an GetCapabilities document with the error in it?
Thanks, Stefan