### PR TITLE
Fix for WFS GetFeature XML filter regression

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 import pytz
 from owslib.etree import etree, ParseError
 from owslib.namespaces import Namespaces
-from urllib.parse import urlsplit, urlencode, urlparse, parse_qs, urlunparse, parse_qsl, unquote
+from urllib.parse import urlsplit, urlencode, urlparse, parse_qs, urlunparse, parse_qsl
 import copy
 
 from io import StringIO, BytesIO
@@ -197,7 +197,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
         rkwargs['data'] = data
 
     elif method.lower() == 'get':
-        rkwargs['params'] = unquote(data) if data else None
+        rkwargs['params'] = data
 
     else:
         raise ValueError("Unknown method ('%s'), expected 'get' or 'post'" % method)

--- a/tests/test_wfs_generic.py
+++ b/tests/test_wfs_generic.py
@@ -1,5 +1,6 @@
 from owslib.wfs import WebFeatureService
 from owslib.util import ServiceException
+from owslib.fes import PropertyIsLike, etree
 from urllib.parse import urlparse
 from tests.utils import resource_file, sorted_url_query, service_ok
 
@@ -169,3 +170,40 @@ def test_schema_wfs_200():
     assert len(schema['properties']) == 4
     assert schema['properties']['summary'] == 'string'
     assert schema['geometry'] == '3D Polygon'
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason="WFS service is unreachable")
+def test_xmlfilter_wfs_110():
+    wfs = WebFeatureService(
+        'https://services.ga.gov.au/gis/stratunits/ows',
+        version='1.1.0')
+    filter_prop = PropertyIsLike(propertyname='stratunit:geologichistory', literal='Cisuralian - Guadalupian',
+        matchCase=True)
+
+    filterxml = etree.tostring(filter_prop.toXML()).decode("utf-8")
+
+    getfeat_params = {'typename': 'stratunit:StratigraphicUnit', 'filter': filterxml}
+
+    response = wfs.getfeature(**getfeat_params).read()
+    assert b'<stratunit:geologichistory>Cisuralian - Guadalupian</stratunit:geologichistory>' in response
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason="WFS service is unreachable")
+def test_xmlfilter_wfs_200():
+    wfs = WebFeatureService(
+        'https://services.ga.gov.au/gis/stratunits/ows',
+        version='2.0.0')
+    filter_prop = PropertyIsLike(propertyname='stratunit:geologichistory', literal='Cisuralian - Guadalupian',
+        matchCase=True)
+
+    filterxml = etree.tostring(filter_prop.toXML()).decode("utf-8")
+
+    getfeat_params = {'typename': 'stratunit:StratigraphicUnit', 'filter': filterxml}
+
+    response = wfs.getfeature(**getfeat_params).read()
+    assert b'<stratunit:geologichistory>Cisuralian - Guadalupian</stratunit:geologichistory>' in response
+


### PR DESCRIPTION
A recent commit has added urllib's "unquote()" to remove all the %-escapes for all of the HTTP GET params :

https://github.com/geopython/OWSLib/commit/5392a92b9f5b4549d04a5f79ccb9e4bf02990623

This removed the protection for angle brackets and spaces being passed in parameters.

So we have a regression - WFS XML filters do not work any more.

I have rolled back this change and added two tests to prevent another regression. 