### PR TITLE
Include custom headers in WMS requests

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -259,7 +259,7 @@ class WebMapService_1_1_1(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth, headers=self.headers)
 
         # check for service exceptions, and return
         if u.info().get('Content-Type', '').split(';')[0] in ['application/vnd.ogc.se_xml']:
@@ -326,7 +326,7 @@ class WebMapService_1_1_1(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth, headers=self.headers)
 
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
@@ -601,7 +601,7 @@ class ContentMetadata(AbstractContentMetadata):
                     and metadataUrl['format'].lower() in ['application/xml', 'text/xml']:  # download URL
                 try:
                     content = openURL(
-                        metadataUrl['url'], timeout=timeout, auth=self.auth)
+                        metadataUrl['url'], timeout=timeout, auth=self.auth, headers=self.headers)
                     doc = etree.fromstring(content.read())
 
                     if metadataUrl['type'] == 'FGDC':

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -305,7 +305,7 @@ class WebMapService_1_3_0(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth, headers=self.headers)
 
         # need to handle casing in the header keys
         headers = {}
@@ -380,7 +380,7 @@ class WebMapService_1_3_0(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth, headers=self.headers)
 
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'XML':
@@ -692,7 +692,7 @@ class ContentMetadata(AbstractContentMetadata):
                     and metadataUrl['format'].lower() in ['application/xml', 'text/xml']:  # download URL
                 try:
                     content = openURL(
-                        metadataUrl['url'], timeout=timeout, auth=self.auth)
+                        metadataUrl['url'], timeout=timeout, auth=self.auth, headers=self.headers)
                     doc = etree.fromstring(content.read())
 
                     mdelem = doc.find('.//metadata')

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -692,7 +692,7 @@ class ContentMetadata(AbstractContentMetadata):
                     and metadataUrl['format'].lower() in ['application/xml', 'text/xml']:  # download URL
                 try:
                     content = openURL(
-                        metadataUrl['url'], timeout=timeout, auth=self.auth, headers=self.headers)
+                        metadataUrl['url'], timeout=timeout, auth=self.auth)
                     doc = etree.fromstring(content.read())
 
                     mdelem = doc.find('.//metadata')

--- a/tests/test_wms_getmap.py
+++ b/tests/test_wms_getmap.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from tests.utils import service_ok
 
@@ -151,3 +153,22 @@ def test_ncwms2():
     assert "height=256" in wms.request
     assert "format=image%2Fpng" in wms.request
     assert "transparent=TRUE" in wms.request
+
+
+@pytest.mark.parametrize('wms_version', ['1.1.1', '1.3.0'])
+def test_wms_sends_headers(wms_version):
+    """Test that if headers are provided in the WMS class they are sent
+    when performing HTTP requests (in this case for GetCapabilities)
+    """
+
+    with mock.patch('owslib.util.requests.request', side_effect=RuntimeError) as mock_request:
+        try:
+            WebMapService(
+                'http://example.com/wms',
+                version=wms_version,
+                headers={'User-agent': 'my-app/1.0'}
+            )
+        except RuntimeError:
+
+            assert mock_request.called
+            assert mock_request.call_args[1]['headers'] == {'User-agent': 'my-app/1.0'}


### PR DESCRIPTION
I recently needed to interact with a WMS service which require authentication via a `User-agent` header (from [France's IGN](https://geoservices.ign.fr/documentation/donnees-ressources-wms-geoportail.html)).

When using `WebMapService` you can actually provide custom headers but they are not used later on when doing the actual HTTP requests:

    wms = WebMapService(
        'http://example.com/wms',
        version='1.3.0',
        headers={'User-agent': 'my-app/1.0'}
    )

    wms.getmap(...)  # Fails as not authorized

The `openURL()` helper already supports sending headers if provided, so it was just a matter of adding the WMS client instance headers (if present) to this function call.

Includes a small test.

