### PR TITLE
changed all 'already exists' errors to warnings

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -233,8 +233,9 @@ class WebMapTileService(object):
                     parse_remote_metadata=parse_remote_metadata)
                 if cm.id:
                     if cm.id in self.contents:
-                        raise KeyError('Content metadata for layer "%s" '
+                        msg=('Content metadata for layer "%s" '
                                        'already exists' % cm.id)
+                        warnings.warn(msg, RuntimeWarning)
                     self.contents[cm.id] = cm
                 gather_layers(elem, cm)
         gather_layers(caps, None)
@@ -244,8 +245,9 @@ class WebMapTileService(object):
             tms = TileMatrixSet(elem)
             if tms.identifier:
                 if tms.identifier in self.tilematrixsets:
-                    raise KeyError('TileMatrixSet with identifier "%s" '
+                    msg = ('TileMatrixSet with identifier "%s" '
                                    'already exists' % tms.identifier)
+                    warnings.warn(msg, RuntimeWarning)
                 self.tilematrixsets[tms.identifier] = tms
 
         self.themes = {}
@@ -253,8 +255,9 @@ class WebMapTileService(object):
             theme = Theme(elem)
             if theme.identifier:
                 if theme.identifier in self.themes:
-                    raise KeyError('Theme with identifier "%s" already exists'
+                    msg=('Theme with identifier "%s" already exists'
                                    % theme.identifier)
+                    warnings.warn(msg, RuntimeWarning)
                 self.themes[theme.identifier] = theme
 
         serviceMetadataURL = self._capabilities.find(_SERVICE_METADATA_URL_TAG)
@@ -509,8 +512,9 @@ class TileMatrixSet(object):
             tm = TileMatrix(tilematrix)
             if tm.identifier:
                 if tm.identifier in self.tilematrix:
-                    raise KeyError('TileMatrix with identifier "%s" '
+                    msg = ('TileMatrix with identifier "%s" '
                                    'already exists' % tm.identifier)
+                    warnings.warn(msg, RuntimeWarning)
                 self.tilematrix[tm.identifier] = tm
 
 
@@ -738,9 +742,10 @@ class ContentMetadata:
         for tmsl in tile_matrix_set_links:
             if tmsl.tilematrixset:
                 if tmsl.tilematrixset in self.tilematrixsetlinks:
-                    raise KeyError('TileMatrixSetLink with tilematrixset "%s"'
+                    msg = ('TileMatrixSetLink with tilematrixset "%s"'
                                    ' already exists' %
                                    tmsl.tilematrixset)
+                    warnings.warn(msg, RuntimeWarning)
                 self.tilematrixsetlinks[tmsl.tilematrixset] = tmsl
 
         self.resourceURLs = []


### PR DESCRIPTION
I was running into problems with using the NASA wmts service and came across these errors. Similar errors were pointed out in #619, which was fixed by pull request #656. However, I find that all of the "already exists" error messages in wmts.py were potentially problematic for the new configuration of the NASA server. Here I have converted all "already exists" errors into warnings, analogous to the change made in #656  for one of these error messages.