### PR TITLE
Make most of Authentication's attributes private

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -872,11 +872,11 @@ class Authentication(object):
             username/password arguments.
         '''
         self.shared = shared
-        self.username = username
-        self.password = password
-        self.cert = cert
-        self.verify = verify
-        self.auth_delegate = auth_delegate
+        self._username = username
+        self._password = password
+        self._cert = cert
+        self._verify = verify
+        self._auth_delegate = auth_delegate
 
     @property
     def username(self):

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -878,6 +878,14 @@ class Authentication(object):
         self._verify = verify
         self._auth_delegate = auth_delegate
 
+        # Trigger the setters to validate the parameters. This couldn't be done directly
+        # since some parameters are mutually exclusive.
+        self.username = username
+        self.password = password
+        self.cert = cert
+        self.verify = verify
+        self.auth_delegate = auth_delegate
+
     @property
     def username(self):
         if self.shared:


### PR DESCRIPTION
Except for `shared` which is not a property.

Fixes #762