### PR TITLE
Add support for topological filters

### DIFF
--- a/owslib/feature/postrequest.py
+++ b/owslib/feature/postrequest.py
@@ -173,8 +173,12 @@ class PostRequest_2_0_0(PostRequest):
 
         Cannot be used with set_bbox() or set_featureid().
         """
-        f = etree.fromstring(filter)
-        sub_elem = f.find(util.nspath("Filter", FES_NAMESPACE))
+        if isinstance(filter, str):
+            f = etree.fromstring(filter)
+            sub_elem = f.find(util.nspath("Filter", FES_NAMESPACE))
+        else:
+            sub_elem = filter
+
         self._query.append(sub_elem)
 
     def set_maxfeatures(self, maxfeatures):

--- a/owslib/fes2.py
+++ b/owslib/fes2.py
@@ -392,6 +392,16 @@ class BBox(OgcExpression):
         return tmp
 
 
+class Filter(OgcExpression):
+    def __init__(self, filter):
+        self.filter = filter
+
+    def toXML(self):
+        node = etree.Element(util.nspath_eval(f"fes:Filter", namespaces))
+        node.append(self.filter.toXML())
+        return node
+
+
 class TopologicalOpType(OgcExpression, metaclass=ABCMeta):
     """Abstract base class for topological operators."""
     @property
@@ -405,14 +415,11 @@ class TopologicalOpType(OgcExpression, metaclass=ABCMeta):
         self.geometry = geometry
 
     def toXML(self):
-        p = etree.Element(util.nspath_eval(f"fes:Filter", namespaces))
-
         node = etree.Element(util.nspath_eval(f"fes:{self.operation}", namespaces))
         etree.SubElement(node, util.nspath_eval("fes:ValueReference", namespaces)).text = self.propertyname
         node.append(self.geometry.toXML())
 
-        p.append(node)
-        return p
+        return node
 
 
 class Intersects(TopologicalOpType):

--- a/owslib/fes2.py
+++ b/owslib/fes2.py
@@ -397,7 +397,7 @@ class Filter(OgcExpression):
         self.filter = filter
 
     def toXML(self):
-        node = etree.Element(util.nspath_eval(f"fes:Filter", namespaces))
+        node = etree.Element(util.nspath_eval("fes:Filter", namespaces))
         node.append(self.filter.toXML())
         return node
 

--- a/owslib/gml.py
+++ b/owslib/gml.py
@@ -7,7 +7,7 @@ from owslib.namespaces import Namespaces
 # default variables
 def get_namespaces():
     n = Namespaces()
-    ns = n.get_namespaces(["gml", "ogc", "xsd"])
+    ns = n.get_namespaces(["gml32", "ogc", "xsd"])
     ns[None] = n.get_namespace("ogc")
     return ns
 
@@ -46,20 +46,20 @@ class Point(AbstractGeometryType, _PointBase):
 
     def toXML(self):
         """Return `lxml.etree.Element` object."""
-        node = etree.Element(prefix("gml:Point"))
+        node = etree.Element(prefix("gml32:Point"))
         for key in ["id", "srsName"]:
             if getattr(self, key, None) is not None:
-                node.set(prefix(f"gml:{key}"), getattr(self, key))
+                node.set(prefix(f"gml32:{key}"), getattr(self, key))
 
         for key in ["description", "descriptionReference", "identifier", "name"]:
             content = getattr(self, key)
             if content is not None:
-                etree.SubElement(node, prefix(f"gml:{key}")).text = content
+                etree.SubElement(node, prefix(f"gml32:{key}")).text = content
 
-        coords = etree.SubElement(node, prefix("gml:pos"))
+        coords = etree.SubElement(node, prefix("gml32:pos"))
         coords.text = " ".join([str(c) for c in self.pos])
         for key in ["srsDimension"]:
             if getattr(self, key, None) is not None:
-                node.set(prefix(f"gml:{key}"), getattr(self, key))
+                node.set(prefix(f"gml32:{key}"), getattr(self, key))
 
         return node

--- a/owslib/gml.py
+++ b/owslib/gml.py
@@ -4,7 +4,7 @@ from owslib.etree import etree
 from owslib import util
 from owslib.namespaces import Namespaces
 
-# default variables
+
 def get_namespaces():
     n = Namespaces()
     ns = n.get_namespaces(["gml32", "ogc", "xsd"])
@@ -37,6 +37,7 @@ class AbstractGeometryType(AbstractGMLType):
 
 @dataclass
 class _PointBase:
+    """This is used to avoid issues arising from non-optional attributes defined after optional attributes."""
     pos: Sequence[float]
 
 

--- a/owslib/gml.py
+++ b/owslib/gml.py
@@ -14,7 +14,10 @@ def get_namespaces():
 
 namespaces = get_namespaces()
 
-prefix = lambda x: util.nspath_eval(x, namespaces)
+
+def prefix(x):
+    """Shorthand to insert namespaces."""
+    return util.nspath_eval(x, namespaces)
 
 
 @dataclass

--- a/owslib/gml.py
+++ b/owslib/gml.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import Sequence
+from owslib.etree import etree
+from owslib import util
+from owslib.namespaces import Namespaces
+
+# default variables
+def get_namespaces():
+    n = Namespaces()
+    ns = n.get_namespaces(["gml", "ogc", "xsd"])
+    ns[None] = n.get_namespace("ogc")
+    return ns
+
+
+namespaces = get_namespaces()
+
+prefix = lambda x: util.nspath_eval(x, namespaces)
+
+
+@dataclass
+class AbstractGMLType():
+    id: str
+
+
+@dataclass
+class AbstractGeometryType(AbstractGMLType):
+    srsName: str = None
+    srsDimension: int = None
+    # axisLabels: str = None
+    # uomLabels: str = None
+
+    description: str = None
+    descriptionReference: str = None
+    identifier: str = None
+    name: str = None
+
+
+@dataclass
+class _PointBase:
+    pos: Sequence[float]
+
+
+@dataclass
+class Point(AbstractGeometryType, _PointBase):
+    """GML Point object."""
+
+    def toXML(self):
+        """Return `lxml.etree.Element` object."""
+        node = etree.Element(prefix("gml:Point"))
+        for key in ["id", "srsName"]:
+            if getattr(self, key, None) is not None:
+                node.set(prefix(f"gml:{key}"), getattr(self, key))
+
+        for key in ["description", "descriptionReference", "identifier", "name"]:
+            content = getattr(self, key)
+            if content is not None:
+                etree.SubElement(node, prefix(f"gml:{key}")).text = content
+
+        coords = etree.SubElement(node, prefix("gml:pos"))
+        coords.text = " ".join([str(c) for c in self.pos])
+        for key in ["srsDimension"]:
+            if getattr(self, key, None) is not None:
+                node.set(prefix(f"gml:{key}"), getattr(self, key))
+
+        return node

--- a/owslib/iso.py
+++ b/owslib/iso.py
@@ -548,7 +548,8 @@ class MD_DataIdentification(object):
             self.status = _testCodeListValue(md.find(util.nspath_eval('gmd:status/gmd:MD_ProgressCode', namespaces)))
 
             self.graphicoverview = []
-            for val in md.findall(util.nspath_eval('gmd:graphicOverview/gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString', namespaces)):
+            for val in md.findall(util.nspath_eval(
+                    'gmd:graphicOverview/gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString', namespaces)):
                 if val is not None:
                     val2 = util.testXMLValue(val)
                     if val2 is not None:

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -19,8 +19,8 @@ class Namespaces(object):
         'gm03': 'http://www.interlis.ch/INTERLIS2.3',
         'gmd': 'http://www.isotc211.org/2005/gmd',
         'gmi': 'http://www.isotc211.org/2005/gmi',
-        'gml': 'http://www.opengis.net/gml/3.2',
-        'gml311': 'http://www.opengis.net/gml',  # Dead link
+        'gml': 'http://www.opengis.net/gml',
+        'gml311': 'http://www.opengis.net/gml',
         'gml32': 'http://www.opengis.net/gml/3.2',
         'gmx': 'http://www.isotc211.org/2005/gmx',
         'gts': 'http://www.isotc211.org/2005/gts',

--- a/owslib/namespaces.py
+++ b/owslib/namespaces.py
@@ -19,8 +19,8 @@ class Namespaces(object):
         'gm03': 'http://www.interlis.ch/INTERLIS2.3',
         'gmd': 'http://www.isotc211.org/2005/gmd',
         'gmi': 'http://www.isotc211.org/2005/gmi',
-        'gml': 'http://www.opengis.net/gml',
-        'gml311': 'http://www.opengis.net/gml',
+        'gml': 'http://www.opengis.net/gml/3.2',
+        'gml311': 'http://www.opengis.net/gml',  # Dead link
         'gml32': 'http://www.opengis.net/gml/3.2',
         'gmx': 'http://www.isotc211.org/2005/gmx',
         'gts': 'http://www.isotc211.org/2005/gts',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytz
 requests>=1.0
 pyproj >=2
 pyyaml
+dataclasses; python_version < '3.7'

--- a/tests/test_fes2.py
+++ b/tests/test_fes2.py
@@ -1,6 +1,6 @@
 from owslib import fes2
 from owslib.gml import Point
-from lxml.etree import tostring
+from owslib.etree import etree
 
 
 def test_filter():
@@ -12,4 +12,5 @@ def test_filter():
     )
 
     xml = f.toXML()
-    assert tostring(xml) ==  b'<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"><fes:And><fes:Intersects><fes:ValueReference>the_geom</fes:ValueReference><gml32:Point xmlns:gml32="http://www.opengis.net/gml/3.2" gml32:id="qc" gml32:srsName="http://www.opengis.net/gml/srs/epsg.xml#4326"><gml32:pos>-71 46</gml32:pos></gml32:Point></fes:Intersects><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\"><fes:ValueReference>name</fes:ValueReference><fes:Literal>value</fes:Literal></fes:PropertyIsLike></fes:And></fes:Filter>'
+    assert etree.tostring(xml) ==  b'<fes:Filter ' \
+                                b'xmlns:fes="http://www.opengis.net/fes/2.0"><fes:And><fes:Intersects><fes:ValueReference>the_geom</fes:ValueReference><gml32:Point xmlns:gml32="http://www.opengis.net/gml/3.2" gml32:id="qc" gml32:srsName="http://www.opengis.net/gml/srs/epsg.xml#4326"><gml32:pos>-71 46</gml32:pos></gml32:Point></fes:Intersects><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\"><fes:ValueReference>name</fes:ValueReference><fes:Literal>value</fes:Literal></fes:PropertyIsLike></fes:And></fes:Filter>'

--- a/tests/test_fes2.py
+++ b/tests/test_fes2.py
@@ -4,7 +4,7 @@ from owslib import fes2
 from owslib.gml import Point
 from owslib.namespaces import Namespaces
 from owslib import util
-import geojson
+import json
 
 n = Namespaces()
 FES_NAMESPACE = n.get_namespace("fes")
@@ -43,4 +43,4 @@ def test_filter():
     point = Point(id="random", srsName="http://www.opengis.net/gml/srs/epsg.xml#4326", pos=[-129.8, 55.44])
     f = fes2.Filter(fes2.Contains(propertyname="geom", geometry=point))
     r = wfs.getfeature(layer, outputFormat="application/json", method="POST", filter=f.toXML())
-    assert geojson.load(r)["totalFeatures"] == 1
+    assert json.load(r)["totalFeatures"] == 1

--- a/tests/test_fes2.py
+++ b/tests/test_fes2.py
@@ -1,0 +1,15 @@
+from owslib import fes2
+from owslib.gml import Point
+from lxml.etree import tostring
+
+
+def test_filter():
+    point = Point(id="qc", srsName="http://www.opengis.net/gml/srs/epsg.xml#4326", pos=[-71, 46])
+    f = fes2.Filter(
+        fes2.And([fes2.Intersects(propertyname="the_geom", geometry=point),
+                  fes2.PropertyIsLike("name", "value")]
+                 )
+    )
+
+    xml = f.toXML()
+    assert tostring(xml) ==  b'<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"><fes:And><fes:Intersects><fes:ValueReference>the_geom</fes:ValueReference><gml32:Point xmlns:gml32="http://www.opengis.net/gml/3.2" gml32:id="qc" gml32:srsName="http://www.opengis.net/gml/srs/epsg.xml#4326"><gml32:pos>-71 46</gml32:pos></gml32:Point></fes:Intersects><fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\"><fes:ValueReference>name</fes:ValueReference><fes:Literal>value</fes:Literal></fes:PropertyIsLike></fes:And></fes:Filter>'

--- a/tests/test_wfs_generic.py
+++ b/tests/test_wfs_generic.py
@@ -2,7 +2,7 @@ from owslib.wfs import WebFeatureService
 from owslib.util import ServiceException
 from urllib.parse import urlparse
 from tests.utils import resource_file, sorted_url_query, service_ok
-
+import json
 import pytest
 
 SERVICE_URL = 'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288'
@@ -54,7 +54,6 @@ def test_getfeature():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_100():
-    import json
     wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
                             version='1.0.0')
     feature = wfs.getfeature(
@@ -66,7 +65,6 @@ def test_outputformat_wfs_100():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_110():
-    import json
     wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
                             version='1.1.0')
     feature = wfs.getfeature(
@@ -78,7 +76,6 @@ def test_outputformat_wfs_110():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_200():
-    import json
     wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
                             version='2.0.0')
     feature = wfs.getfeature(
@@ -90,7 +87,6 @@ def test_outputformat_wfs_200():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_srsname_wfs_100():
-    import json
     wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
                             version='1.0.0')
     # ServiceException: Unable to support srsName: EPSG:99999999
@@ -99,7 +95,6 @@ def test_srsname_wfs_100():
             typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
             srsname="EPSG:99999999")
 
-    import json
     wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
                             version='1.0.0')
     feature = wfs.getfeature(
@@ -112,7 +107,6 @@ def test_srsname_wfs_100():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_srsname_wfs_110():
-    import json
     wfs = WebFeatureService(
         'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
         version='1.1.0')
@@ -122,7 +116,6 @@ def test_srsname_wfs_110():
             typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
             srsname="EPSG:99999999")
 
-    import json
     wfs = WebFeatureService(
         'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
         version='1.0.0')


### PR DESCRIPTION
This PR allows users to filter WFS requests using spatial filters: Intercepts, Contains, Within, Touches, Disjoint, Overlaps, Equals. 

- Add spatial filters in fes2.py;
- Create gml:Point object;

# Notes

- Only works with WFS 2.0 and POST. 
- The `set_filter` method in GetFeature is weird. It expects a GetFeature xml request, instead of just the Filter node.  I've added a shortcut to allow passing a filter XML object directly. Suggestions welcome. I suggest that when passing `filter` to getfeature, we only pass the filter node, not the getfeature node. 
- I've tested it on our own geoserver instance, but unclear how to test this actually works without a live instance somewhere. 
- The implementation bypasses the FilterRequest class, which seemed to target CSW.
- I used dataclasses, but that's only available from 3.7 onward so added it to dependencies if python < 3.7.

# Related
#128 