### PR TITLE
Update pyproj syntax and fix some issue in WFS

### DIFF
--- a/tests/resources/wfs_dov_getcapabilities_100_verbOptions.xml
+++ b/tests/resources/wfs_dov_getcapabilities_100_verbOptions.xml
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WFS_Capabilities version="1.0.0" xmlns="http://www.opengis.net/wfs"
+                  xmlns:gw_meetnetten="http://dov.vlaanderen.be/grondwater/gw_meetnetten"
+                  xmlns:ogc="http://www.opengis.net/ogc"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.opengis.net/wfs https://www.dov.vlaanderen.be:443/geoserver/schemas/wfs/1.0.0/WFS-capabilities.xsd">
+    <Service>
+        <Name>WFS</Name>
+        <Title>Download Service van Databank Ondergrond Vlaanderen</Title>
+        <Abstract>Download Service van Databank Ondergrond Vlaanderen
+        </Abstract>
+        <Keywords/>
+        <OnlineResource>
+            https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs
+        </OnlineResource>
+        <Fees>No fees</Fees>
+        <AccessConstraints/>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <DCPType>
+                    <HTTP>
+                        <Get onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs?request=GetCapabilities"/>
+                    </HTTP>
+                </DCPType>
+                <DCPType>
+                    <HTTP>
+                        <Post onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs"/>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <DescribeFeatureType>
+                <SchemaDescriptionLanguage>
+                    <XMLSCHEMA/>
+                </SchemaDescriptionLanguage>
+                <DCPType>
+                    <HTTP>
+                        <Get onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs?request=DescribeFeatureType"/>
+                    </HTTP>
+                </DCPType>
+                <DCPType>
+                    <HTTP>
+                        <Post onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs"/>
+                    </HTTP>
+                </DCPType>
+            </DescribeFeatureType>
+            <GetFeature>
+                <ResultFormat>
+                    <KML/>
+                    <GML2/>
+                    <GML3/>
+                    <SHAPE-ZIP/>
+                    <CSV/>
+                    <JSON/>
+                </ResultFormat>
+                <DCPType>
+                    <HTTP>
+                        <Get onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs?request=GetFeature"/>
+                    </HTTP>
+                </DCPType>
+                <DCPType>
+                    <HTTP>
+                        <Post onlineResource="https://www.dov.vlaanderen.be:443/geoserver/gw_meetnetten/meetnetten/wfs"/>
+                    </HTTP>
+                </DCPType>
+            </GetFeature>
+        </Request>
+    </Capability>
+    <FeatureTypeList>
+        <Operations>
+            <Query/>
+        </Operations>
+        <FeatureType>
+            <Name>gw_meetnetten:meetnetten</Name>
+            <Title>Grondwatermeetnetten</Title>
+            <Abstract>In de Databank Ondergrond Vlaanderen zijn verschillende
+                grondwatermeetnetten opgenomen. Deze meetnetten staan in
+                functie van uitgebreide monitoringprogramma's met de bedoeling
+                een goed beeld te krijgen van de beschikbare
+                grondwaterkwantiteit en grondwaterkwaliteit van de
+                watervoerende lagen in Vlaanderen.
+            </Abstract>
+            <Keywords>DOV_PATHNAME@001#DOV:150#Grondwateronderzoek:010#,
+                DOV_EXPERTISE@C#D#E#F, grondwater, meetnet(werk), Geologie,
+                Toegevoegd GDI-Vl, Herbruikbaar, Vlaamse Open data, Kosteloos,
+                Lijst M&amp;R INSPIRE, Metadata INSPIRE-conform, Metadata
+                GDI-Vl-conform
+            </Keywords>
+            <SRS>EPSG:31370</SRS>
+            <LatLongBoundingBox minx="2.4985990253931107"
+                                miny="49.35896492737394"
+                                maxx="5.959258812134792"
+                                maxy="52.81962471411561"/>
+        </FeatureType>
+    </FeatureTypeList>
+    <FeatureTypeList>
+        <Operations>
+            <Query/>
+        </Operations>
+        <FeatureType>
+            <Name>gw_meetnetten:meetnetten</Name>
+            <Title>Grondwatermeetnetten</Title>
+            <Abstract>In de Databank Ondergrond Vlaanderen zijn verschillende
+                grondwatermeetnetten opgenomen. Deze meetnetten staan in
+                functie van uitgebreide monitoringprogramma's met de bedoeling
+                een goed beeld te krijgen van de beschikbare
+                grondwaterkwantiteit en grondwaterkwaliteit van de
+                watervoerende lagen in Vlaanderen.
+            </Abstract>
+            <Keywords>DOV_PATHNAME@001#DOV:150#Grondwateronderzoek:010#,
+                DOV_EXPERTISE@C#D#E#F, grondwater, meetnet(werk), Geologie,
+                Toegevoegd GDI-Vl, Herbruikbaar, Vlaamse Open data, Kosteloos,
+                Lijst M&amp;R INSPIRE, Metadata INSPIRE-conform, Metadata
+                GDI-Vl-conform
+            </Keywords>
+            <SRS>EPSG:31370</SRS>
+            <LatLongBoundingBox minx="2.4985990253931107"
+                                miny="49.35896492737394"
+                                maxx="5.959258812134792"
+                                maxy="52.81962471411561"/>
+            <Operations>
+                <Insert/>
+            </Operations>
+        </FeatureType>
+    </FeatureTypeList>
+    <ogc:Filter_Capabilities>
+        <ogc:Spatial_Capabilities>
+            <ogc:Spatial_Operators>
+                <ogc:Disjoint/>
+                <ogc:Equals/>
+                <ogc:DWithin/>
+                <ogc:Beyond/>
+                <ogc:Intersect/>
+                <ogc:Touches/>
+                <ogc:Crosses/>
+                <ogc:Within/>
+                <ogc:Contains/>
+                <ogc:Overlaps/>
+                <ogc:BBOX/>
+            </ogc:Spatial_Operators>
+        </ogc:Spatial_Capabilities>
+        <ogc:Scalar_Capabilities>
+            <ogc:Logical_Operators/>
+            <ogc:Comparison_Operators>
+                <ogc:Simple_Comparisons/>
+                <ogc:Between/>
+                <ogc:Like/>
+                <ogc:NullCheck/>
+            </ogc:Comparison_Operators>
+            <ogc:Arithmetic_Operators>
+                <ogc:Simple_Arithmetic/>
+                <ogc:Functions>
+                    <ogc:Function_Names>
+                        <ogc:Function_Name nArgs="1">abs</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">abs_2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">abs_3</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">abs_4</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">acos</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">AddCoverages
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">Affine
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">Aggregate
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">area</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">area2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">AreaGrid
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">asin</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">asMultiGeometry
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">atan</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">atan2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">BandMerge
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">BandSelect
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-6">BarnesSurface
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">between
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">boundary
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">boundaryDimension
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Bounds</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">buffer
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">BufferFeatureCollection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">bufferWithSegments
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="7">Categorize
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">ceil</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">centroid
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">classify
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">Clip</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">CollectGeometries
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Average
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Bounds
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">Collection_Count
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Max
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Median
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Min
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Nearest
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Sum
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Collection_Unique
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">Concatenate
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">contains
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">Contour
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">convert
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">convexHull
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">ConvolveCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">cos</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">Count</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">CoverageClassStats
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">CropCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">crosses
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">dateFormat
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">dateParse
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">densify
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">difference
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">dimension
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">disjoint
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">disjoint3D
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">distance
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">distance3D
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">double2bool
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">endAngle
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">endPoint
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">env</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">envelope
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">EqualInterval
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">equalsExact
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">equalsExactTolerance
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">equalTo
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">exp</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">exteriorRing
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">Feature
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">FeatureClassStats
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">floor</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">FormatDateTimezone
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">geometry
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">geometryType
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">geomFromWKT
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">geomLength
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-3">GeorectifyCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">GetFullCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">getGeometryN
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">getID</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">getX</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">getY</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">getz</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">greaterEqualThan
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">greaterThan
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-3">Grid</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-5">Heatmap
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">id</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">IEEEremainder
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">if_then_else
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">Import</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">in</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="11">in10</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">in2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="4">in3</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="5">in4</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="6">in5</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="7">in6</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="8">in7</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="9">in8</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="10">in9</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">
+                            InclusionFeatureCollection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">int2bbool
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">int2ddouble
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">interiorPoint
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">interiorRingN
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-5">Interpolate
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">intersection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">
+                            IntersectionFeatureCollection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">intersects
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">intersects3D
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isClosed
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">isCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isEmpty
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isInstanceOf
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">isLike</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isNull</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">isometric
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isRing</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isSimple
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">isValid
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">isWithinDistance
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">isWithinDistance3D
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">Jenks</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">length</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">lessEqualThan
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">lessThan
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">list</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">log</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="4">LRSGeocode
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-4">LRSMeasure
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="5">LRSSegment
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">max</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">max_2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">max_3</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">max_4</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">min</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">min_2</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">min_3</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">min_4</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">mincircle
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">minimumdiameter
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">minrectangle
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">modulo</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">MultiplyCoverages
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">Nearest
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">NormalizeCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">not</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">notEqualTo
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">numberFormat
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="5">numberFormat2
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">numGeometries
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">numInteriorRing
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">numPoints
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">octagonalenvelope
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">offset</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">overlaps
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">PagedUnique
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">parameter
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">parseBoolean
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">parseDouble
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">parseInt
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">parseLong
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">pi</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">PointBuffers
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">pointN</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-6">PointStacker
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">PolygonExtraction
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">polygonize
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">pow</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">property
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">PropertyExists
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">Quantile
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">Query</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="0">random</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">RangeLookup
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">RasterAsPointCollection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">RasterZonalStatistics
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-6">RasterZonalStatistics2
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="5">Recode</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">RectangularClip
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">relate</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">relatePattern
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">reproject
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">ReprojectGeometry
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-3">rescaleToPixels
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">rint</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">round</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">round_2
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">roundDouble
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-5">ScaleCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">setCRS</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">simplify
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">sin</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">Snap</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">splitPolygon
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">sqrt</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">StandardDeviation
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">startAngle
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">startPoint
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">StoreCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">strCapitalize
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strConcat
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strEndsWith
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strEqualsIgnoreCase
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strIndexOf
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="4">stringTemplate
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strLastIndexOf
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">strLength
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strMatches
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">strPosition
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="4">strReplace
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strStartsWith
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">strSubstring
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">strSubstringStart
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">strToLowerCase
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">strToUpperCase
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">strTrim
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">strTrim2
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">strURLEncode
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">StyleCoverage
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">symDifference
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">tan</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">toDegrees
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-1">toDirectPosition
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">ToEnvelope
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-3">toLineString
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">toPoint
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">toRadians
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">touches
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">toWKT</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">toXlinkHref
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">Transform
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-2">union</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">UnionFeatureCollection
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">Unique</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">UniqueInterval
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="-4">VectorToRaster
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="3">VectorZonalStatistics
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="1">vertices
+                        </ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">Vocab</ogc:Function_Name>
+                        <ogc:Function_Name nArgs="2">within</ogc:Function_Name>
+                    </ogc:Function_Names>
+                </ogc:Functions>
+            </ogc:Arithmetic_Operators>
+        </ogc:Scalar_Capabilities>
+    </ogc:Filter_Capabilities>
+</WFS_Capabilities>

--- a/tests/test_wfs_generic.py
+++ b/tests/test_wfs_generic.py
@@ -50,6 +50,14 @@ def test_getfeature():
         'maxfeatures=2', 'request=GetFeature', 'service=WFS', 'typename=okresy', 'version=1.1.0']
 
 
+def test_verbOptions_wfs_100():
+    with open(resource_file("wfs_dov_getcapabilities_100_verbOptions.xml"), "rb") as f:
+        getcapsin = f.read()
+    wfs = WebFeatureService('http://gis.bnhelp.cz/ows/crwfs', xml=getcapsin, version='1.0.0')
+    verbOptions = [cm.verbOptions for cm in wfs.contents.values()]
+    assert len(verbOptions[0]) == 2
+
+
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")


### PR DESCRIPTION
This PR includes the following improvements/fixes:
1. Update `pyproj` syntax for the transform operation according to the proposed style on their [website](https://pyproj4.github.io/pyproj/stable/gotchas.html) to fix the deprecation warning.
2. Fix an issue in `WFS` where a list addition operation was not assigned to the intended variable.
3. Remove the unnecessary `else` in an if-block, since an exception is being raised.