### PR TITLE
Add maximumMegabytes.

### DIFF
--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1062,7 +1062,7 @@ class ComplexData(object):
         self.mimeType = mimeType
         self.encoding = encoding
         self.schema = schema
-        self.maximumMegabytes = maximumMegaBytes
+        self.maximumMegabytes = maximumMegaBytes  # defined only if provided by ProcessDescription ComplexData
 
 
 class InputOutput(object):
@@ -1224,6 +1224,10 @@ class InputOutput(object):
                     )
                 )
 
+            # Optional attribute 'maximumMegabytes' can be omitted entirely from 'ComplexData'
+            # but in the case it is made available, report it in the format for reference.
+            # This could be used by a file validation step to be respected during process execution
+            # but this check should be done on the server side, so it is only informative here.
             max_mb = complex_data_element.attrib.get("maximumMegabytes")
             for format_element in\
                     complex_data_element.findall('Supported/Format'):

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -1058,10 +1058,11 @@ class ComplexData(object):
     Class that represents a ComplexData element in a WPS document
     """
 
-    def __init__(self, mimeType=None, encoding=None, schema=None):
+    def __init__(self, mimeType=None, encoding=None, schema=None, maximumMegaBytes=None):
         self.mimeType = mimeType
         self.encoding = encoding
         self.schema = schema
+        self.maximumMegabytes = maximumMegaBytes
 
 
 class InputOutput(object):
@@ -1176,7 +1177,7 @@ class InputOutput(object):
         Method to parse a ComplexData or ComplexOutput element.
         """
 
-        # <ComplexData>
+        # <ComplexData maximumMegabytes="200">
         #     <Default>
         #         <Format>
         #            <MimeType>text/xml</MimeType>
@@ -1223,13 +1224,15 @@ class InputOutput(object):
                     )
                 )
 
+            max_mb = complex_data_element.attrib.get("maximumMegabytes")
             for format_element in\
                     complex_data_element.findall('Supported/Format'):
                 self.supportedValues.append(
                     ComplexData(
                         mimeType=testXMLValue(format_element.find('MimeType')),
                         encoding=testXMLValue(format_element.find('Encoding')),
-                        schema=testXMLValue(format_element.find('Schema'))
+                        schema=testXMLValue(format_element.find('Schema')),
+                        maximumMegaBytes=max_mb
                     )
                 )
 
@@ -1240,7 +1243,8 @@ class InputOutput(object):
                         default_format_element.find('MimeType')),
                     encoding=testXMLValue(
                         default_format_element.find('Encoding')),
-                    schema=testXMLValue(default_format_element.find('Schema'))
+                    schema=testXMLValue(default_format_element.find('Schema')),
+                    maximumMegaBytes=max_mb
                 )
 
     def _parseBoundingBoxData(self, element, bboxElementName):


### PR DESCRIPTION
Transfer `maximumMegabytes` attribute if available in WPS ComplexData definition. 
This is useful for applications that want to make use of objects generated by parsing a `DescribeProcess` response, but is not explicitly employed by the code.