### PR TITLE
add support for OGC API - Features - Part 3: CQL

### DIFF
--- a/docs/en/features.rst
+++ b/docs/en/features.rst
@@ -49,13 +49,15 @@ Standards Support
 OGC API Support
 ---------------
 
-+---------------------------------------------------+
-| Standard                             | Version(s) |
-+======================================+============+
-| `OGC API - Features - Part 1: Core`_ | 1.0        |
-+--------------------------------------+------------+
-| `OGC API - Records - Part 1: Core`_  | draft      |
-+--------------------------------------+------------+
++--------------------------------------------------------------------------------------+------------+
+| Standard                                                                             | Version(s) |
++======================================================================================+============+
+| `OGC API - Features - Part 1: Core`_                                                 | 1.0        |
++--------------------------------------------------------------------------------------+------------+
+| `OGC API - Records - Part 1: Core`_                                                  | draft      |
++--------------------------------------------------------------------------------------+------------+
+| `OGC API - Features - Part 3: Filtering and the Common Query Language (CQL) draft`_  | draft      |
++--------------------------------------------------------------------------------------+------------+
 
 .. _`OGC WMS`: https://www.opengeospatial.org/standards/wms
 .. _`OGC WFS`: https://www.opengeospatial.org/standards/wfs
@@ -83,3 +85,4 @@ OGC API Support
 .. _`OGC API`: https://ogcapi.ogc.org
 .. _`OGC API - Features - Part 1: Core`: https://docs.opengeospatial.org/is/17-069r3/17-069r3.html
 .. _`OGC API - Records - Part 1: Core`: https://github.com/opengeospatial/ogcapi-records
+.. _`OGC API - Features - Part 3: Filtering and the Common Query Language (CQL) draft`: https://docs.ogc.org/DRAFTS/19-079.html

--- a/docs/en/usage.rst
+++ b/docs/en/usage.rst
@@ -266,6 +266,12 @@ OGC API - Records 1.0
   2
   >>> msc_wis_dcpc_query2['numberReturned']
   2
+  >>> my_catalogue_cql_text_query = w.collection_items('my-catalogue', filter="title LIKE 'Roadrunner%'")
+  >>> my_catalogue_cql_text_query['features'][0]['properties']['title']
+  u'Roadrunner ambush locations'
+  >>> my_catalogue_cql_json_query = w.collection_items('my-catalogue', limit=1, cql={'eq': [{ 'property': 'title' }, 'Roadrunner ambush locations']})
+  >>> my_catalogue_cql_json_query['features'][0]['properties']['title']
+  u'Roadrunner ambush locations'
 
 
 WCS

--- a/owslib/catalogue/csw2.py
+++ b/owslib/catalogue/csw2.py
@@ -694,7 +694,7 @@ class CatalogueServiceWeb(object):
 
             self.request = util.element_to_string(self.request, encoding='utf-8')
 
-            self.response = http_post(request_url, self.request, self.lang, self.timeout, auth=self.auth)
+            self.response = http_post(request_url, self.request, self.lang, self.timeout, auth=self.auth).content
 
         # parse result see if it's XML
         self._exml = etree.parse(BytesIO(self.response))

--- a/owslib/catalogue/csw3.py
+++ b/owslib/catalogue/csw3.py
@@ -585,7 +585,7 @@ class CatalogueServiceWeb(object):
 
             self.request = util.element_to_string(self.request, encoding='utf-8')
 
-            self.response = http_post(request_url, self.request, self.lang, self.timeout, auth=self.auth)
+            self.response = http_post(request_url, self.request, self.lang, self.timeout, auth=self.auth).content
 
         # parse result see if it's XML
         self._exml = etree.parse(BytesIO(self.response))

--- a/owslib/ogcapi/features.py
+++ b/owslib/ogcapi/features.py
@@ -54,6 +54,10 @@ class Features(Collections):
         @param startindex: start position of results
         @type q: string
         @param q: full text search
+        @type filter: string
+        @param filter: CQL TEXT expression
+        @type cql: dict
+        @param cql: CQL JSON payload
 
         @returns: feature results
         """

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -413,6 +413,10 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
         'Host': u.netloc,
     }
 
+    if isinstance(request, dict):
+        headers['Content-type'] = 'application/json'
+        headers.pop('Accept')
+
     rkwargs = {}
 
     if auth:
@@ -429,8 +433,10 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
     rkwargs['verify'] = auth.verify
     rkwargs['cert'] = auth.cert
 
-    up = requests.post(url, request, headers=headers, **rkwargs)
-    return up.content
+    if not isinstance(request, dict):
+        return requests.post(url, request, headers=headers, **rkwargs)
+    else:
+        return requests.post(url, json=request, headers=headers, **rkwargs)
 
 
 def http_get(*args, **kwargs):

--- a/tests/test_ogcapi_records_pycsw.py
+++ b/tests/test_ogcapi_records_pycsw.py
@@ -1,0 +1,69 @@
+from tests.utils import service_ok
+
+import pytest
+
+from owslib.ogcapi.records import Records
+
+SERVICE_URL = 'https://demo.pycsw.org/cite'
+
+
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason='service is unreachable')
+def test_ogcapi_records_pygeoapi():
+    w = Records(SERVICE_URL)
+
+    assert w.url == 'https://demo.pycsw.org/cite/'
+    assert w.url_query_string is None
+
+    api = w.api()
+    assert api['components']['parameters'] is not None
+    paths = api['paths']
+    assert paths is not None
+    assert paths['/collections/metadata:main'] is not None
+
+    conformance = w.conformance()
+    assert len(conformance['conformsTo']) == 10
+
+    collections = w.collections()
+    assert len(collections) > 0
+
+    record_collections = w.records()
+    assert record_collections == ['metadata:main']
+
+    pycsw_cite_demo = w.collection('metadata:main')
+    assert pycsw_cite_demo['id'] == 'metadata:main'
+    assert pycsw_cite_demo['title'] == 'pycsw OGC CITE demo and Reference Implementation'  # noqa
+    assert pycsw_cite_demo['itemType'] == 'record'
+    assert w.request == 'https://demo.pycsw.org/cite/collections/metadata:main'  # noqa
+    assert w.response is not None
+    assert isinstance(w.response, dict)
+
+    pycsw_cite_demo_queryables = w.collection_queryables('metadata:main')
+    assert len(pycsw_cite_demo_queryables['properties'].keys()) == 60
+
+    # Minimum of limit param is 1
+    with pytest.raises(RuntimeError):
+        pycsw_cite_demo_query = w.collection_items('metadata:main', limit=0)
+
+    pycsw_cite_demo_query = w.collection_items('metadata:main', limit=1)
+    assert pycsw_cite_demo_query['numberMatched'] == 12
+    assert pycsw_cite_demo_query['numberReturned'] == 1
+    assert len(pycsw_cite_demo_query['features']) == 1
+
+    pycsw_cite_demo_query = w.collection_items('metadata:main', q='lorem')
+    assert pycsw_cite_demo_query['numberMatched'] == 5
+    assert pycsw_cite_demo_query['numberReturned'] == 5
+    assert len(pycsw_cite_demo_query['features']) == 5
+
+    cql_text = "title LIKE 'Lorem%'"
+    pycsw_cite_demo_query = w.collection_items('metadata:main', filter=cql_text)
+    assert pycsw_cite_demo_query['numberMatched'] == 2
+    assert pycsw_cite_demo_query['numberReturned'] == 2
+    assert len(pycsw_cite_demo_query['features']) == 2
+
+    cql_json = {'eq': [{'property': 'title'}, 'Lorem ipsum']}
+    pycsw_cite_demo_query = w.collection_items('metadata:main', cql=cql_json)
+    assert pycsw_cite_demo_query['numberMatched'] == 1
+    assert pycsw_cite_demo_query['numberReturned'] == 1
+    assert len(pycsw_cite_demo_query['features']) == 1


### PR DESCRIPTION
Adds support for https://docs.ogc.org/DRAFTS/19-079.html

Note that `tests/test_ogcapi_records_pycsw.py` will pass once https://github.com/geopython/pycsw/pull/715 goes live on https://demo.pycsw.org/cite.