### PR TITLE
CSW: add headers to CatalogueServiceWeb init

### DIFF
--- a/owslib/catalogue/csw2.py
+++ b/owslib/catalogue/csw2.py
@@ -43,7 +43,7 @@ schema_location = '%s %s' % (namespaces['csw'], schema)
 class CatalogueServiceWeb(object):
     """ csw request class """
     def __init__(self, url, lang='en-US', version='2.0.2', timeout=10, skip_caps=False,
-                 username=None, password=None, auth=None):
+                 username=None, password=None, auth=None, headers=None):
         """
 
         Construct and process a GetCapabilities request
@@ -59,6 +59,7 @@ class CatalogueServiceWeb(object):
         - username: username for HTTP basic authentication
         - password: password for HTTP basic authentication
         - auth: instance of owslib.util.Authentication
+        - headers: HTTP headers to send with requests
 
         """
         if auth:
@@ -71,6 +72,7 @@ class CatalogueServiceWeb(object):
         self.version = version
         self.timeout = timeout
         self.auth = auth or Authentication(username, password)
+        self.headers = headers
         self.service = 'CSW'
         self.exceptionreport = None
         self.owscommon = ows.OwsCommon('1.0.0')
@@ -677,8 +679,8 @@ class CatalogueServiceWeb(object):
         if isinstance(self.request, str):  # GET KVP
             self.request = '%s%s' % (bind_url(request_url), self.request)
             self.response = openURL(
-                self.request, None, 'Get', timeout=self.timeout, auth=self.auth
-            ).read()
+                self.request, None, 'Get', timeout=self.timeout, auth=self.auth,
+                headers=self.headers).read()
         else:
             self.request = cleanup_namespaces(self.request)
             # Add any namespaces used in the "typeNames" attribute of the

--- a/owslib/catalogue/csw3.py
+++ b/owslib/catalogue/csw3.py
@@ -43,7 +43,7 @@ schema_location = '%s %s' % (namespaces['csw30'], schema)
 class CatalogueServiceWeb(object):
     """ csw request class """
     def __init__(self, url, lang='en-US', version='3.0.0', timeout=10, skip_caps=False,
-                 username=None, password=None, auth=None):
+                 username=None, password=None, auth=None, headers=None):
         """
 
         Construct and process a GetCapabilities request
@@ -59,6 +59,7 @@ class CatalogueServiceWeb(object):
         - username: username for HTTP basic authentication
         - password: password for HTTP basic authentication
         - auth: instance of owslib.util.Authentication
+        - headers: HTTP headers to send with requests
 
         """
         if auth:
@@ -71,6 +72,7 @@ class CatalogueServiceWeb(object):
         self.version = version
         self.timeout = timeout
         self.auth = auth or Authentication(username, password)
+        self.headers = headers
         self.service = 'CSW'
         self.exceptionreport = None
         self.owscommon = ows.OwsCommon('2.0.0')
@@ -567,8 +569,11 @@ class CatalogueServiceWeb(object):
 
         if isinstance(self.request, str):  # GET KVP
             self.request = '%s%s' % (bind_url(request_url), self.request)
+            headers_ = {'Accept': outputformat}
+            if self.headers:
+                headers_.update(self.headers)
             self.response = openURL(
-                self.request, None, 'Get', timeout=self.timeout, auth=self.auth, headers={'Accept': outputformat}
+                self.request, None, 'Get', timeout=self.timeout, auth=self.auth, headers=headers_
             ).read()
         else:
             self.request = cleanup_namespaces(self.request)

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -18,7 +18,7 @@ from .util import clean_ows_url, Authentication
 
 
 def CatalogueServiceWeb(url, lang='en-US', version='2.0.2', timeout=10, skip_caps=False,
-                        username=None, password=None, auth=None):
+                        username=None, password=None, auth=None, headers=None):
     """
     CSW factory function, returns a version specific CatalogueServiceWeb object
 
@@ -39,6 +39,9 @@ def CatalogueServiceWeb(url, lang='en-US', version='2.0.2', timeout=10, skip_cap
     @param password: password for HTTP basic authentication
     @type auth: string
     @param auth: instance of owslib.util.Authentication
+    @type headers: dict
+    @param headers: HTTP headers to send with requests
+
     @return: initialized CatalogueServiceWeb object
     """
 
@@ -56,12 +59,12 @@ def CatalogueServiceWeb(url, lang='en-US', version='2.0.2', timeout=10, skip_cap
         return csw2.CatalogueServiceWeb(
             clean_url, lang=lang, version=version, timeout=timeout,
             skip_caps=skip_caps, username=username, password=password,
-            auth=auth)
+            auth=auth, headers=headers)
     if version == '3.0.0':
         return csw3.CatalogueServiceWeb(
             clean_url, lang=lang, version=version, timeout=timeout,
             skip_caps=skip_caps, username=username, password=password,
-            auth=auth)
+            auth=auth, headers=headers)
 
     raise NotImplementedError('The CSW version ({}) you requested is'
                               ' not implemented. Please use 2.0.2 or'

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -384,7 +384,7 @@ def testXMLAttribute(element, attribute):
     return None
 
 
-def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, password=None, auth=None):
+def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, password=None, auth=None, headers=None):
     """
 
     Invoke an HTTP POST request
@@ -396,6 +396,8 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
     - request: the request message
     - lang: the language
     - timeout: timeout in seconds
+    - auth: owslib.util.Auth instance
+    - headers: HTTP headers to send with requests
 
     """
 
@@ -404,7 +406,7 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
 
     u = urlsplit(url)
 
-    headers = {
+    headers_ = {
         'User-Agent': 'OWSLib (https://geopython.github.io/OWSLib)',
         'Content-type': 'text/xml',
         'Accept': 'text/xml,application/xml',
@@ -413,9 +415,12 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
         'Host': u.netloc,
     }
 
+    if headers:
+        headers_.update(headers)
+
     if isinstance(request, dict):
-        headers['Content-type'] = 'application/json'
-        headers.pop('Accept')
+        headers_['Content-type'] = 'application/json'
+        headers_.pop('Accept')
 
     rkwargs = {}
 
@@ -434,9 +439,9 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
     rkwargs['cert'] = auth.cert
 
     if not isinstance(request, dict):
-        return requests.post(url, request, headers=headers, **rkwargs)
+        return requests.post(url, request, headers=headers_, **rkwargs)
     else:
-        return requests.post(url, json=request, headers=headers, **rkwargs)
+        return requests.post(url, json=request, headers=headers_, **rkwargs)
 
 
 def http_get(*args, **kwargs):

--- a/tests/test_csw_headers.py
+++ b/tests/test_csw_headers.py
@@ -1,0 +1,35 @@
+from unittest import mock
+from tests.utils import service_ok
+
+import pytest
+
+from owslib.csw import CatalogueServiceWeb
+
+
+def test_csw_sends_headers():
+    """
+    Test that if headers are provided in the CSW class they are sent
+    when performing HTTP requests (in this case for GetCapabilities)
+    """
+
+    with mock.patch('owslib.util.requests.request', side_effect=RuntimeError) as mock_request:
+        try:
+            CatalogueServiceWeb(
+                'http://example.com/csw',
+                version='2.0.2',
+                headers={'User-agent': 'my-app/1.0'}
+            )
+        except RuntimeError:
+            assert mock_request.called
+            assert mock_request.call_args[1]['headers'] == {'User-agent': 'my-app/1.0'}
+
+    with mock.patch('owslib.util.requests.request', side_effect=RuntimeError) as mock_request:
+        try:
+            CatalogueServiceWeb(
+                'http://example.com/csw',
+                version='3.0.0',
+                headers={'User-agent': 'my-app/1.0'}
+            )
+        except RuntimeError:
+            assert mock_request.called
+            assert mock_request.call_args[1]['headers'] == {'Accept': 'application/xml', 'User-agent': 'my-app/1.0'}


### PR DESCRIPTION
This PR provides clients the option to add custom headers to `owslib.csw.CatalogueServiceWeb` (and thereby parity with other modules that already support this idiom).