### PR TITLE
Use ows:Keyword for WFS 2.0.0 content metadata

### DIFF
--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -529,7 +529,8 @@ class ContentMetadata(AbstractContentMetadata):
         else:
             self.abstract = None
         self.keywords = [
-            f.text for f in elem.findall(nspath("Keywords", ns=WFS_NAMESPACE))
+            f.text 
+            for f in elem.findall(nspath("Keywords/Keyword", ns=OWS_NAMESPACE))
         ]
 
         # bboxes


### PR DESCRIPTION
I noticed when making GetCapabilities requests against WFS 2.0.0 services that the keywords list for a FeatureType was empty.

The cause was the `ContentMetadata` class searching for `wfs:Keywords` rather than `ows:Keywords`. A quick look at the WFS 2.0.0 specifications seems to indicate the current behaviour is incorrect.

This PR corrects this behaviour. I have tested against a Geoserver instance, and the LINZ data service.