### PR TITLE
fix a bug for XML results parsing.

### DIFF
--- a/owslib/catalogue/csw2.py
+++ b/owslib/catalogue/csw2.py
@@ -336,7 +336,7 @@ class CatalogueServiceWeb(object):
         """
 
         if xml is not None:
-            if xml.startswith(b'<'):
+            if (isinstance(xml, bytes) and xml.startswith(b'<')) or (isinstance(xml, str) and xml.startswith('<')):
                 self.request = etree.fromstring(xml)
                 val = self.request.find(util.nspath_eval('csw:Query/csw:ElementSetName', namespaces))
                 if val is not None:

--- a/owslib/catalogue/csw3.py
+++ b/owslib/catalogue/csw3.py
@@ -224,7 +224,7 @@ class CatalogueServiceWeb(object):
         """
 
         if xml is not None:
-            if xml.startswith(b'<'):
+            if (isinstance(xml, bytes) and xml.startswith(b'<')) or (isinstance(xml, str) and xml.startswith('<')):
                 self.request = etree.fromstring(xml)
                 val = self.request.find(util.nspath_eval('csw30:Query/csw30:ElementSetName', namespaces))
                 if val is not None:


### PR DESCRIPTION
found this bug when requesting `DistributedSearch` via pycsw with `federatedcatalogues` config. Just as follows:

```
    File "/home/bk/vpy_csw/lib/python3.9/site-packages/owslib/catalogue/csw3.py", line 225, in getrecords
        if xml.startswith(b'<'):
    TypeError: startswith first arg must be str or a tuple of str, not bytes
```