### PR TITLE
WMS,WFS: add custom request parameters

### DIFF
--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -29,8 +29,7 @@ class WFSCapabilitiesReader(object):
         self._infoset = None
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
     def capabilities_url(self, service_url):
         """Return a capabilities url

--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -8,7 +8,15 @@ class WFSCapabilitiesReader(object):
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version="1.0", username=None, password=None, headers=None, auth=None):
+    def __init__(
+        self,
+        version="1.0",
+        username=None,
+        password=None,
+        headers=None,
+        auth=None,
+        **kwargs,
+    ):
         """Initialize"""
         self.headers = headers
         if auth:
@@ -19,6 +27,10 @@ class WFSCapabilitiesReader(object):
         self.auth = auth or Authentication(username, password)
         self.version = version
         self._infoset = None
+        self.vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                self.vendor_kwargs[kw] = kwargs[kw]
 
     def capabilities_url(self, service_url):
         """Return a capabilities url
@@ -35,6 +47,15 @@ class WFSCapabilitiesReader(object):
             qs.append(("request", "GetCapabilities"))
         if "version" not in params:
             qs.append(("version", self.version))
+
+        if self.vendor_kwargs:
+            if not isinstance(self.vendor_kwargs, dict):
+                raise ValueError(
+                    "vendor_kwargs ('%s'), expected 'dict()'" % self.vendor_kwargs
+                )
+            for param_key, param_value in self.vendor_kwargs.items():
+                if param_key not in params:
+                    qs.append((param_key, param_value))
 
         urlqs = urlencode(tuple(qs))
         return service_url.split("?")[0] + "?" + urlqs

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -25,7 +25,7 @@ GML_NAMESPACES = (
 
 
 def get_schema(
-    url, typename, version="1.0.0", timeout=30, headers=None, username=None, password=None, auth=None
+    url, typename, version="1.0.0", timeout=30, headers=None, username=None, password=None, auth=None, **kwargs
 ):
     """Parses DescribeFeatureType response and creates schema compatible
     with :class:`fiona`
@@ -36,6 +36,7 @@ def get_schema(
     :param int timeout: request timeout
     :param str username: service authentication username
     :param str password: service authentication password
+    :param **kwargs: key/value pairs for optional request parameters
     :param Authentication auth: instance of owslib.util.Authentication
     """
     if auth:
@@ -45,7 +46,11 @@ def get_schema(
             auth.password = password
     else:
         auth = Authentication(username, password)
-    url = _get_describefeaturetype_url(url, version, typename)
+    vendor_kwargs = {}
+    if kwargs:
+        for kw in kwargs:
+            vendor_kwargs[kw] = kwargs[kw]
+    url = _get_describefeaturetype_url(url, version, typename, **vendor_kwargs)
     root = _get_remote_describefeaturetype(url, timeout=timeout,
                                            headers=headers, auth=auth)
 
@@ -139,7 +144,7 @@ def _construct_schema(elements, nsmap):
         return None
 
 
-def _get_describefeaturetype_url(url, version, typename):
+def _get_describefeaturetype_url(url, version, typename, **kwargs):
     """Get url for describefeaturetype request
 
     :return str: url
@@ -159,6 +164,10 @@ def _get_describefeaturetype_url(url, version, typename):
         query_string.append(("version", version))
 
     query_string.append(("typeName", typename))
+    if kwargs:
+        for kw in kwargs:
+            if kw not in params:
+                query_string.append((kw, kwargs[kw]))
 
     urlqs = urlencode(tuple(query_string))
     return url.split("?")[0] + "?" + urlqs

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -97,8 +97,7 @@ class WebFeatureService_1_0_0(object):
         obj = object.__new__(self)
         vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                vendor_kwargs[kw] = kwargs[kw]
+            vendor_kwargs.update(kwargs)
         obj.__init__(
             url,
             version,
@@ -147,8 +146,7 @@ class WebFeatureService_1_0_0(object):
         self._capabilities = None
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
         reader = WFSCapabilitiesReader(
             self.version,
             headers=self.headers,

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -86,8 +86,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         obj = object.__new__(self)
         vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                vendor_kwargs[kw] = kwargs[kw]
+            vendor_kwargs.update(kwargs)
         obj.__init__(
             url,
             version,
@@ -138,8 +137,7 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         self._capabilities = None
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
         self.owscommon = OwsCommon("1.0.0")
         reader = WFSCapabilitiesReader(
             self.version,

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -78,8 +78,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         obj = object.__new__(self)
         vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                vendor_kwargs[kw] = kwargs[kw]
+            vendor_kwargs.update(kwargs)
         obj.__init__(
             url,
             version,
@@ -131,8 +130,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         self._capabilities = None
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
         reader = WFSCapabilitiesReader(
             self.version,
             headers=self.headers,

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -57,6 +57,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         username=None,
         password=None,
         auth=None,
+        **kwargs,
     ):
         """ overridden __new__ method
 
@@ -71,9 +72,14 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         @param username: service authentication username
         @param password: service authentication password
         @param auth: instance of owslib.util.Authentication
+        @param **kwargs: optional request parameters
         @return: initialized WebFeatureService_2_0_0 object
         """
         obj = object.__new__(self)
+        vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                vendor_kwargs[kw] = kwargs[kw]
         obj.__init__(
             url,
             version,
@@ -84,6 +90,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             username=username,
             password=password,
             auth=auth,
+            **vendor_kwargs,
         )
         return obj
 
@@ -105,6 +112,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         username=None,
         password=None,
         auth=None,
+        **kwargs,
     ):
         """Initialize."""
         if auth:
@@ -121,7 +129,16 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         self.timeout = timeout
         self.headers = headers
         self._capabilities = None
-        reader = WFSCapabilitiesReader(self.version, headers=self.headers, auth=self.auth)
+        self.vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                self.vendor_kwargs[kw] = kwargs[kw]
+        reader = WFSCapabilitiesReader(
+            self.version,
+            headers=self.headers,
+            auth=self.auth,
+            **self.vendor_kwargs,
+        )
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -204,10 +221,12 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         """Request and return capabilities document from the WFS as a
         file-like object.
         NOTE: this is effectively redundant now"""
-        reader = WFSCapabilitiesReader(self.version, auth=self.auth)
+        reader = WFSCapabilitiesReader(self.version, auth=self.auth, **self.vendor_kwargs)
         return openURL(
-            reader.capabilities_url(self.url), timeout=self.timeout,
-            headers=self.headers, auth=self.auth
+            reader.capabilities_url(self.url),
+            timeout=self.timeout,
+            headers=self.headers,
+            auth=self.auth,
         )
 
     def items(self):
@@ -322,7 +341,14 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 startindex,
                 sortby)
 
-        u = openURL(url, data, method, timeout=self.timeout, headers=self.headers, auth=self.auth)
+        u = openURL(
+                url,
+                data,
+                method,
+                timeout=self.timeout,
+                headers=self.headers,
+                auth=self.auth
+            )
 
         # check for service exceptions, rewrap, and return
         # We're going to assume that anything with a content-length > 32k

--- a/owslib/map/common.py
+++ b/owslib/map/common.py
@@ -8,7 +8,7 @@ class WMSCapabilitiesReader(object):
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version='1.1.1', url=None, un=None, pw=None, headers=None, auth=None):
+    def __init__(self, version='1.1.1', url=None, un=None, pw=None, headers=None, auth=None, **kwargs):
         """Initialize"""
         self.version = version
         self._infoset = None
@@ -21,6 +21,11 @@ class WMSCapabilitiesReader(object):
         self.headers = headers
         self.request = None
         self.auth = auth or Authentication(un, pw)
+        self.vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                self.vendor_kwargs[kw] = kwargs[kw]
+
 
         # if self.username and self.password:
         #     # Provide login information in order to use the WMS server
@@ -47,6 +52,11 @@ class WMSCapabilitiesReader(object):
             qs.append(('request', 'GetCapabilities'))
         if 'version' not in params:
             qs.append(('version', self.version))
+
+        if self.vendor_kwargs:
+             for kw in self.vendor_kwargs:
+                if kw not in params:
+                    qs.append((kw, self.vendor_kwargs[kw]))
 
         urlqs = urlencode(tuple(qs))
         return service_url.split('?')[0] + '?' + urlqs

--- a/owslib/map/common.py
+++ b/owslib/map/common.py
@@ -23,8 +23,7 @@ class WMSCapabilitiesReader(object):
         self.auth = auth or Authentication(un, pw)
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
 
         # if self.username and self.password:

--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -52,7 +52,8 @@ class WebMapService_1_1_1(object):
             raise KeyError("No content named %s" % name)
 
     def __init__(self, url, version='1.1.1', xml=None, username=None, password=None,
-                 parse_remote_metadata=False, headers=None, timeout=30, auth=None):
+                 parse_remote_metadata=False, headers=None, timeout=30, auth=None,
+                 **kwargs):
         """Initialize."""
         if auth:
             if username:
@@ -65,10 +66,15 @@ class WebMapService_1_1_1(object):
         self.headers = headers
         self._capabilities = None
         self.auth = auth or Authentication(username, password)
+        self.vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                self.vendor_kwargs[kw] = kwargs[kw]
+
 
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(
-            self.version, url=self.url, headers=headers, auth=self.auth)
+            self.version, url=self.url, headers=headers, auth=self.auth, **self.vendor_kwargs)
         if xml:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
@@ -142,7 +148,7 @@ class WebMapService_1_1_1(object):
         NOTE: this is effectively redundant now"""
 
         reader = WMSCapabilitiesReader(
-            self.version, url=self.url, auth=self.auth)
+            self.version, url=self.url, auth=self.auth, **self.vendor_kwargs)
         u = self._open(reader.capabilities_url(self.url))
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':

--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -68,8 +68,7 @@ class WebMapService_1_1_1(object):
         self.auth = auth or Authentication(username, password)
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
 
         # Authentication handled by Reader

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -52,7 +52,7 @@ class WebMapService_1_3_0(object):
 
     def __init__(self, url, version='1.3.0', xml=None, username=None,
                  password=None, parse_remote_metadata=False, timeout=30,
-                 headers=None, auth=None):
+                 headers=None, auth=None, **kwargs):
         """initialize"""
         if auth:
             if username:
@@ -65,10 +65,14 @@ class WebMapService_1_3_0(object):
         self.headers = headers
         self._capabilities = None
         self.auth = auth or Authentication(username, password)
+        self.vendor_kwargs = {}
+        if kwargs:
+            for kw in kwargs:
+                self.vendor_kwargs[kw] = kwargs[kw]
 
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(
-            self.version, url=self.url, headers=headers, auth=self.auth)
+            self.version, url=self.url, headers=headers, auth=self.auth, **self.vendor_kwargs)
         if xml:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -67,8 +67,7 @@ class WebMapService_1_3_0(object):
         self.auth = auth or Authentication(username, password)
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -45,8 +45,7 @@ def WebFeatureService(url, version='1.0.0', xml=None,
         auth = Authentication(username, password)
     vendor_kwargs = {}
     if kwargs:
-        for kw in kwargs:
-            vendor_kwargs[kw] = kwargs[kw]
+        vendor_kwargs.update(kwargs)
     clean_url = clean_ows_url(url)
 
     if version in ['1.0', '1.0.0']:

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -19,7 +19,7 @@ from .util import clean_ows_url, Authentication
 
 def WebFeatureService(url, version='1.0.0', xml=None,
                       parse_remote_metadata=False, timeout=30, username=None,
-                      password=None, headers=None, auth=None):
+                      password=None, headers=None, auth=None, **kwargs):
     ''' wfs factory function, returns a version specific WebFeatureService object
 
     @type url: string
@@ -33,6 +33,7 @@ def WebFeatureService(url, version='1.0.0', xml=None,
     @param username: service authentication username
     @param password: service authentication password
     @param auth: instance of owslib.util.Authentication
+    @param **kwargs : extra arguments. Anything else e.g. vendor specific parameters
     @return: initialized WebFeatureService object (version dependent)
     '''
     if auth:
@@ -42,17 +43,24 @@ def WebFeatureService(url, version='1.0.0', xml=None,
             auth.password = password
     else:
         auth = Authentication(username, password)
+    vendor_kwargs = {}
+    if kwargs:
+        for kw in kwargs:
+            vendor_kwargs[kw] = kwargs[kw]
     clean_url = clean_ows_url(url)
 
     if version in ['1.0', '1.0.0']:
         return wfs100.WebFeatureService_1_0_0(
             clean_url, version, xml, parse_remote_metadata,
-            timeout=timeout, headers=headers, auth=auth)
+            timeout=timeout, headers=headers, auth=auth,
+            **vendor_kwargs)
     elif version in ['1.1', '1.1.0']:
         return wfs110.WebFeatureService_1_1_0(
             clean_url, version, xml, parse_remote_metadata,
-            timeout=timeout, headers=headers, auth=auth)
+            timeout=timeout, headers=headers, auth=auth,
+            **vendor_kwargs)
     elif version in ['2.0', '2.0.0']:
         return wfs200.WebFeatureService_2_0_0(
             clean_url, version, xml, parse_remote_metadata,
-            timeout=timeout, headers=headers, auth=auth)
+            timeout=timeout, headers=headers, auth=auth,
+            **vendor_kwargs)

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -20,7 +20,7 @@ from .util import clean_ows_url, Authentication
 
 
 def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
-                  parse_remote_metadata=False, timeout=30, headers=None, auth=None):
+                  parse_remote_metadata=False, timeout=30, headers=None, auth=None, **kwargs):
 
     '''wms factory function, returns a version specific WebMapService object
 
@@ -35,6 +35,7 @@ def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
     @param username: service authentication username
     @param password: service authentication password
     @param auth: instance of owslib.util.Authentication
+    @param **kwargs : extra arguments. Anything else e.g. vendor specific parameters
     @return: initialized WebFeatureService_2_0_0 object
     '''
     if auth:
@@ -45,14 +46,19 @@ def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
     else:
         auth = Authentication(username, password)
     clean_url = clean_ows_url(url)
+    vendor_kwargs = {}
+    if kwargs:
+        for kw in kwargs:
+            vendor_kwargs[kw] = kwargs[kw]
+
 
     if version in ['1.1.1']:
         return wms111.WebMapService_1_1_1(
             clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,
-            timeout=timeout, headers=headers, auth=auth)
+            timeout=timeout, headers=headers, auth=auth, **vendor_kwargs)
     elif version in ['1.3.0']:
         return wms130.WebMapService_1_3_0(
             clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,
-            timeout=timeout, headers=headers, auth=auth)
+            timeout=timeout, headers=headers, auth=auth, **vendor_kwargs)
     raise NotImplementedError(
         'The WMS version ({}) you requested is not implemented. Please use 1.1.1 or 1.3.0.'.format(version))

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -48,8 +48,7 @@ def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
     clean_url = clean_ows_url(url)
     vendor_kwargs = {}
     if kwargs:
-        for kw in kwargs:
-            vendor_kwargs[kw] = kwargs[kw]
+        vendor_kwargs.update(kwargs)
 
 
     if version in ['1.1.1']:

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -169,8 +169,7 @@ class WebMapTileService(object):
         self.timeout = timeout or 30
         self.vendor_kwargs = {}
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
         # Authentication handled by Reader
         reader = WMTSCapabilitiesReader(
@@ -830,8 +829,7 @@ class WMTSCapabilitiesReader:
         self.vendor_kwargs = {}
         self.headers=headers
         if kwargs:
-            for kw in kwargs:
-                self.vendor_kwargs[kw] = kwargs[kw]
+            self.vendor_kwargs.update(kwargs)
 
 
     def capabilities_url(self, service_url):


### PR DESCRIPTION
This pull request:
- adds the possibility to add additional URL request parameters for WMS and WFS services.
- moves the `vendor_kwargs` parameters of WMTS methods in the constructor

Fixes https://github.com/geopython/OWSLib/issues/810

breaking changes:
- the parameter `vendor_kwargs` in wmts functions is removed, and replaced with a `**kwargs` logic in the wmts main constructor. The reason for this is that some vendors require additional parameters already in the GetCapabilities request. Also,  if all the requests need to be "decorated" with custom parameters, it makes sense to put them already in the constructor.
