### PR TITLE
CSW: support bytes or str for incoming XML requests

### DIFF
--- a/owslib/catalogue/csw2.py
+++ b/owslib/catalogue/csw2.py
@@ -336,7 +336,12 @@ class CatalogueServiceWeb(object):
         """
 
         if xml is not None:
-            if xml.startswith(b'<'):
+            if isinstance(xml, bytes):
+                startswith_xml = xml.startswith(b'<')
+            else:  # str
+                startswith_xml = xml.startswith('<')
+
+            if startswith_xml:
                 self.request = etree.fromstring(xml)
                 val = self.request.find(util.nspath_eval('csw:Query/csw:ElementSetName', namespaces))
                 if val is not None:

--- a/owslib/catalogue/csw3.py
+++ b/owslib/catalogue/csw3.py
@@ -224,7 +224,12 @@ class CatalogueServiceWeb(object):
         """
 
         if xml is not None:
-            if xml.startswith(b'<'):
+            if isinstance(xml, bytes):
+                startswith_xml = xml.startswith(b'<')
+            else:  # str
+                startswith_xml = xml.startswith('<')
+
+            if startswith_xml:
                 self.request = etree.fromstring(xml)
                 val = self.request.find(util.nspath_eval('csw30:Query/csw30:ElementSetName', namespaces))
                 if val is not None:


### PR DESCRIPTION
Addressing [this pycsw issue](https://github.com/geopython/pycsw/issues/729), this PR safeguards CSW federated search by handling either `bytes` or `str` input for incoming XML payloads (further safeguarding previous fix in https://github.com/geopython/OWSLib/pull/776).