### PR TITLE
Use yaml.safe_load instead of yaml.load.

### DIFF
--- a/owslib/ogcapi/__init__.py
+++ b/owslib/ogcapi/__init__.py
@@ -100,7 +100,7 @@ class API:
             if openapi_format == openapi_json_mimetype:
                 content = response.json()
             elif openapi_format == openapi_yaml_mimetype:
-                content = yaml.load(response.text)
+                content = yaml.safe_load(response.text)
             return content
         else:
             msg = 'Did not find service-desc link'


### PR DESCRIPTION
As reported in [Debian Bug #1022033](https://bugs.debian.org/1022033):
> We hope to upgrade python3-yaml (aka pyyaml) to version 6 before the freeze, per [#1008262](https://bugs.debian.org/1008262)
>
> Your package appears to use `yaml.load()` without specifying a `Loader=` argument, which will become an error in pyyaml version 6. This should have emitted a warning message since version 5.1 (from 2019).
>
> In most cases this can be fixed by replacing `yaml.load` with `yaml.safe_load`, unless the ability for yaml to create arbitrary python objects is desirable.
>
>
> Found in https://sources.debian.org/src/owslib/0.27.2-1/owslib/ogcapi/__init__.py/?hl=102#L102 (but only when loading openapi in yaml format - not sure if this codepath is much used).

From https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml:
> Warning: It is not safe to call `yaml.load` with any data received from an untrusted source! `yaml.load` is as powerful as `pickle.load` and so may call any Python function. Check the `yaml.safe_load` function though.
> 
> [...]
> 
> Note that the ability to construct an arbitrary Python object may be dangerous if you receive a YAML document from an untrusted source such as the Internet. The function `yaml.safe_load` limits this ability to simple Python objects like integers or lists.
> 
> A python object can be marked as safe and thus be recognized by `yaml.safe_load`. To do this, derive it from `yaml.YAMLObject` (as explained in section [Constructors, representers, resolvers](https://pyyaml.org/wiki/PyYAMLDocumentation#constructors-representers-resolvers)) and explicitly set its class property `yaml_loader` to `yaml.SafeLoader`.
