### PR TITLE
Allow optional setting of bgcolor in a WMS GetMap request

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -175,8 +175,10 @@ class WebMapService_1_1_1(object):
         request['bbox'] = ','.join([repr(x) for x in bbox])
         request['format'] = str(format)
         request['transparent'] = str(transparent).upper()
-        request['bgcolor'] = '0x' + bgcolor[1:7]
         request['exceptions'] = str(exceptions)
+
+        if bgcolor:
+            request['bgcolor'] = '0x' + bgcolor[1:7]
 
         if time is not None:
             request['time'] = str(time)

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -186,8 +186,10 @@ class WebMapService_1_3_0(object):
         request['bbox'] = ','.join([repr(x) for x in bbox])
         request['format'] = str(format)
         request['transparent'] = str(transparent).upper()
-        request['bgcolor'] = '0x' + bgcolor[1:7]
         request['exceptions'] = str(exceptions)
+
+        if bgcolor:
+            request['bgcolor'] = '0x' + bgcolor[1:7]
 
         if time is not None:
             request['time'] = str(time)

--- a/tests/test_wms_getmap.py
+++ b/tests/test_wms_getmap.py
@@ -122,6 +122,28 @@ def test_getmap_130_national_map():
     assert "height=300" in wms.request
     assert "format=image%2Fpng" in wms.request
     assert "transparent=TRUE" in wms.request
+    assert "bgcolor=0x#FFFFFF" in wms.request
+
+
+@pytest.mark.online
+@pytest.mark.skip(reason="this is a flaky test")
+# @pytest.mark.skipif(not service_ok(SERVICE_URL_NATIONAL_MAP),
+#                    reason="WMS service is unreachable")
+def test_getmap_130_national_map_no_bgcolor():
+    """National Map"""
+    url = SERVICE_URL_NATIONAL_MAP
+    wms = WebMapService(url, version='1.3.0')
+    rsp = wms.getmap(
+        layers=['3'],
+        styles=['default'],
+        srs='CRS:84',
+        bbox=(-176.646, 17.7016, -64.8017, 71.2854),
+        size=(500, 300),
+        format='image/png',
+        transparent=True,
+        bgcolor=None)
+    assert type(rsp) is ResponseWrapper
+    assert "bgcolor" not in wms.request
 
 
 @pytest.mark.online
@@ -153,6 +175,7 @@ def test_ncwms2():
     assert "height=256" in wms.request
     assert "format=image%2Fpng" in wms.request
     assert "transparent=TRUE" in wms.request
+    assert "bgcolor=0x#FFFFFF" in wms.request
 
 
 @pytest.mark.parametrize('wms_version', ['1.1.1', '1.3.0'])


### PR DESCRIPTION
In a WMS `GetMap` request `bgcolor` is marked as optional:

```
        bgcolor : string
            Optional. Image background color.
```

However attempting to set this parameter to None or an empty string will currently throw an error. This pull request allows `None` (or an empty string) to be passed to a `GetMap` request to avoid setting a background color.
This is useful, for example, when using MapServer which may have an  [IMAGECOLOR ](https://mapserver.org/mapfile/map.html#mapfile-map-imagecolor) set in a Mapfile, and to allow a WMS request to use this color by default. Otherwise currently OWSLib defaults to setting a white background, or requiring a different color to be set. 

The update then allows the following:
```python
resp = wms.getmap(
   layers=['3'],
   styles=['default'],
   srs='CRS:84',
   bbox=(-176.646, 17.7016, -64.8017, 71.2854),
   size=(500, 300),
    format="image/png",
    bgcolor="", # allow background colors set in the map to be used
    transparent=False,
)
```
