### PR TITLE
update OAProc process list filtering

### DIFF
--- a/owslib/ogcapi/coverages.py
+++ b/owslib/ogcapi/coverages.py
@@ -24,11 +24,11 @@ class Coverages(Collections):
         __doc__ = Collections.__doc__  # noqa
         super().__init__(url, json_, timeout, headers, auth)
 
-    def coverages(self) -> dict:
+    def coverages(self) -> list:
         """
         implements /collections filtered on coverages
 
-        @returns: `dict` of filtered collections object
+        @returns: `list` of filtered collections object
         """
 
         coverages_ = []

--- a/owslib/ogcapi/features.py
+++ b/owslib/ogcapi/features.py
@@ -24,11 +24,11 @@ class Features(Collections):
         __doc__ = Collections.__doc__  # noqa
         super().__init__(url, json_, timeout, headers, auth)
 
-    def feature_collections(self) -> dict:
+    def feature_collections(self) -> list:
         """
         implements /collections filtered on features
 
-        @returns: `dict` of filtered collections object
+        @returns: `list` of filtered collections object
         """
 
         features_ = []

--- a/owslib/ogcapi/maps.py
+++ b/owslib/ogcapi/maps.py
@@ -24,11 +24,11 @@ class Maps(Collections):
         __doc__ = Collections.__doc__  # noqa
         super().__init__(url, json_, timeout, headers, auth)
 
-    def maps(self) -> dict:
+    def maps(self) -> list:
         """
         implements /collections filtered on maps
 
-        @returns: `dict` of filtered collections object
+        @returns: `list` of filtered collections object
         """
 
         maps_ = []

--- a/owslib/ogcapi/processes.py
+++ b/owslib/ogcapi/processes.py
@@ -22,15 +22,15 @@ class Processes(Collections):
         __doc__ = Collections.__doc__  # noqa
         super().__init__(url, json_, timeout, headers, auth)
 
-    def processes(self) -> dict:
+    def processes(self) -> list:
         """
         implements /processes
 
-        @returns: `dict` of available processes
+        @returns: `list` of available processes
         """
 
         path = 'processes'
-        return self._request(path=path)
+        return self._request(path=path)['processes']
 
     def process(self, process_id: str) -> dict:
         """

--- a/owslib/ogcapi/records.py
+++ b/owslib/ogcapi/records.py
@@ -22,11 +22,11 @@ class Records(Features):
         __doc__ = Features.__doc__  # noqa
         super().__init__(url, json_, timeout, headers, auth)
 
-    def records(self) -> dict:
+    def records(self) -> list:
         """
         implements /collections filtered on records
 
-        @returns: `dict` of filtered collections object
+        @returns: `list` of filtered collections object
         """
 
         records_ = []

--- a/tests/test_ogcapi_processes_pygeoapi.py
+++ b/tests/test_ogcapi_processes_pygeoapi.py
@@ -29,7 +29,7 @@ def test_ogcapi_processes_pygeoapi():
     assert len(collections) > 0
 
     processes = p.processes()
-    assert len(processes) == 1
+    assert len(processes) == 3
 
     hello_world = p.process('hello-world')
     assert hello_world['id'] == 'hello-world'


### PR DESCRIPTION
Ensure that `owslib.ogcapi.processes:Processes.processes() returns a list of only processes (not links).