### PR TITLE
Raise an error if GetCapabilities requests don't return XML

### DIFF
--- a/owslib/coverage/wcsBase.py
+++ b/owslib/coverage/wcsBase.py
@@ -11,7 +11,7 @@
 
 from urllib.parse import urlencode, parse_qsl
 from owslib.etree import etree
-from owslib.util import Authentication, openURL
+from owslib.util import Authentication, openURL, getXMLTree
 
 
 class ServiceException(Exception):
@@ -118,7 +118,7 @@ class WCSCapabilitiesReader(object):
         """
         request = self.capabilities_url(service_url)
         u = openURL(request, timeout=timeout, cookies=self.cookies, auth=self.auth, headers=self.headers)
-        return etree.fromstring(u.read())
+        return getXMLTree(u)
 
     def readString(self, st):
         """Parse a WCS capabilities document, returning an

--- a/owslib/feature/common.py
+++ b/owslib/feature/common.py
@@ -1,5 +1,5 @@
 from owslib.etree import etree
-from owslib.util import Authentication, openURL
+from owslib.util import Authentication, openURL, getXMLTree
 
 from urllib.parse import urlencode, parse_qsl
 
@@ -52,7 +52,7 @@ class WFSCapabilitiesReader(object):
         """
         request = self.capabilities_url(url)
         u = openURL(request, timeout=timeout, headers=self.headers, auth=self.auth)
-        return etree.fromstring(u.read())
+        return getXMLTree(u)
 
     def readString(self, st):
         """Parse a WFS capabilities document, returning an

--- a/owslib/map/common.py
+++ b/owslib/map/common.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode, parse_qsl
 
 from owslib.etree import etree
-from owslib.util import strip_bom, Authentication, openURL
+from owslib.util import strip_bom, Authentication, openURL, getXMLTree
 
 
 class WMSCapabilitiesReader(object):
@@ -64,24 +64,7 @@ class WMSCapabilitiesReader(object):
         spliturl = self.request.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get',
                     timeout=timeout, headers=self.headers, auth=self.auth)
-
-        raw_text = strip_bom(u.read())
-        et = etree.fromstring(raw_text)
-
-        # check for response type - if it is not xml then raise an error
-        content_type = u.info()['Content-Type']
-        if content_type != 'text/xml':
-            html_body = et.find('BODY') # this is case-sensitive
-
-            if html_body.text:
-                response_text = html_body.text.strip("\n")
-            else:
-                response_text = raw_text
-
-            raise ValueError("%s responded with Content-Type '%s': '%s'" %
-                (u.geturl(), content_type, response_text))
-
-        return et
+        return getXMLTree(u)
 
     def readString(self, st):
         """Parse a WMS capabilities document, returning an elementtree instance.

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode, parse_qsl
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes import FilterCapabilities
-from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time
+from owslib.util import openURL, testXMLValue, nspath_eval, nspath, extract_time, getXMLTree
 from owslib.namespaces import Namespaces
 
 
@@ -314,7 +314,7 @@ class SosCapabilitiesReader(object):
         getcaprequest = self.capabilities_url(service_url)
         spliturl = getcaprequest.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
-        return etree.fromstring(u.read())
+        return getXMLTree(u)
 
     def read_string(self, st):
         """

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode, parse_qsl
 from owslib import ows
 from owslib.crs import Crs
 from owslib.fes2 import FilterCapabilities
-from owslib.util import openURL, testXMLValue, testXMLAttribute, nspath_eval, extract_time
+from owslib.util import openURL, testXMLValue, testXMLAttribute, nspath_eval, extract_time, getXMLTree
 from owslib.namespaces import Namespaces
 from owslib.swe.observation.om import MeasurementObservation
 from owslib.swe.observation.waterml2 import MeasurementTimeseriesObservation
@@ -331,7 +331,7 @@ class SosCapabilitiesReader(object):
         getcaprequest = self.capabilities_url(service_url)
         spliturl = getcaprequest.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get', username=self.username, password=self.password)
-        return etree.fromstring(u.read())
+        return getXMLTree(u)
 
     def read_string(self, st):
         """

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -326,6 +326,38 @@ def getXMLInteger(elem, tag):
     return int(e.text.strip())
 
 
+def getXMLTree(responseWrapper):
+    """
+    Parse a response into an XML elementtree instance
+    
+    Parameters
+    ----------
+
+    - responseWrapper: the response wrapper   
+    """
+    
+    raw_text = strip_bom(responseWrapper.read())
+    et = etree.fromstring(raw_text)
+        
+    # check for response type - if it is not xml then raise an error
+    content_type = responseWrapper.info()['Content-Type']
+    url = responseWrapper.geturl()
+    
+    if content_type != 'text/xml':
+        html_body = et.find('BODY') # this is case-sensitive
+        print(html_body)
+        print(html_body.text)
+        if html_body and html_body.text:
+            response_text = html_body.text.strip("\n")
+        else:
+            response_text = raw_text
+
+        raise ValueError("%s responded with Content-Type '%s': '%s'" %
+            (url, content_type, response_text))
+            
+    return et
+
+
 def testXMLValue(val, attrib=False):
     """
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -346,7 +346,7 @@ def getXMLTree(rsp: ResponseWrapper) -> etree:
     content_type = rsp.info()['Content-Type']
     url = rsp.geturl()
 
-    xml_types = ['text/xml', 'application/xml']
+    xml_types = ['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']
     if not any(xt in content_type.lower() for xt in xml_types):
         html_body = et.find('BODY') # note this is case-sensitive
         if html_body is not None and len(html_body.text) > 0:

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -326,35 +326,36 @@ def getXMLInteger(elem, tag):
     return int(e.text.strip())
 
 
-def getXMLTree(responseWrapper):
+def getXMLTree(rsp: ResponseWrapper) -> etree:
     """
     Parse a response into an XML elementtree instance
-    
+    and raise a ValueError if the server returns a
+    non-XML response. The response may contain a useful
+    error message from the server.
+
     Parameters
     ----------
 
-    - responseWrapper: the response wrapper   
+    @param rsp: the ResponseWrapper for the XML request
     """
-    
-    raw_text = strip_bom(responseWrapper.read())
+
+    raw_text = strip_bom(rsp.read())
     et = etree.fromstring(raw_text)
-        
+
     # check for response type - if it is not xml then raise an error
-    content_type = responseWrapper.info()['Content-Type']
-    url = responseWrapper.geturl()
-    
-    if content_type != 'text/xml':
-        html_body = et.find('BODY') # this is case-sensitive
-        print(html_body)
-        print(html_body.text)
-        if html_body and html_body.text:
+    content_type = rsp.info()['Content-Type']
+    url = rsp.geturl()
+
+    if 'text/xml' not in content_type.lower():
+        html_body = et.find('BODY') # note this is case-sensitive
+        if html_body is not None and len(html_body.text) > 0:
             response_text = html_body.text.strip("\n")
         else:
             response_text = raw_text
 
         raise ValueError("%s responded with Content-Type '%s': '%s'" %
             (url, content_type, response_text))
-            
+
     return et
 
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -348,14 +348,14 @@ def getXMLTree(rsp: ResponseWrapper) -> etree:
 
     xml_types = ['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']
     if not any(xt in content_type.lower() for xt in xml_types):
-        html_body = et.find('BODY') # note this is case-sensitive
+        html_body = et.find('BODY')  # note this is case-sensitive
         if html_body is not None and len(html_body.text) > 0:
             response_text = html_body.text.strip("\n")
         else:
             response_text = raw_text
 
         raise ValueError("%s responded with Content-Type '%s': '%s'" %
-            (url, content_type, response_text))
+                         (url, content_type, response_text))
 
     return et
 

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -346,7 +346,8 @@ def getXMLTree(rsp: ResponseWrapper) -> etree:
     content_type = rsp.info()['Content-Type']
     url = rsp.geturl()
 
-    if 'text/xml' not in content_type.lower():
+    xml_types = ['text/xml', 'application/xml']
+    if not any(xt in content_type.lower() for xt in xml_types):
         html_body = et.find('BODY') # note this is case-sensitive
         if html_body is not None and len(html_body.text) > 0:
             response_text = html_body.text.strip("\n")

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -34,7 +34,7 @@ import warnings
 from urllib.parse import (urlencode, urlparse, urlunparse, parse_qs,
                           ParseResult)
 from .etree import etree
-from .util import clean_ows_url, testXMLValue, getXMLInteger, Authentication, openURL
+from .util import clean_ows_url, testXMLValue, getXMLInteger, Authentication, openURL, getXMLTree
 from .fgdc import Metadata
 from .iso import MD_Metadata
 from .ows import ServiceProvider, ServiceIdentification, OperationsMetadata
@@ -929,7 +929,7 @@ class WMTSCapabilitiesReader:
         # now split it up again to use the generic openURL function...
         spliturl = getcaprequest.split('?')
         u = openURL(spliturl[0], spliturl[1], method='Get', headers=self.headers, auth=self.auth)
-        return etree.fromstring(u.read())
+        return getXMLTree(u)
 
     def readString(self, st):
         """Parse a WMTS capabilities document, returning an elementtree instance

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 import codecs
 from unittest import mock
+import pytest
 from owslib.util import clean_ows_url, build_get_url, strip_bom, extract_time, ResponseWrapper, getXMLTree
 from owslib.etree import etree
 from datetime import datetime, timezone


### PR DESCRIPTION
Currently if a GetCapabilities request doesn't return an XML document it raises cryptic error messages such as:

```
  File "owslib\feature\wfs200.py", line 164, in _buildMetadata
    for elem in self._capabilities.find(nspath("OperationsMetadata"))[:]:
TypeError: 'NoneType' object is not subscriptable
```

This pull request checks to see if the server response `Content-Type` is XML, and if not it raises an exception that includes the URL and response. If the response is HTML it attempts to parse the body of the document to use as the error message. This is particularly useful when working with MapServer which returns errors in `text/html` format. E.g.

```
http:///example.org/?service=WFS&request=GetCapabilities&version=2.0.0 responded 
with Content-Type 'text/html': 'msCGILoadMap(): Web application error. CGI variable "map" is not set.'
```

Currently any `Content-Type` which has any match/partial match against the following list will be considered as XML: `
['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']`

It may be better to just check for `xml` in case there are types I've missed?

In addition the `strip_bom` was only previously used for WMS GetCapabilities requests - this change means it is applied to all service types (WFS, SOS, WCS, WMTS). 

