### PR TITLE
remove use of logging.isEnabledFor()

### DIFF
--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -156,11 +156,10 @@ class WebCoverageService_1_1_0(WCSBase):
         if store = true, returns a coverages XML file
         if store = false, returns a multipart mime
         """
-        if log.isEnabledFor(logging.DEBUG):
-            msg = 'WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier={}, bbox={}, time={}, format={}, rangesubset={}, gridbaseCRS={}, gridtype={}, gridCS={}, gridorigin={}, gridoffsets={}, method={}, other_arguments={}'  # noqa
-            log.debug(msg.format(
-                identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS,
-                gridorigin, gridoffsets, method, str(kwargs)))
+        msg = 'WCS 1.1.0 DEBUG: Parameters passed to GetCoverage: identifier={}, bbox={}, time={}, format={}, rangesubset={}, gridbaseCRS={}, gridtype={}, gridCS={}, gridorigin={}, gridoffsets={}, method={}, other_arguments={}'  # noqa
+        log.debug(msg.format(
+            identifier, bbox, time, format, rangesubset, gridbaseCRS, gridtype, gridCS,
+            gridorigin, gridoffsets, method, str(kwargs)))
 
         if method == 'Get':
             method = self.ns.WCS_OWS('Get')

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -153,25 +153,24 @@ class WebCoverageService_2_0_0(WCSBase):
 
 
         """
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                "WCS 2.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s"  # noqa
-                % (
-                    identifier,
-                    bbox,
-                    time,
-                    format,
-                    crs,
-                    width,
-                    height,
-                    resx,
-                    resy,
-                    resz,
-                    parameter,
-                    method,
-                    str(kwargs),
-                )
+        log.debug(
+            "WCS 2.0.0 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s"  # noqa
+            % (
+                identifier,
+                bbox,
+                time,
+                format,
+                crs,
+                width,
+                height,
+                resx,
+                resy,
+                resz,
+                parameter,
+                method,
+                str(kwargs),
             )
+        )
 
         try:
             base_url = next(

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -153,25 +153,24 @@ class WebCoverageService_2_0_1(WCSBase):
 
 
         """
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                "WCS 2.0.1 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s"  # noqa
-                % (
-                    identifier,
-                    bbox,
-                    time,
-                    format,
-                    crs,
-                    width,
-                    height,
-                    resx,
-                    resy,
-                    resz,
-                    parameter,
-                    method,
-                    str(kwargs),
-                )
+        log.debug(
+            "WCS 2.0.1 DEBUG: Parameters passed to GetCoverage: identifier=%s, bbox=%s, time=%s, format=%s, crs=%s, width=%s, height=%s, resx=%s, resy=%s, resz=%s, parameter=%s, method=%s, other_arguments=%s"  # noqa
+            % (
+                identifier,
+                bbox,
+                time,
+                format,
+                crs,
+                width,
+                height,
+                resx,
+                resy,
+                resz,
+                parameter,
+                method,
+                str(kwargs),
             )
+        )
 
         try:
             base_url = next(


### PR DESCRIPTION
Fixes #871.

This fixes an issue where given changes in made to logging in #864, the `log.isEnabledFor(logging.DEBUG)` method call in the various `owslib.coverage` modules returns an `AttributeError` since the `log`variable  no longer represents  a `Logger` instance but rather the logging module itself.

Similar to what was done in #864, the `log.debug` calls no longer sit behind an if condition and the debug messages are dispatched regardless of the  log level.