### PR TITLE
Silence FutureWarning when passing XML etree object to filter

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -348,7 +348,7 @@ class WebFeatureService_(object):
             request.set_featureid(featureid)
         elif bbox:
             request.set_bbox(self.getBBOXPost(bbox, typename))
-        elif filter:
+        elif filter is not None:
             request.set_filter(filter)
 
         if featureversion:


### PR DESCRIPTION
When passing an `xml.etree.ElementTree` object to `owslib.wfs.WebFeatureService.getfeature()` as a filter,  a `FutureWarning` will pop up:
```
  /home/myself/mambaforge/envs/my_env/lib/python3.11/site-packages/owslib/feature/__init__.py:351: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    elif filter:
```

This PR silences that warning.