### PR TITLE
Fix pip install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ numerous OGC Web Service interfaces.
 
 ## Installation
 
-The easiest way to install pywis-pubsub is via the Python [pip](https://pip.pypa.io)
+The easiest way to install OWSLib is via the Python [pip](https://pip.pypa.io)
 utility:
 
 ```bash
-pip3 install pywis-pubsub
+pip3 install OWSLib
 ```
 
 ## Requirements


### PR DESCRIPTION
Fixes the pip install command in README file.

Closes #882