### PR TITLE
Remove cgi import

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -15,7 +15,6 @@ API for Web Map Service (WMS) methods and metadata.
 Currently supports only version 1.1.1 of the WMS protocol.
 """
 
-import cgi
 from urllib.parse import urlencode
 
 import warnings


### PR DESCRIPTION
The `cgi` module is deprecated at python 3.11 and will be removed at python 3.13.  I noticed this because I got a deprecation warning while running the Cartopy tests.
https://docs.python.org/3/library/cgi.html

Fortunately, it also seems to be unused here.