### PR TITLE
Ensure schema_key is never None when reading Namespaces

### DIFF
--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -96,15 +96,14 @@ def _construct_schema(elements, nsmap):
     # if nsmap is defined, use it
     if nsmap:
         for key in nsmap:
-            if nsmap[key] == XS_NAMESPACE:
-                schema_key = key
-            if nsmap[key] in GML_NAMESPACES:
-                gml_key = key
+            if key is not None:
+                if nsmap[key] == XS_NAMESPACE:
+                    schema_key = key
+                if nsmap[key] in GML_NAMESPACES:
+                    gml_key = key
     # if no nsmap is defined, we have to guess
-    if gml_key is None:
+    else:
         gml_key = "gml"
-
-    if schema_key is None:
         schema_key = "xsd"
 
     mappings = {

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -101,8 +101,10 @@ def _construct_schema(elements, nsmap):
             if nsmap[key] in GML_NAMESPACES:
                 gml_key = key
     # if no nsmap is defined, we have to guess
-    else:
+    if gml_key is None:
         gml_key = "gml"
+
+    if schema_key is None:
         schema_key = "xsd"
 
     mappings = {

--- a/owslib/feature/schema.py
+++ b/owslib/feature/schema.py
@@ -101,9 +101,12 @@ def _construct_schema(elements, nsmap):
                     schema_key = key
                 if nsmap[key] in GML_NAMESPACES:
                     gml_key = key
-    # if no nsmap is defined, we have to guess
-    else:
+
+    # if no nsmap keys are defined, we have to guess
+    if gml_key is None:
         gml_key = "gml"
+
+    if schema_key is None:
         schema_key = "xsd"
 
     mappings = {


### PR DESCRIPTION
I ran into an issue when generating schemas from a MapServer `DescribeFeatureType` request. The `properties` were always empty:

```python
wfs = WebFeatureService(url=url, version="2.0.0")
print(feature_type)
print(wfs.get_schema(feature_type))
{'properties': {}, 'required': ['msGeometry', 'ObjectId', 'GUID], 'geometry': 'GeometryCollection', 'geometry_column': 'msGeometry'}
```

The responses include the following namespaces (see this [msautotest](https://github.com/MapServer/MapServer/blob/370afa1ff1ddd463a8569f6cd3f526bfc88a0ebc/msautotest/wxs/expected/wfs_200_describefeaturetype_outputformat_gml212.xml#L4) for example):

```xml
<?xml version='1.0' encoding="UTF-8" ?>
<schema
   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:gml="http://www.opengis.net/gml"
   elementFormDefault="qualified" version="0.1" >
```

When these are parsed `nsmap` ends up with a `None` value as a key:

```python
from owslib.etree import etree
# from lxml import etree # no diffence if using lxml directly

data = """<schema
   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   elementFormDefault="qualified" version="0.1" >
</schema>"""
root = etree.fromstring(data)
print(root.nsmap)

{'ms': 'http://mapserver.gis.umn.edu/mapserver', 
'xsd': 'http://www.w3.org/2001/XMLSchema', 
None: 'http://www.w3.org/2001/XMLSchema', 
'gml': 'http://www.opengis.net/gml/3.2'}
```

Note the `None: 'http://www.w3.org/2001/XMLSchema'` value. This may be a bug in MapServer, but has been unchanged for 7+ years so it would be good to handle old instances of MapServer in OWSLib. 

When this `nsmap` is iterated in [schema.py](https://github.com/geopython/OWSLib/blob/bc88ee1a6509746cff1cccfbad6e6501bae4c256/owslib/feature/schema.py#L97-L103) there is a match for the `None` key against `XS_NAMESPACE` - as this is the last key that matches `schema_key` gets set to `None`. 

```python
if nsmap:
    for key in nsmap:
        if nsmap[key] == XS_NAMESPACE:
            schema_key = key
        if nsmap[key] in GML_NAMESPACES:
            gml_key = key
```

This means that later on no properties are added due to this check:

```python
if schema_key is not None:
    schema["properties"][name] = data_type.replace(schema_key + ":", "")
```

This pull request filters out any keys which are None, and if the keys are still empty reverts to defaults. 






