### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/owslib/waterml/wml.py
+++ b/owslib/waterml/wml.py
@@ -786,7 +786,7 @@ class Source(XMLParser):
 
     def get_contact(self, name):
         ci = [ci for ci in self.contact_info if ci.name == name]
-        if len(ci) < 0:
+        if len(ci) > 0:
             return ci[0]
         return None
 


### PR DESCRIPTION
In file: wml.py, the comparison of Collection length creates a logical short circuit. It will always evaluate to false since the collection's length can never be less than zero. However, probably the intent was to check for a non-zero collection and then access the first element. I suggested that change. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.