### PR TITLE
clean up code in WFS classes

### DIFF
--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -75,47 +75,6 @@ class WebFeatureService_1_0_0(object):
     Implements IWebFeatureService.
     """
 
-    def __new__(
-        self,
-        url,
-        version,
-        xml,
-        parse_remote_metadata=False,
-        timeout=30,
-        headers=None,
-        username=None,
-        password=None,
-        auth=None,
-    ):
-        """ overridden __new__ method
-
-        @type url: string
-        @param url: url of WFS capabilities document
-        @type xml: string
-        @param xml: elementtree object
-        @type parse_remote_metadata: boolean
-        @param parse_remote_metadata: whether to fully process MetadataURL elements
-        @param headers: HTTP headers to send with requests
-        @param timeout: time (in seconds) after which requests should timeout
-        @param username: service authentication username
-        @param password: service authentication password
-        @param auth: instance of owslib.util.Authentication
-        @return: initialized WebFeatureService_1_0_0 object
-        """
-        obj = object.__new__(self)
-        obj.__init__(
-            url,
-            version,
-            xml,
-            parse_remote_metadata,
-            timeout,
-            headers=headers,
-            username=username,
-            password=password,
-            auth=auth,
-        )
-        return obj
-
     def __getitem__(self, name):
         """ check contents dictionary to allow dict like access to service layers"""
         if name in list(self.__getattribute__("contents").keys()):
@@ -135,7 +94,21 @@ class WebFeatureService_1_0_0(object):
         password=None,
         auth=None,
     ):
-        """Initialize."""
+        """Initialize.
+
+        @type url: string
+        @param url: url of WFS capabilities document
+        @type xml: string
+        @param xml: elementtree object
+        @type parse_remote_metadata: boolean
+        @param parse_remote_metadata: whether to fully process MetadataURL elements
+        @param headers: HTTP headers to send with requests
+        @param timeout: time (in seconds) after which requests should timeout
+        @param username: service authentication username
+        @param password: service authentication password
+        @param auth: instance of owslib.util.Authentication
+        @return: initialized WebFeatureService_1_0_0 object
+        """
         if auth:
             if username:
                 auth.username = username

--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -53,47 +53,6 @@ class WebFeatureService_1_1_0(WebFeatureService_):
     Implements IWebFeatureService.
     """
 
-    def __new__(
-        self,
-        url,
-        version,
-        xml,
-        parse_remote_metadata=False,
-        timeout=30,
-        headers=None,
-        username=None,
-        password=None,
-        auth=None,
-    ):
-        """ overridden __new__ method
-
-        @type url: string
-        @param url: url of WFS capabilities document
-        @type xml: string
-        @param xml: elementtree object
-        @type parse_remote_metadata: boolean
-        @param parse_remote_metadata: whether to fully process MetadataURL elements
-        @param headers: HTTP headers to send with requests
-        @param timeout: time (in seconds) after which requests should timeout
-        @param username: service authentication username
-        @param password: service authentication password
-        @param auth: instance of owslib.util.Authentication
-        @return: initialized WebFeatureService_1_1_0 object
-        """
-        obj = object.__new__(self)
-        obj.__init__(
-            url,
-            version,
-            xml,
-            parse_remote_metadata,
-            timeout,
-            headers=headers,
-            username=username,
-            password=password,
-            auth=auth,
-        )
-        return obj
-
     def __getitem__(self, name):
         """ check contents dictionary to allow dict like access to service layers"""
         if name in list(self.__getattribute__("contents").keys()):
@@ -113,7 +72,21 @@ class WebFeatureService_1_1_0(WebFeatureService_):
         password=None,
         auth=None,
     ):
-        """Initialize."""
+        """Initialize.
+
+        @type url: string
+        @param url: url of WFS capabilities document
+        @type xml: string
+        @param xml: elementtree object
+        @type parse_remote_metadata: boolean
+        @param parse_remote_metadata: whether to fully process MetadataURL elements
+        @param headers: HTTP headers to send with requests
+        @param timeout: time (in seconds) after which requests should timeout
+        @param username: service authentication username
+        @param password: service authentication password
+        @param auth: instance of owslib.util.Authentication
+        @return: initialized WebFeatureService_1_1_0 object
+        """
         if auth:
             if username:
                 auth.username = username

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -46,47 +46,6 @@ class WebFeatureService_2_0_0(WebFeatureService_):
     Implements IWebFeatureService.
     """
 
-    def __new__(
-        self,
-        url,
-        version,
-        xml,
-        parse_remote_metadata=False,
-        timeout=30,
-        headers=None,
-        username=None,
-        password=None,
-        auth=None,
-    ):
-        """ overridden __new__ method
-
-        @type url: string
-        @param url: url of WFS capabilities document
-        @type xml: string
-        @param xml: elementtree object
-        @type parse_remote_metadata: boolean
-        @param parse_remote_metadata: whether to fully process MetadataURL elements
-        @param headers: HTTP headers to send with requests
-        @param timeout: time (in seconds) after which requests should timeout
-        @param username: service authentication username
-        @param password: service authentication password
-        @param auth: instance of owslib.util.Authentication
-        @return: initialized WebFeatureService_2_0_0 object
-        """
-        obj = object.__new__(self)
-        obj.__init__(
-            url,
-            version,
-            xml,
-            parse_remote_metadata,
-            timeout,
-            headers=headers,
-            username=username,
-            password=password,
-            auth=auth,
-        )
-        return obj
-
     def __getitem__(self, name):
         """ check contents dictionary to allow dict like access to service layers"""
         if name in list(self.__getattribute__("contents").keys()):
@@ -106,7 +65,21 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         password=None,
         auth=None,
     ):
-        """Initialize."""
+        """Initialize.
+
+        @type url: string
+        @param url: url of WFS capabilities document
+        @type xml: string
+        @param xml: elementtree object
+        @type parse_remote_metadata: boolean
+        @param parse_remote_metadata: whether to fully process MetadataURL elements
+        @param headers: HTTP headers to send with requests
+        @param timeout: time (in seconds) after which requests should timeout
+        @param username: service authentication username
+        @param password: service authentication password
+        @param auth: instance of owslib.util.Authentication
+        @return: initialized WebFeatureService_2_0_0 object
+        """
         if auth:
             if username:
                 auth.username = username

--- a/tests/test_ogcapi_records_pycsw.py
+++ b/tests/test_ogcapi_records_pycsw.py
@@ -23,7 +23,7 @@ def test_ogcapi_records_pycsw():
     assert paths['/collections/{collectionId}'] is not None
 
     conformance = w.conformance()
-    assert len(conformance['conformsTo']) == 18
+    assert len(conformance['conformsTo']) == 14
 
     collections = w.collections()
     assert len(collections) > 0
@@ -40,7 +40,7 @@ def test_ogcapi_records_pycsw():
     assert isinstance(w.response, dict)
 
     pycsw_cite_demo_queryables = w.collection_queryables('metadata:main')
-    assert len(pycsw_cite_demo_queryables['properties'].keys()) == 12
+    assert len(pycsw_cite_demo_queryables['properties'].keys()) == 13
 
     # Minimum of limit param is 1
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Code cleaned up and simplified.
The manual call of the init function is not necessary. Until now, the function is called twice.