### PR TITLE
Fix Installation Command in README: Removed 'git' from 'conda install

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,7 +37,7 @@ Anaconda:
 
 .. code-block:: bash
 
- git conda install -c conda-forge owslib
+  conda install -c conda-forge owslib
 
 openSUSE:
 


### PR DESCRIPTION
Corrected Installation Command in README
issue resolved #880 