### PR TITLE
Fix for issue #624: BGS geonetwork test had an SSL config problem

### DIFF
--- a/tests/test_csw_geonetwork.py
+++ b/tests/test_csw_geonetwork.py
@@ -4,11 +4,10 @@ import pytest
 
 from owslib.csw import CatalogueServiceWeb
 
-SERVICE_URL = 'https://metadata.bgs.ac.uk/geonetwork/srv/en/csw'
+SERVICE_URL = 'https://metadata.bgs.ac.uk/geonetwork/srv/eng/csw'
 
 
 @pytest.mark.online
-@pytest.mark.skip(reason='server ssl issue. See issue #624')
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason='service is unreachable')
 def test_csw_geonetwork():


### PR DESCRIPTION
In issue #624 the BGS geonetwork test was disabled because of an SSL config problem.

- SSL problem has been fixed so this test can be re-enabled
- Correct URL error
- Remove the skip decorator