### PR TITLE
Make GetFeature-Urls ending with & work

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -209,7 +209,7 @@ class WebFeatureService_(object):
                 if m.get("type").lower() == method.lower()
             )
         )
-        base_url = base_url if base_url.endswith("?") else base_url + "?"
+        base_url = base_url if base_url.endswith("?") or base_url.endswith('&') else base_url + "?"
 
         request = {"service": "WFS", "version": self.version, "request": "GetFeature"}
 


### PR DESCRIPTION
This fixes a bug where a GetFeature URL ending with "&" was incorrectly constructed.

Also while debugging I was missing logs in the "owslib" namespace (as written in the docs). I think the second change in this MR fixes this.