### PR TITLE
Change `nullable` check to resolve `FutureWarning`

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -68,7 +68,7 @@ class WebMapService_1_1_1(object):
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(
             self.version, url=self.url, headers=headers, auth=self.auth)
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url, timeout=self.timeout)

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -69,7 +69,7 @@ class WebMapService_1_3_0(object):
         # Authentication handled by Reader
         reader = WMSCapabilitiesReader(
             self.version, url=self.url, headers=headers, auth=self.auth)
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url, timeout=self.timeout)

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -50,7 +50,7 @@ class SensorObservationService_1_0_0(object):
         reader = SosCapabilitiesReader(
             version=self.version, url=self.url, username=self.username, password=self.password
         )
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.read_string(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url)

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -52,7 +52,7 @@ class SensorObservationService_2_0_0(object):
         reader = SosCapabilitiesReader(
             version=self.version, url=self.url, username=self.username, password=self.password
         )
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.read_string(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url)

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -61,7 +61,7 @@ class TileMapService(object):
         reader = TMSCapabilitiesReader(
             self.version, url=self.url, un=username, pw=password, headers=self.headers, auth=self.auth
         )
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url, timeout=self.timeout)

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -180,7 +180,7 @@ class WebMapTileService(object):
         # Authentication handled by Reader
         reader = WMTSCapabilitiesReader(
             self.version, url=self.url, headers=self.headers, auth=self.auth)
-        if xml:  # read from stored xml
+        if xml is not None:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
             self._capabilities = reader.read(self.url, self.vendor_kwargs)


### PR DESCRIPTION
Resolves several more cases of this warning in addition to #881, #595
```
FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```