### PR TITLE
CI: change base URL for GeoNetwork based CSW

### DIFF
--- a/tests/test_csw_geonetwork.py
+++ b/tests/test_csw_geonetwork.py
@@ -4,7 +4,7 @@ import pytest
 
 from owslib.csw import CatalogueServiceWeb
 
-SERVICE_URL = 'https://metadata.bgs.ac.uk/geonetwork/srv/eng/csw'
+SERVICE_URL = 'http://geoportal.ypen.gr/geonetwork/srv/eng/csw'
 
 
 @pytest.mark.online


### PR DESCRIPTION
Switch CSW GeoNetwork testing to pre-4.0 (ref: https://github.com/geonetwork/core-geonetwork/issues/6155).