### PR TITLE
Add exception handlers for Polygon and Locale methods

### DIFF
--- a/owslib/iso3.py
+++ b/owslib/iso3.py
@@ -1140,12 +1140,13 @@ class EX_Polygon(printable):
             try:
                 interior_ring_elements = md.findall(util.nspath_eval('gml32:Polygon/gml32:interior', self.namespaces))
                 self.interior_rings = []
-                for iring_element in interior_ring_elements:
-                    try:
-                        linear_ring = iring_element.find(util.nspath_eval('gml32:LinearRing', self.namespaces))
-                        self.interior_rings.append(self._coordinates_for_ring(linear_ring))
-                    except KeyError:
-                        pass
+                if interior_ring_elements is not None:
+                    for iring_element in interior_ring_elements:
+                        try:
+                            linear_ring = iring_element.find(util.nspath_eval('gml32:LinearRing', self.namespaces))
+                            self.interior_rings.append(self._coordinates_for_ring(linear_ring))
+                        except KeyError:
+                            pass
             except KeyError:
                 pass
 

--- a/owslib/iso3.py
+++ b/owslib/iso3.py
@@ -338,18 +338,29 @@ class PT_Locale(printable):
         :param md: PT_Locale etree.Element
         """
         self.namespaces = namespaces
-        if md is None:
-            self.id = None
-            self.languagecode = None
-            self.charset = None
-        else:
-            self.id = md.attrib.get('id')
-            self.languagecode = md.find(
-                util.nspath_eval('lan:language/lan:LanguageCode', self.namespaces)).attrib.get('codeListValue')
-            self.charset = md.find(
-                util.nspath_eval('lan:characterEncoding/lan:MD_CharacterSetCode', self.namespaces)).attrib.get(
-                'codeListValue')
 
+        self.id = None
+        self.languagecode = None
+        self.charset = None
+
+        if md is not None:
+            try:
+                self.id = md.attrib.get('id')
+            except AttributeError:
+                pass
+
+            try:
+                self.languagecode = md.find(
+                    util.nspath_eval('lan:language/lan:LanguageCode', self.namespaces)).attrib.get('codeListValue')
+            except AttributeError:
+                pass
+
+            try:
+                self.charset = md.find(
+                    util.nspath_eval('lan:characterEncoding/lan:MD_CharacterSetCode', self.namespaces)).attrib.get(
+                    'codeListValue')
+            except AttributeError:
+                pass
 
 
 class CI_Date(printable):
@@ -1114,19 +1125,30 @@ class EX_Polygon(printable):
         :param md: EX_Polygon etree.Element
         """
         self.namespaces = namespaces
-        if md is None:
-            self.exterior_ring = None
-            self.interior_rings = []
-        else:
-            linear_ring = md.find(util.nspath_eval('gml32:Polygon/gml32:exterior/gml32:LinearRing', self.namespaces))
-            if linear_ring is not None:
-                self.exterior_ring = self._coordinates_for_ring(linear_ring)
 
-            interior_ring_elements = md.findall(util.nspath_eval('gml32:Polygon/gml32:interior', self.namespaces))
-            self.interior_rings = []
-            for iring_element in interior_ring_elements:
-                linear_ring = iring_element.find(util.nspath_eval('gml32:LinearRing', self.namespaces))
-                self.interior_rings.append(self._coordinates_for_ring(linear_ring))
+        self.exterior_ring = None
+        self.interior_rings = []
+
+        if md is not None:
+            try:
+                linear_ring = md.find(util.nspath_eval('gml32:Polygon/gml32:exterior/gml32:LinearRing', self.namespaces))
+                if linear_ring is not None:
+                    self.exterior_ring = self._coordinates_for_ring(linear_ring)
+            except KeyError:
+                pass
+
+            try:
+                interior_ring_elements = md.findall(util.nspath_eval('gml32:Polygon/gml32:interior', self.namespaces))
+                self.interior_rings = []
+                for iring_element in interior_ring_elements:
+                    try:
+                        linear_ring = iring_element.find(util.nspath_eval('gml32:LinearRing', self.namespaces))
+                        self.interior_rings.append(self._coordinates_for_ring(linear_ring))
+                    except KeyError:
+                        pass
+            except KeyError:
+                pass
+
 
     def _coordinates_for_ring(self, linear_ring):
         """ Get coordinates for gml coordinate ring


### PR DESCRIPTION
Please feel free to ignore/add new commits to the PR if you don't think it's useful, I won't put more efforts to this PR since the problems have been solved for us;

Missing the exception handlers blocking us from processing large number of records;

sample code to reproduce:

```python
# Define the queries to search for records using GCMD Keywords
gcmd_query_lower = PropertyIsLike("AnyText", "%gcmd%")
gcmd_query_upper = PropertyIsLike("AnyText", "%GCMD%")
gcmd_query_full = PropertyIsLike("AnyText", "%Global Change Master Directory%")

# Define the query to exclude records containing 'AODN Discovery Parameter Vocabulary'
aodn_exclude_query = PropertyIsNotEqualTo(
    "AnyText", "AODN Discovery Parameter Vocabulary"
)

# Combine all queries using Or and And filters
combined_gcmd_query = Or([gcmd_query_lower, gcmd_query_upper, gcmd_query_full])
final_query = And([combined_gcmd_query, aodn_exclude_query])

# Connect to the CSW service
csw = CatalogueServiceWeb(
    "https://catalogue.aodn.org.au/geonetwork/srv/eng/csw?request=GetCapabilities&service=CSW&version=2.0.2"
)
```

you might want to use `outputschema` param within `csw.getrecords2()` method to be: http://standards.iso.org/iso/19115/-3/mdb/2.0