### PR TITLE
Fix parsing of options - support missing options

### DIFF
--- a/owslib/opensearch.py
+++ b/owslib/opensearch.py
@@ -197,11 +197,12 @@ class Description:
                 p_def = {
                     'pattern': p.attrib.get('pattern'),
                     'title': p.attrib.get('title'),
-                    'value': p.attrib.get('value'),
-                    'options': []
+                    'value': p.attrib.get('value')
                 }
-                for o in p.findall(nspath_eval('parameters:Option', namespaces)):
-                    p_def['options'].append(o.attrib.get('value'))
+
+                options = [o.attrib.get('value') for o in p.findall(nspath_eval('parameters:Option', namespaces))]
+                if len(options) > 0 :
+                    p_def['options'] = options
 
                 url_def['parameters'][p_name] = p_def
 


### PR DESCRIPTION
Currently the OpenSearch parser generates Parameter instances with a default empty array for options. But at querying time this causes the parameter to be validated against an empty set of valid values, and therefore fail.

This fix leaves the `options` attribute empty if no options are passed in the description document.