### PR TITLE
add stalebot GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: 'Close stale Issues and Pull Requests'
+
+env:
+  STALE_AFTER_INACTIVE_DAYS: 90
+  CLOSE_AFTER_INACTIVE_DAYS: 7
+
+on:
+  schedule:
+    - cron: '1 3 * * 0'  # runs every Sunday at 03h01 UTC
+    # - cron: '0 * * * *'  # runs every hour, for debugging
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    if: github.repository == 'geopython/OWSLib'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/stale@v9'
+        with:
+          # debug-only: true
+          operations-per-run: 1000
+          enable-statistics: true
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: blocker
+          exempt-pr-labels: blocker
+          days-before-stale: ${{ env.STALE_AFTER_INACTIVE_DAYS }}
+          days-before-close: ${{ env.CLOSE_AFTER_INACTIVE_DAYS }}
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            This Issue has been inactive for ${{env.STALE_AFTER_INACTIVE_DAYS }}
+            days. In order to manage maintenance burden, it will be automatically closed
+            in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+          stale-pr-message: >
+            This Pull Request has been inactive for ${{env.STALE_AFTER_INACTIVE_DAYS }}
+            days. In order to manage maintenance burden, it will be automatically closed
+            in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+          close-issue-message: >
+            This Issue has been closed due to there being no activity for more
+            than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.
+          close-pr-message: >
+            This Pull Request has been closed due to there being no activity for more
+            than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.


### PR DESCRIPTION
This PR adds a stalebot GitHub Action to close inactive issues and PRs.  The defaults set are 90 days of inactivity (warning) and 7 days thereafter (closing).  The PR leverages the great work of @ricardogsilva as per https://github.com/geopython/pygeoapi/pull/1582.