### PR TITLE
Fix concatenation of query params to WFS 2.0.0 url when it already contains params

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -9,7 +9,7 @@ import logging
 
 from urllib.parse import urlencode
 from owslib.crs import Crs
-from owslib.util import Authentication
+from owslib.util import Authentication, build_get_url
 from owslib.feature.schema import get_schema
 from owslib.feature.postrequest import PostRequest_1_1_0, PostRequest_2_0_0
 
@@ -209,7 +209,6 @@ class WebFeatureService_(object):
                 if m.get("type").lower() == method.lower()
             )
         )
-        base_url = base_url if base_url.endswith("?") else base_url + "?"
 
         request = {"service": "WFS", "version": self.version, "request": "GetFeature"}
 
@@ -248,9 +247,7 @@ class WebFeatureService_(object):
         if outputFormat is not None:
             request["outputFormat"] = outputFormat
 
-        data = urlencode(request, doseq=True)
-
-        return base_url + data
+        return build_get_url(base_url, request)
 
     def getPOSTGetFeatureRequest(
         self,


### PR DESCRIPTION
WebFeatureService_.getGETGetFeatureRequest() is used by WebFeatureService_2_0_0.getfeature() to prepare the getfeature() request url from a base url and dictionary of query parameters. The implementation doesn't correctly handle a base url that already contains a parameter list. For example, if base url is:
`https://my.url.com.au/ows?authkey=myauthkey
`
then the url returned by getGETGetFeatureRequest will be:
`https://my.url.com.au/ows?authkey=myauthkey?service=WFS&version=2.0.0&request=GetFeature&typename=mylayer
`

Note that this url contains two ?. Unfortunately openUrl() doesn't successfully open this url (in the case of the 'authkey' parameter, a 401 Unauthorized error occurs because presumably the geoserver doesn't parse the url in the way that we expect). Regardless of the precise issue (if any) that occurs with a url containing multiple ?, it doesn't seem correct to concatenate the url in this way.

There is already a function in util.py that builds a GET url taking into account a query expression in the base url - build_get_url() - so this has been used in getGETGetFeatureRequest to concatenate the WFS parameters to the base url. There is one case that build_get_url() might not handle correctly - where the query parameter dictionary has a list (sequence) for a value - for example {"myparam": ['myval']}. Ideally the call to urlencode in build_get_url() would specify doseq=True but it doesn't.

Interestingly getGETGetFeatureRequest() is _not_ used by the WFS 1.0.0 or 1.1.0 getfeature() requests. However, it appears that both of these have the same problem with an extra ?, but the url is successfully encoded - it appears that openURL is called differently with these implementations, where base_url and data are kept separate in the call to openURL, so requests.request() is able to fix the duplicate ?.