### PR TITLE
Add srsname to wfs200.py getfeature GET request

### DIFF
--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -160,6 +160,7 @@ class WebFeatureService_(object):
         featureversion=None,
         propertyname=None,
         maxfeatures=None,
+        srsname=None,
         storedQueryID=None,
         storedQueryParams=None,
         outputFormat=None,
@@ -183,6 +184,8 @@ class WebFeatureService_(object):
             List of feature property names. '*' matches all.
         maxfeatures : int
             Maximum number of features to be returned.
+        srsname: string
+            EPSG code to request the data in
         method : string
             Qualified name of the HTTP DCP method to use.
         outputFormat: string (optional)
@@ -238,6 +241,13 @@ class WebFeatureService_(object):
                 request["count"] = str(maxfeatures)
             else:
                 request["maxfeatures"] = str(maxfeatures)
+        if srsname:
+            request["srsname"] = str(srsname)
+
+            # Check if desired SRS is supported by the service for each
+            # typename. Warning will be thrown if that SRS is not allowed.
+            for name in typename:
+                _ = self.getSRS(srsname, name)
         if startindex:
             request["startindex"] = str(startindex)
         if storedQueryID:

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -226,6 +226,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
         featureversion=None,
         propertyname=None,
         maxfeatures=None,
+        srsname=None,
         storedQueryID=None,
         storedQueryParams=None,
         method="Get",
@@ -254,6 +255,8 @@ class WebFeatureService_2_0_0(WebFeatureService_):
             For Post request, leave blank (None) to get all properties.
         maxfeatures : int
             Maximum number of features to be returned.
+        srsname: string
+            EPSG code to request the data in
         storedQueryID : string
             A name identifying a prepared set available in WFS-service
         storedQueryParams : dict
@@ -298,6 +301,7 @@ class WebFeatureService_2_0_0(WebFeatureService_):
                 featureversion,
                 propertyname,
                 maxfeatures,
+                srsname,
                 storedQueryID,
                 storedQueryParams,
                 outputFormat,

--- a/tests/test_wfs_generic.py
+++ b/tests/test_wfs_generic.py
@@ -6,8 +6,7 @@ from tests.utils import resource_file, sorted_url_query, service_ok
 import json
 import pytest
 
-SERVICE_URL = 'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288'
-
+SERVICE_URL = 'https://services.ga.gov.au/gis/stratunits/ows'
 
 def test_caps_info():
     getcapsin = open(resource_file("wfs_HSRS_GetCapabilities_1_1_0.xml"), "rb").read()
@@ -59,59 +58,50 @@ def test_verbOptions_wfs_100():
     assert len(verbOptions[0]) == 2
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_100():
-    wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-                            version='1.0.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.0.0')
     feature = wfs.getfeature(
-        typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json')
     assert len(json.loads(feature.read())['features']) == 1
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_110():
-    wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-                            version='1.1.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.1.0')
     feature = wfs.getfeature(
-        typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json')
     assert len(json.loads(feature.read())['features']) == 1
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_outputformat_wfs_200():
-    wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-                            version='2.0.0')
+    wfs = WebFeatureService(SERVICE_URL, version='2.0.0')
     feature = wfs.getfeature(
-        typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json')
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json')
     assert len(json.loads(feature.read())['features']) == 1
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_srsname_wfs_100():
-    wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-                            version='1.0.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.0.0')
     # ServiceException: Unable to support srsName: EPSG:99999999
     with pytest.raises(ServiceException):
         feature = wfs.getfeature(
-            typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+            typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
             srsname="EPSG:99999999")
 
-    wfs = WebFeatureService('https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-                            version='1.0.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.0.0')
     feature = wfs.getfeature(
-        typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
         srsname="urn:x-ogc:def:crs:EPSG:4326")
     assert len(json.loads(feature.read())['features']) == 1
 
@@ -121,73 +111,76 @@ def test_srsname_wfs_100():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_srsname_wfs_110():
-    wfs = WebFeatureService(
-        'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-        version='1.1.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.1.0')
     # ServiceException: Unable to support srsName: EPSG:99999999
     with pytest.raises(ServiceException):
         feature = wfs.getfeature(
-            typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+            typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
             srsname="EPSG:99999999")
 
-    wfs = WebFeatureService(
-        'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-        version='1.0.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.1.0')
     feature = wfs.getfeature(
-        typename=['sb:Project_Area'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
         srsname="urn:x-ogc:def:crs:EPSG:4326")
     assert len(json.loads(feature.read())['features']) == 1
 
 
-@pytest.mark.xfail
+@pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason="WFS service is unreachable")
+def test_srsname_wfs_200():
+    wfs = WebFeatureService(SERVICE_URL, version='2.0.0')
+    # ServiceException: Unable to support srsName: EPSG:99999999
+    with pytest.raises(ServiceException):
+        feature = wfs.getfeature(
+            typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+            srsname="EPSG:99999999")
+
+    wfs = WebFeatureService(SERVICE_URL, version='2.0.0')
+    feature = wfs.getfeature(
+        typename=['stratunit:StratigraphicUnit'], maxfeatures=1, propertyname=None, outputFormat='application/json',
+        srsname="urn:x-ogc:def:crs:EPSG:4326")
+    assert len(json.loads(feature.read())['features']) == 1
+
+
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_schema_wfs_100():
-    wfs = WebFeatureService(
-        'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-        version='1.0.0')
-    schema = wfs.get_schema('footprint')
-    assert len(schema['properties']) == 4
-    assert schema['properties']['summary'] == 'string'
-    assert schema['geometry'] == 'Polygon'
+    wfs = WebFeatureService(SERVICE_URL, version='1.0.0')
+    schema = wfs.get_schema('stratunit:StratigraphicUnit')
+    assert len(schema['properties']) == 33
+    assert schema['properties']['DESCRIPTION'] == 'string'
+    assert schema['geometry'] is None
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_schema_wfs_110():
-    wfs = WebFeatureService(
-        'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-        version='1.1.0')
-    schema = wfs.get_schema('footprint')
-    assert len(schema['properties']) == 4
-    assert schema['properties']['summary'] == 'string'
-    assert schema['geometry'] == '3D Polygon'
+    wfs = WebFeatureService(SERVICE_URL, version='1.1.0')
+    schema = wfs.get_schema('stratunit:StratigraphicUnit')
+    assert len(schema['properties']) == 33
+    assert schema['properties']['DESCRIPTION'] == 'string'
+    assert schema['geometry'] is None
 
 
-@pytest.mark.xfail
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_schema_wfs_200():
-    wfs = WebFeatureService(
-        'https://www.sciencebase.gov/catalogMaps/mapping/ows/53398e51e4b0db25ad10d288',
-        version='2.0.0')
-    schema = wfs.get_schema('footprint')
-    assert len(schema['properties']) == 4
-    assert schema['properties']['summary'] == 'string'
-    assert schema['geometry'] == '3D Polygon'
+    wfs = WebFeatureService(SERVICE_URL, version='2.0.0')
+    schema = wfs.get_schema('stratunit:StratigraphicUnit')
+    assert len(schema['properties']) == 33
+    assert schema['properties']['DESCRIPTION'] == 'string'
+    assert schema['geometry'] is None
 
 
 @pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_xmlfilter_wfs_110():
-    wfs = WebFeatureService(
-        'https://services.ga.gov.au/gis/stratunits/ows',
-        version='1.1.0')
+    wfs = WebFeatureService(SERVICE_URL, version='1.1.0')
     filter_prop = PropertyIsLike(propertyname='stratunit:GEOLOGICHISTORY', literal='Cisuralian - Guadalupian',
         matchCase=True)
 
@@ -203,9 +196,7 @@ def test_xmlfilter_wfs_110():
 @pytest.mark.skipif(not service_ok(SERVICE_URL),
                     reason="WFS service is unreachable")
 def test_xmlfilter_wfs_200():
-    wfs = WebFeatureService(
-        'https://services.ga.gov.au/gis/stratunits/ows',
-        version='2.0.0')
+    wfs = WebFeatureService(SERVICE_URL,  version='2.0.0')
     filter_prop = PropertyIsLike(propertyname='stratunit:geologichistory', literal='Cisuralian - Guadalupian',
         matchCase=True)
 


### PR DESCRIPTION
WebFeatureService_2_0_0.getfeature() is missing an srsName argument. This issue has been reported previously in #910, #905, and #682. This prevents features being retrieved with a non-default crs when using WFS 2.0.0. srsName _is_ supported by WebFeatureService_1_1_0.getfeature() and WebFeatureService_1_0_0.getfeature(). This seems to be an oversight as srsname is a valid KVP ('key value pair') parameter - see OGC WFS 2.0.2 specification https://portal.ogc.org/files/?artifact_id=39967 Sections 7.9.2.3 and 7.9.2.4.4.

Changes in this PR:
* Add srsname arg to WebFeatureService_2_0_0.getfeature() for GET requests
* Add srsname arg to WebFeatureService_.getGETGetFeatureRequest() (which is called by getfeature)

Note that srsname hasn't been added for POST requests. This is actually consistent with the implementation of getfeature() in wfs110.py, where srsname can be specified for GET requests but not POST requests. It seems this is likely to be unintentional, but fixing up POST requests across all WFS versions is better done in a separate PR.

A suggestion for future improvement would be to support kwargs in getfeature(), so that arbitrary query parameters can be supported without having to explicitly declare them in the function argument list. These parameters would merely be added verbatim to the request's query params. However, this is beyond the scope of the current issue.
