### PR TITLE
Add offline testing to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,15 @@ jobs:
         pip3 install -r docs/requirements.txt
     - name: run tests ⚙️
       run: python3 -m pytest
+    - name: run tests in offline mode
+      if: matrix.python-version == '3.10'
+      run: |
+          python3 -m pytest \
+            -m "not online" \
+            --disable-socket \
+            --deselect="tests/doctests/wcs_thredds.txt::wcs_thredds.txt" \
+            --deselect="tests/doctests/wfs_MapServerWFSCapabilities.txt::wfs_MapServerWFSCapabilities.txt" \
+            --deselect="tests/doctests/wms_geoserver_mass_gis.txt::wms_geoserver_mass_gis.txt"
     - name: run coveralls ⚙️
       run: coveralls
     - name: build docs 🏗️

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 flake8
 pytest
 pytest-cov
+pytest-socket
 Pillow
 tox
 twine

--- a/tests/test_csw_geonetwork.py
+++ b/tests/test_csw_geonetwork.py
@@ -19,6 +19,7 @@ def test_csw_geonetwork():
 
 SERVICE_URL3 = 'https://metawal.wallonie.be/geonetwork/srv/eng/csw'
 
+@pytest.mark.online
 @pytest.mark.skipif(not service_ok(SERVICE_URL3),
                     reason='service is unreachable')
 @pytest.mark.parametrize("esn_in", ['full', 'summary'])

--- a/tests/test_ogcapi_connectedsystems_osh.py
+++ b/tests/test_ogcapi_connectedsystems_osh.py
@@ -182,6 +182,7 @@ class OSHFixtures:
 class TestSystems:
     fixtures = OSHFixtures()
 
+    @pytest.mark.online
     def test_system_readonly(self):
         # get all systems
         res = self.fixtures.systems_api.systems()
@@ -250,6 +251,7 @@ class TestDeployments:
 class TestSamplingFeatures:
     fixtures = OSHFixtures()
 
+    @pytest.mark.online
     def test_sampling_features_readonly(self):
         all_features = self.fixtures.sampling_feature_api.sampling_features(use_fois=True)
         assert len(all_features['items']) == 51
@@ -296,6 +298,7 @@ class TestSamplingFeatures:
 class TestDatastreams:
     fixtures = OSHFixtures()
 
+    @pytest.mark.online
     def test_datastreams_readonly(self):
         ds_id = 'kjg2qrcm40rfk'
         datastreams = self.fixtures.datastream_api.datastreams()
@@ -342,6 +345,7 @@ class TestDatastreams:
 class TestObservations:
     fixtures = OSHFixtures()
 
+    @pytest.mark.online
     def test_observations_readonly(self):
         ds_id = 'kjg2qrcm40rfk'
         observations = self.fixtures.observations_api.observations_of_datastream(ds_id)
@@ -383,6 +387,7 @@ class TestObservations:
 class TestSystemHistory:
     fixtures = OSHFixtures()
 
+    @pytest.mark.online
     def test_system_history(self):
         sys_id = '0s2lbn2n1bnc8'
         res = self.fixtures.system_history_api.system_history(sys_id)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ addopts =
     --doctest-glob='tests/**/*.txt'
     --cov-report=term-missing
     --cov=owslib
-    --allow-hosts=127.0.0.1,127.0.1.1
 
 norecursedirs = .git docs examples etc cov* *.egg* pytest* .tox _broken
 markers =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,17 @@
 [pytest]
-addopts = -v -rxs -s --color=yes --tb=native --ignore=setup.py --doctest-modules --doctest-glob 'tests/**/*.txt' --cov-report term-missing --cov owslib
+addopts = 
+    -v
+    -rxs
+    -s
+    --color=yes
+    --tb=native
+    --ignore=setup.py
+    --doctest-modules
+    --doctest-glob='tests/**/*.txt'
+    --cov-report=term-missing
+    --cov=owslib
+    --allow-hosts=127.0.0.1,127.0.1.1
+
 norecursedirs = .git docs examples etc cov* *.egg* pytest* .tox _broken
 markers =
     online: test requires online resources.


### PR DESCRIPTION
This pull request makes use of the https://github.com/miketheman/pytest-socket/ plugin to check the test suite runs without network access. Relates to #951. 

There is no simple way to mark doctests as requiring online access, or to disable the `--doctest-modules` flag from the command line, so I have manually deselected the 3 tests that require network access in the main.yml file. 

To ensure the test suite passes additional `@pytest.mark.online` have been added to tests requiring network access. 

`tox.ini` was modified to put options on separate lines to improve readibility. 