### PR TITLE
FIX: numpy floats parsed incorrectly

### DIFF
--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -176,7 +176,7 @@ class WebCoverageService_1_1_0(WCSBase):
         request['identifier'] = identifier
         # request['identifier'] = ','.join(identifier)
         if bbox:
-            request['boundingbox'] = ','.join([repr(x) for x in bbox])
+            request['boundingbox'] = ','.join([str(x) for x in bbox])
         if time:
             request['timesequence'] = ','.join(time)
         request['format'] = format

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -268,7 +268,7 @@ class WebFeatureService_1_0_0(object):
         if featureid:
             request["featureid"] = ",".join(featureid)
         elif bbox and typename:
-            request["bbox"] = ",".join([repr(x) for x in bbox])
+            request["bbox"] = ",".join([str(x) for x in bbox])
         elif filter and typename:
             request["filter"] = str(filter)
 

--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -172,7 +172,7 @@ class WebMapService_1_1_1(object):
         request['height'] = str(size[1])
 
         request['srs'] = str(srs)
-        request['bbox'] = ','.join([repr(x) for x in bbox])
+        request['bbox'] = ','.join([str(x) for x in bbox])
         request['format'] = str(format)
         request['transparent'] = str(transparent).upper()
         request['exceptions'] = str(exceptions)

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -182,7 +182,7 @@ class WebMapService_1_3_0(object):
 
         # remapping the srs to crs for the request
         request['crs'] = str(srs)
-        request['bbox'] = ','.join([repr(x) for x in bbox])
+        request['bbox'] = ','.join([str(x) for x in bbox])
         request['format'] = str(format)
         request['transparent'] = str(transparent).upper()
         request['exceptions'] = str(exceptions)

--- a/tests/test_wms_getmap.py
+++ b/tests/test_wms_getmap.py
@@ -4,12 +4,33 @@ import pytest
 from tests.utils import service_ok
 
 from owslib.wms import WebMapService
+from owslib.map.wms130 import WebMapService_1_3_0
 from owslib.util import ServiceException
 from owslib.util import ResponseWrapper
 
 
 SERVICE_URL = 'http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi'
 NCWMS2_URL = "http://wms.stccmop.org:8080/ncWMS2/wms"
+
+
+@pytest.fixture
+def wms():
+    return WebMapService_1_3_0(SERVICE_URL, version='1.3.0')
+
+
+def test_build_getmap_request_bbox_precision(wms):
+    bbox = (-126.123456789, 24.123456789, -66.123456789, 50.123456789)
+    bbox_yx = (bbox[1], bbox[0], bbox[3], bbox[2])
+    request = wms._WebMapService_1_3_0__build_getmap_request(
+        layers=['layer1'],
+        styles=['default'],
+        srs='EPSG:4326',
+        bbox=bbox,
+        format='image/jpeg',
+        size=(250, 250),
+        transparent=True
+    )
+    assert request['bbox'] == ','.join(map(str, bbox_yx))
 
 
 @pytest.mark.online


### PR DESCRIPTION
Referring to https://github.com/SciTools/cartopy/issues/2472#issuecomment-2457518215

Currently `owslib` cannot handle bbox defined as `numpy.float64`. This PR fixes the referred issue by using `str` instead of `repr`.