### PR TITLE
Catch and raise HTTP 403 Forbidden errors

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -206,7 +206,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
 
     req = requests.request(method.upper(), url_base, headers=headers, **rkwargs)
 
-    if req.status_code in [400, 401]:
+    if req.status_code in [400, 401, 403]:
         raise ServiceException(req.text)
 
     if req.status_code in [404, 500, 502, 503, 504]:    # add more if needed

--- a/tests/test_wms_getmap.py
+++ b/tests/test_wms_getmap.py
@@ -18,10 +18,15 @@ def wms():
     return WebMapService_1_3_0(SERVICE_URL, version='1.3.0')
 
 
-def test_build_getmap_request_bbox_precision(wms):
+@pytest.mark.parametrize("version", ["1.3.0", "1.1.1"])
+def test_build_getmap_request_bbox_precision(version):
     bbox = (-126.123456789, 24.123456789, -66.123456789, 50.123456789)
     bbox_yx = (bbox[1], bbox[0], bbox[3], bbox[2])
-    request = wms._WebMapService_1_3_0__build_getmap_request(
+
+    m = mock.Mock()
+    type(m).version = mock.PropertyMock(return_value=version)
+
+    request = WebMapService_1_3_0._WebMapService_1_3_0__build_getmap_request(m,
         layers=['layer1'],
         styles=['default'],
         srs='EPSG:4326',


### PR DESCRIPTION
It would have been easier to see the reason for recent failing CI tests (see #956) if an error had been raised when HTTP code 403 was returned. 

As HTTP error code is a client error code, I added to the list with 400 and 401 (rather than the server error codes 5xx list). 

See also #936. 

Note, this could break existing workflows by raising a ServiceException - so comments/thoughts welcome. 