### PR TITLE
Update WMTS server to new URL

### DIFF
--- a/tests/test_wmts.py
+++ b/tests/test_wmts.py
@@ -105,7 +105,7 @@ def test_wmts_without_serviceprovider_tag():
     _ = WebMapTileService(EXAMPLE_SERVICE_URL)
 
 
-SERVICE_URL_REST = 'https://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml'
+SERVICE_URL_REST = 'https://mapsneu.wien.gv.at/basemapneu/1.0.0/WMTSCapabilities.xml'
 
 
 @pytest.mark.online


### PR DESCRIPTION
Fixes #961.
New server URLs at https://cdn.basemap.at/basemap.at_URL_Umstellung_2023.pdf
Thanks for the instant response from viennagis@post.wien.gv.at!