### PR TITLE
Filter out ExtendedCapabilities when reading WebMapTileService

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -34,7 +34,7 @@ import warnings
 from urllib.parse import (urlencode, urlparse, urlunparse, parse_qs,
                           ParseResult)
 from .etree import etree
-from .util import clean_ows_url, testXMLValue, getXMLInteger, Authentication, openURL, getXMLTree
+from .util import clean_ows_url, testXMLValue, getXMLInteger, Authentication, openURL, getXMLTree, nspath
 from .fgdc import Metadata
 from .iso import MD_Metadata
 from .ows import ServiceProvider, ServiceIdentification, OperationsMetadata
@@ -227,7 +227,8 @@ class WebMapTileService(object):
         #  REST only WMTS does not have any Operations
         if serviceop is not None:
             for elem in serviceop[:]:
-                self.operations.append(OperationsMetadata(elem))
+                if elem.tag != nspath('ExtendedCapabilities'):
+                    self.operations.append(OperationsMetadata(elem))
 
         # serviceContents metadata: our assumption is that services use
         # a top-level layer as a metadata organizer, nothing more.


### PR DESCRIPTION
Fix for #965. 

Tested with the following:

```python
from owslib.wmts import WebMapTileService
service_url = "https://api.dataforsyningen.dk/dhm_bluespot_ekstremregn?token=f3ecb52320902f733a433aa9945d8dc8&"
wmts = WebMapTileService(service_url)

tile = wmts.gettile(layer='bluespot_ekstremregn_0',
                    tilematrixset='View1', tilematrix='L00',
                    row=0, column=0, format="image/png")
print(tile.info()['Content-Type'])

# without fix - AttributeError: 'OperationsMetadata' object has no attribute 'name'
```

CC @CJGutz - can you check if this fixes it for you. 

I'm considering adding a "live" test for this pointing to https://api.dataforsyningen.dk but endless test failures due to service changes are a concern. Long-term it may be better to spin up a local test server and return local XML and other files. 
