### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ numerous OGC Web Service interfaces.
 
 ## Installation
 
-The easiest way to install pywis-pubsub is via the Python [pip](https://pip.pypa.io)
+The easiest way to install OWSLib is via the Python [pip](https://pip.pypa.io)
 utility:
 
 ```bash
@@ -156,7 +156,7 @@ Releasing
   git push --tags
   # update on PyPI (must be a maintainer)
   rm -fr build dist *.egg-info
-  python3 setup.py sdist bdist_wheel --universal
+  python3 setup.py sdist bdist_wheel
   twine upload dist/*
 ```
 


### PR DESCRIPTION
- Fix reference to wrong library
- Remove `--universal` from release notes, so wheels don't contain reference to py2 (`OWSLib-0.32.1-py3-none-any.whl` instead of `OWSLib-0.32.1-py2.py3-none-any.whl`). 