### PR TITLE
CI: Fix failing tests and doc builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ ipykernel
 nbconvert
 nbsphinx
 pypandoc
-sphinx
+sphinx==8.1.3 # issue with nbsphinx in sphinx 8.2, see https://github.com/spatialaudio/nbsphinx/issues/825

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -107,8 +107,15 @@ Test exceptions
 
 Lastly, test the getcapabilities and getmap methods
 
+    >>> import requests
     >>> wms = WebMapService('http://gis-prod.digital.mass.gov/geoserver/wms', version='1.1.1', timeout=120)
-    >>> img = wms.getmap(layers=['massgis:GISDATA.SHORELINES_ARC'], styles=[''], srs='EPSG:4326', bbox=(-70.8, 42, -70, 42.8), size=(300, 300), format='image/jpeg', transparent=True)
-    >>> out = open(scratch_file('massgis_shoreline.jpg'), 'wb')
-    >>> bytes_written = out.write(img.read())
-    >>> out.close()
+    >>> try:
+    ...     img = wms.getmap(layers=['massgis:GISDATA.SHORELINES_ARC'], styles=[''], 
+    ...                      srs='EPSG:4326', bbox=(-70.8, 42, -70, 42.8), size=(300, 300), 
+    ...                      format='image/jpeg', transparent=True)
+    ...     out = open(scratch_file('massgis_shoreline.jpg'), 'wb')
+    ...     bytes_written = out.write(img.read())
+    ...     out.close()
+    ... except requests.exceptions.ConnectTimeout:
+    ...     print("Warning: Connection to the server timed out.")
+

--- a/tests/test_opensearch_creodias.py
+++ b/tests/test_opensearch_creodias.py
@@ -4,13 +4,12 @@ import pytest
 
 from owslib.opensearch import OpenSearch
 
-SERVICE_URL = 'https://finder.creodias.eu/resto/api/collections/Sentinel1/describe.xml'
+SERVICE_URL = 'https://datahub.creodias.eu/resto/api/collections/Sentinel1/describe.xml'
 
 
 @pytest.mark.online
-# service testing is commented out given CREODIAS does not allow HEAD requests
-# @pytest.mark.skipif(not service_ok(SERVICE_URL),
-#                    reason='service is unreachable')
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason='service is unreachable')
 def test_opensearch_creodias():
 
     o = OpenSearch(SERVICE_URL)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,7 +87,11 @@ def service_ok(url, timeout=5):
         if 'html' in resp.headers['content-type']:
             ok = False
         else:
-            ok = resp.ok
+            if resp.ok is False:
+                # URL may refuse HEAD requests, so try with a GET
+                # and use stream=True to only download the headers
+                resp = requests.get(url, timeout=timeout, stream=True)
+                return resp.ok
     except requests.exceptions.ReadTimeout:
         ok = False
     except requests.exceptions.ConnectTimeout:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -84,14 +84,11 @@ def sorted_url_query(url):
 def service_ok(url, timeout=5):
     try:
         resp = requests.head(url, allow_redirects=True, timeout=timeout)
-        if 'html' in resp.headers['content-type']:
-            ok = False
-        else:
-            if resp.ok is False:
-                # URL may refuse HEAD requests, so try with a GET
-                # and use stream=True to only download the headers
-                resp = requests.get(url, timeout=timeout, stream=True)
-                return resp.ok
+        if 'html' in resp.headers.get('content-type', '').lower():
+            return False
+        if not resp.ok:  # if HEAD is not supported try GET with streaming
+            resp = requests.get(url, timeout=timeout, stream=True)
+        return resp.ok
     except requests.exceptions.ReadTimeout:
         ok = False
     except requests.exceptions.ConnectTimeout:


### PR DESCRIPTION
A few fixes to get the CI passing again:

1. Docs currently fail with Sphinx 8.2.1 and the nbsphinx plugin. See https://github.com/spatialaudio/nbsphinx/issues/825. This is currently fixed by pinning the Sphinx version to 8.1.3
2. One of the test URLs https://finder.creodias.eu/resto/api/collections/Sentinel1/describe.xml no longer seems valid. https://datahub.creodias.eu/resto/api/collections/Sentinel1/describe.xml seems to be the new URL as mentioned in https://creodias.eu/news/action-required-new-catalogue-api-for-creodias-data-catalogue/. Updated and tests passing again. 
3. The test helper function `service_ok` has been updated so if a server doesn't accept HEAD requests a GET request is attempted with `stream=True` so no data is downloaded, and only headers retrieved. 
4. The doctest `wms_geoserver_mass_gis.txt` intermittently fails (even though the server seems fine) - possibly due to throttling? This has been wrapped in a `try..except` statement, so the CI continues to pass if this fails again. 