### PR TITLE
Default to text/xml if server doesn't return a Content-Type

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -342,7 +342,8 @@ def getXMLTree(rsp: ResponseWrapper) -> etree:
     et = etree.fromstring(raw_text)
 
     # check for response type - if it is not xml then raise an error
-    content_type = rsp.info()['Content-Type']
+    # if the server doesn't provide a Content-Type then assume xml
+    content_type = rsp.info().get('Content-Type', 'text/xml')
     url = rsp.geturl()
 
     xml_types = ['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,6 +71,19 @@ def test_getXMLTree_valid():
     assert et.find('.//Title').text == "Example"
 
 
+def test_getXMLTree_valid_missing_content_type():
+
+    mock_resp = mock.Mock()
+    mock_resp.url = 'http:///example.org/?service=WFS&request=GetCapabilities&version=2.0.0'
+    mock_resp.content = b'<?xml version="1.0" encoding="UTF-8"?>\n<WFS_Capabilities><ServiceIdentification>' \
+                        b'<Title>Example</Title></ServiceIdentification></WFS_Capabilities>'
+    mock_resp.headers = {}
+    resp_wrap = ResponseWrapper(mock_resp)
+
+    et = getXMLTree(resp_wrap)
+    assert et.find('.//Title').text == "Example"
+
+
 def test_getXMLTree_invalid():
 
     mock_resp = mock.Mock()


### PR DESCRIPTION
Fix for #976. Assume content is `text/xml` if the server doesn't return a `Content-Type` header, as in the case of https://data.geopf.fr/wfs/wfs?service=WFS&request=GetCapabilities&version=2.0.0 which returns valid XML. 
