### PR TITLE
Fix FutureWarnings for testing lxml elements

### DIFF
--- a/owslib/feature/wfs110.py
+++ b/owslib/feature/wfs110.py
@@ -444,9 +444,11 @@ class ContentMetadata(AbstractContentMetadata):
                     elif metadataUrl["type"] in ["TC211", "19115", "19139"]:
                         mdelem = doc.find(
                             ".//" + nspath_eval("gmd:MD_Metadata", namespaces)
-                        ) or doc.find(
-                            ".//" + nspath_eval("gmi:MI_Metadata", namespaces)
                         )
+                        if mdelem is None:
+                            mdelem = doc.find(
+                                ".//" + nspath_eval("gmi:MI_Metadata", namespaces)
+                            )
                         if mdelem is not None:
                             metadataUrl["metadata"] = MD_Metadata(mdelem)
                         else:

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -567,9 +567,11 @@ class ContentMetadata(AbstractContentMetadata):
 
                     mdelem = doc.find(
                         ".//" + util.nspath_eval("gmd:MD_Metadata", n.get_namespaces(["gmd"]))
-                    ) or doc.find(
-                        ".//" + util.nspath_eval("gmi:MI_Metadata", n.get_namespaces(["gmi"]))
                     )
+                    if mdelem is None:
+                        mdelem = doc.find(
+                            ".//" + util.nspath_eval("gmi:MI_Metadata", n.get_namespaces(["gmi"]))
+                        )
                     if mdelem is not None:
                         metadataUrl["metadata"] = MD_Metadata(mdelem)
                         continue

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -703,8 +703,14 @@ class ContentMetadata(AbstractContentMetadata):
                         metadataUrl['metadata'] = Metadata(mdelem)
                         continue
 
-                    mdelem = doc.find('.//' + nspath_eval('gmd:MD_Metadata', n.get_namespaces(['gmd']))) \
-                        or doc.find('.//' + nspath_eval('gmi:MI_Metadata', n.get_namespaces(['gmi'])))
+                    mdelem = doc.find(
+                        './/' + nspath_eval('gmd:MD_Metadata', n.get_namespaces(['gmd']))
+                    )
+                    if mdelem is None:
+                        doc.find(
+                            './/' + nspath_eval('gmi:MI_Metadata', n.get_namespaces(['gmi']))
+                        )
+
                     if mdelem is not None:
                         metadataUrl['metadata'] = MD_Metadata(mdelem)
                         continue


### PR DESCRIPTION
Fixes the following FutureWarnings displayed when running the test suite:

```
  /home/runner/work/OWSLib/OWSLib/owslib/feature/wfs110.py:445: FutureWarning: Truth-testing of elements was a source of confusion and will always return True in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    mdelem = doc.find(
```

Element objects are considered a False value if they have no children, so using `or` could skip the first result. 

See https://github.com/lxml/lxml/blob/0eb4f0029497957e58a9f15280b3529bdb18d117/src/lxml/etree.pyx#L1313