### PR TITLE
Remove unknown pytest.mark.unit

### DIFF
--- a/tests/test_iso3_parsing.py
+++ b/tests/test_iso3_parsing.py
@@ -45,8 +45,6 @@ from owslib.iso3 import (MD_Metadata, SV_ServiceIdentification, PT_Locale,
                           MD_ReferenceSystem, MD_FeatureCatalogueDescription,
                           MD_ImageDescription, MD_Band)
 
-pytestmark = pytest.mark.unit
-
 
 @pytest.fixture
 def ns():


### PR DESCRIPTION
Fixes warning:

```
OWSLib/OWSLib/tests/test_iso3_parsing.py:48: PytestUnknownMarkWarning: Unknown pytest.mark.unit - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```

The custom `unit` mark isn't used anywhere in the project. 