### PR TITLE
Add URL check for https://demo.pycsw.org/cite

### DIFF
--- a/tests/test_ogcapi_records_pycsw.py
+++ b/tests/test_ogcapi_records_pycsw.py
@@ -70,6 +70,8 @@ def test_ogcapi_records_pycsw():
 
 
 @pytest.mark.online
+@pytest.mark.skipif(not service_ok(SERVICE_URL),
+                    reason='service is unreachable')
 @pytest.mark.parametrize("path, expected", [
     ('collections/foo/1', 'https://demo.pycsw.org/cite/collections/foo/1'),
     ('collections/foo/https://example.org/11', 'https://demo.pycsw.org/cite/collections/foo/https://example.org/11')  # noqa


### PR DESCRIPTION
The URL https://demo.pycsw.org/cite has been offline several times in the last month(s). 

```
502 Bad Gateway
nginx/1.18.0 (Ubuntu)
```

This PR skips the failing test if the URL is unavailable. 