### PR TITLE
Test for XML in response, regardless of mimetype

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -346,8 +346,10 @@ def getXMLTree(rsp: ResponseWrapper) -> etree:
     content_type = rsp.info().get('Content-Type', 'text/xml')
     url = rsp.geturl()
 
+    has_xml_tag = raw_text.lstrip().startswith(b'<?xml')
+
     xml_types = ['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']
-    if not any(xt in content_type.lower() for xt in xml_types):
+    if not any(xt in content_type.lower() for xt in xml_types) and not has_xml_tag:
         html_body = et.find('BODY')  # note this is case-sensitive
         if html_body is not None and len(html_body.text) > 0:
             response_text = html_body.text.strip("\n")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,6 +71,20 @@ def test_getXMLTree_valid():
     assert et.find('.//Title').text == "Example"
 
 
+def test_getXMLTree_non_xml_mime_type():
+
+    mock_resp = mock.Mock()
+    mock_resp.url = 'http:///example.org/?service=WFS&request=GetCapabilities&version=2.0.0'
+    mock_resp.content = b'<?xml version="1.0" encoding="UTF-8"?>\n<WFS_Capabilities><ServiceIdentification>' \
+                        b'<Title>Example</Title></ServiceIdentification></WFS_Capabilities>'
+    # test with a non-XML mime type, but the response starts with <?xml
+    mock_resp.headers = {'Content-Type': 'application/octet-stream'}
+    resp_wrap = ResponseWrapper(mock_resp)
+
+    et = getXMLTree(resp_wrap)
+    assert et.find('.//Title').text == "Example"
+
+
 def test_getXMLTree_valid_missing_content_type():
 
     mock_resp = mock.Mock()


### PR DESCRIPTION
Fix for #983. `application/octet-stream` is a very generic mime type which could contain anything, so rather than adding more mime types to the list, a check is made to see if the response contains an xml tag, or is one of the following mime types:

```python
['text/xml', 'application/xml', 'application/vnd.ogc.wms_xml']
```

@SimonSAMPERE - can you check if this works with the WFS/WMS services that previously were failing?



