### PR TITLE
do not show warnings on missing style name&title

### DIFF
--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -539,8 +539,6 @@ class ContentMetadata(AbstractContentMetadata):
             title = s.find('Title')
             if name is None and title is None:
                 raise ValueError('%s missing name and title' % (s,))
-            if name is None or title is None:
-                warnings.warn('%s missing name or title' % (s,))
             title_ = title.text if title is not None else name.text
             name_ = name.text if name is not None else title.text
             style = {'title': title_}

--- a/owslib/map/wms130.py
+++ b/owslib/map/wms130.py
@@ -584,8 +584,6 @@ class ContentMetadata(AbstractContentMetadata):
             title = s.find(nspath('Title', WMS_NAMESPACE))
             if name is None and title is None:
                 raise ValueError('%s missing name and title' % (s,))
-            if name is None or title is None:
-                warnings.warn('%s missing name or title' % (s,))
             title_ = title.text if title is not None else name.text
             name_ = name.text if name is not None else title.text
             style = {'title': title_}


### PR DESCRIPTION
The warning about missing name|title in wms-style clogs our logs, because it is shown on each layer of a wms (if that wms has either key not set). On the other I don't see much value of the warning.

issue improves #987