### PR TITLE
Enhance datatype determination and improve `service_ok` util

### DIFF
--- a/tests/resources/wfs_koeln_arcgis_describefeaturetype_110.xml
+++ b/tests/resources/wfs_koeln_arcgis_describefeaturetype_110.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:adressen_stadtteil="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" targetNamespace="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xsd:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/3.1.1/base/gml.xsd"/>
+<xsd:element name="Blumenberg" type="adressen_stadtteil:BlumenbergFeatureType" substitutionGroup="gml:_Feature"/>
+<xsd:complexType name="BlumenbergFeatureType">
+  <xsd:complexContent>
+    <xsd:extension base="gml:AbstractFeatureType">
+      <xsd:sequence>
+        <xsd:element minOccurs="0" maxOccurs="1" name="objectid" type="xsd:int"/>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Nummer">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="11"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Adresse">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="47"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Strassenschlüssel">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Straße">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Amtl._Straßenname">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Straße__Stadtbezirk_">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Hausnummer">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Gebäude_ID_ALKIS">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="16"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Nutzung__ALKIS_Gebäudefunktion_">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="80"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Blockseite">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="8"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtviertel__Nr._">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtviertel">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Statistisches_Quartier__Nr._">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="9"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Statistisches_Quartier">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtteil__Nr._">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="3"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtteil">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtbezirk__Nr._">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="1"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtbezirk">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stimmbezirk">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Postleitzahlgebiet">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Schiedsamtsbezirk">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="2"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Sozialraum__Nr._">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="9"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Sozialraum">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="globalid" type="xsd:string"/>
+        <xsd:element minOccurs="0" maxOccurs="1" name="shape" type="gml:PointPropertyType"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+</xsd:schema>

--- a/tests/resources/wfs_koeln_arcgis_describefeaturetype_200.xml
+++ b/tests/resources/wfs_koeln_arcgis_describefeaturetype_200.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:adressen_stadtteil="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xsd:element name="Blumenberg" type="adressen_stadtteil:BlumenbergFeatureType" substitutionGroup="gml:AbstractFeature"/>
+<xsd:complexType name="BlumenbergFeatureType">
+  <xsd:complexContent>
+    <xsd:extension base="gml:AbstractFeatureType">
+      <xsd:sequence>
+        <xsd:element minOccurs="0" maxOccurs="1" name="objectid" type="xsd:int"/>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Nummer" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="11"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Adresse" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="47"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Strassenschlüssel" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Straße" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Amtl._Straßenname" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Straße__Stadtbezirk_" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Hausnummer" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Gebäude_ID_ALKIS" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="16"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Nutzung__ALKIS_Gebäudefunktion_" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="80"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Blockseite" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="8"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtviertel__Nr._" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtviertel" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Statistisches_Quartier__Nr._" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="9"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Statistisches_Quartier" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtteil__Nr._" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="3"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtteil" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtbezirk__Nr._" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="1"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stadtbezirk" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="40"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Stimmbezirk" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Postleitzahlgebiet" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="5"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Schiedsamtsbezirk" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="2"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Sozialraum__Nr._" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="9"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="Sozialraum" nillable="true">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:maxLength value="100"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element minOccurs="0" maxOccurs="1" name="globalid" type="xsd:string"/>
+        <xsd:element minOccurs="0" maxOccurs="1" name="shape" nillable="true" type="gml:PointPropertyType"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+</xsd:schema>

--- a/tests/resources/wfs_koeln_arcgis_getcapabilities_110.xml
+++ b/tests/resources/wfs_koeln_arcgis_getcapabilities_110.xml
@@ -1,0 +1,1256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:WFS_Capabilities
+ xmlns:wfs="http://www.opengis.net/wfs"
+ xmlns:ogc="http://www.opengis.net/ogc"
+ xmlns:gml="http://www.opengis.net/gml"
+ xmlns:ows="http://www.opengis.net/ows"
+ xmlns:adressen_stadtteil="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsAll.xsd https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?service=wfs%26version=1.1.0%26request=DescribeFeatureType"
+ version="1.1.0"
+>
+<ows:ServiceIdentification>
+  <ows:Title>Adressen je Stadtteil</ows:Title>
+  <ows:Abstract></ows:Abstract>
+  <ows:Keywords>
+    <ows:Keyword>ESRI(LongLat)</ows:Keyword>
+  </ows:Keywords>
+  <ows:ServiceType>WFS</ows:ServiceType>
+  <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
+  <ows:Fees></ows:Fees>
+  <ows:AccessConstraints></ows:AccessConstraints>
+</ows:ServiceIdentification>
+<ows:ServiceProvider>
+  <ows:ProviderName>Stadt Köln - Amt für Stadtentwicklung und Statistik</ows:ProviderName>
+  <ows:ServiceContact>
+    <ows:IndividualName>Raumbezugssystem</ows:IndividualName>
+    <ows:PositionName></ows:PositionName>
+    <ows:ContactInfo>
+    <ows:Phone>
+      <ows:Voice></ows:Voice>
+      <ows:Facsimile></ows:Facsimile>
+    </ows:Phone>
+    <ows:Address>
+      <ows:DeliveryPoint>Willy-Brandt-Platz 2</ows:DeliveryPoint>
+      <ows:City>Köln</ows:City>
+      <ows:AdministrativeArea></ows:AdministrativeArea>
+      <ows:PostalCode>50679</ows:PostalCode>
+      <ows:Country>Deutschland</ows:Country>
+      <ows:ElectronicMailAddress>statistik-rbs@stadt-koeln.de</ows:ElectronicMailAddress>
+    </ows:Address>
+    <ows:OnlineResource xlink:href="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer"/>
+    <ows:HoursOfService></ows:HoursOfService>
+    <ows:ContactInstructions></ows:ContactInstructions>
+    </ows:ContactInfo>
+    <ows:Role></ows:Role>
+  </ows:ServiceContact>
+</ows:ServiceProvider>
+<ows:OperationsMetadata>
+  <ows:Operation name="GetCapabilities">
+    <ows:DCP>
+      <ows:HTTP>
+        <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+        <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+      </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="AcceptVersions">
+      <ows:Value>1.1.0</ows:Value>
+    </ows:Parameter>
+    <ows:Parameter name="AcceptFormats">
+      <ows:Value>GML3</ows:Value>
+      <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+  </ows:Operation>
+  <ows:Operation name="DescribeFeatureType">
+    <ows:DCP>
+      <ows:HTTP>
+        <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+        <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+      </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="outputFormat">
+      <ows:Value>GML3</ows:Value>
+      <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+  </ows:Operation>
+  <ows:Operation name="GetFeature">
+    <ows:DCP>
+      <ows:HTTP>
+        <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+        <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+      </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="resultType">
+      <ows:Value>results</ows:Value>
+      <ows:Value>hits</ows:Value>
+    </ows:Parameter>
+    <ows:Parameter name="outputFormat">
+      <ows:Value>GML3</ows:Value>
+      <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+  </ows:Operation>
+</ows:OperationsMetadata>
+<wfs:FeatureTypeList>
+    <wfs:Operations>
+      <wfs:Operation>Query</wfs:Operation>
+    </wfs:Operations>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Altstadt_Nord</wfs:Name>
+    <wfs:Title>Altstadt_Nord</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Altstadt_Süd</wfs:Name>
+    <wfs:Title>Altstadt_Süd</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bayenthal</wfs:Name>
+    <wfs:Title>Bayenthal</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bickendorf</wfs:Name>
+    <wfs:Title>Bickendorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bilderstöckchen</wfs:Name>
+    <wfs:Title>Bilderstöckchen</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Blumenberg</wfs:Name>
+    <wfs:Title>Blumenberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bocklemünd_Mengenich</wfs:Name>
+    <wfs:Title>Bocklemünd_Mengenich</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Braunsfeld</wfs:Name>
+    <wfs:Title>Braunsfeld</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Brück</wfs:Name>
+    <wfs:Title>Brück</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Buchforst</wfs:Name>
+    <wfs:Title>Buchforst</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Buchheim</wfs:Name>
+    <wfs:Title>Buchheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Chorweiler</wfs:Name>
+    <wfs:Title>Chorweiler</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Dellbrück</wfs:Name>
+    <wfs:Title>Dellbrück</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Deutz</wfs:Name>
+    <wfs:Title>Deutz</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Dünnwald</wfs:Name>
+    <wfs:Title>Dünnwald</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ehrenfeld</wfs:Name>
+    <wfs:Title>Ehrenfeld</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Eil</wfs:Name>
+    <wfs:Title>Eil</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Elsdorf</wfs:Name>
+    <wfs:Title>Elsdorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ensen</wfs:Name>
+    <wfs:Title>Ensen</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Esch_Auweiler</wfs:Name>
+    <wfs:Title>Esch_Auweiler</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Finkenberg</wfs:Name>
+    <wfs:Title>Finkenberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Flittard</wfs:Name>
+    <wfs:Title>Flittard</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Fühlingen</wfs:Name>
+    <wfs:Title>Fühlingen</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Godorf</wfs:Name>
+    <wfs:Title>Godorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Gremberghoven</wfs:Name>
+    <wfs:Title>Gremberghoven</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Grengel</wfs:Name>
+    <wfs:Title>Grengel</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Hahnwald</wfs:Name>
+    <wfs:Title>Hahnwald</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Heimersdorf</wfs:Name>
+    <wfs:Title>Heimersdorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Höhenberg</wfs:Name>
+    <wfs:Title>Höhenberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Höhenhaus</wfs:Name>
+    <wfs:Title>Höhenhaus</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Holweide</wfs:Name>
+    <wfs:Title>Holweide</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Humboldt_Gremberg</wfs:Name>
+    <wfs:Title>Humboldt_Gremberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Immendorf</wfs:Name>
+    <wfs:Title>Immendorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Junkersdorf</wfs:Name>
+    <wfs:Title>Junkersdorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Kalk</wfs:Name>
+    <wfs:Title>Kalk</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Klettenberg</wfs:Name>
+    <wfs:Title>Klettenberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Langel</wfs:Name>
+    <wfs:Title>Langel</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Libur</wfs:Name>
+    <wfs:Title>Libur</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lind</wfs:Name>
+    <wfs:Title>Lind</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lindenthal</wfs:Name>
+    <wfs:Title>Lindenthal</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lindweiler</wfs:Name>
+    <wfs:Title>Lindweiler</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Longerich</wfs:Name>
+    <wfs:Title>Longerich</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lövenich</wfs:Name>
+    <wfs:Title>Lövenich</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Marienburg</wfs:Name>
+    <wfs:Title>Marienburg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Mauenheim</wfs:Name>
+    <wfs:Title>Mauenheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Merheim</wfs:Name>
+    <wfs:Title>Merheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Merkenich</wfs:Name>
+    <wfs:Title>Merkenich</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Meschenich</wfs:Name>
+    <wfs:Title>Meschenich</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Mülheim</wfs:Name>
+    <wfs:Title>Mülheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Müngersdorf</wfs:Name>
+    <wfs:Title>Müngersdorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neubrück</wfs:Name>
+    <wfs:Title>Neubrück</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neuehrenfeld</wfs:Name>
+    <wfs:Title>Neuehrenfeld</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neustadt_Nord</wfs:Name>
+    <wfs:Title>Neustadt_Nord</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neustadt_Süd</wfs:Name>
+    <wfs:Title>Neustadt_Süd</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Niehl</wfs:Name>
+    <wfs:Title>Niehl</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Nippes</wfs:Name>
+    <wfs:Title>Nippes</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ossendorf</wfs:Name>
+    <wfs:Title>Ossendorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ostheim</wfs:Name>
+    <wfs:Title>Ostheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Pesch</wfs:Name>
+    <wfs:Title>Pesch</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Poll</wfs:Name>
+    <wfs:Title>Poll</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Porz</wfs:Name>
+    <wfs:Title>Porz</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Raderberg</wfs:Name>
+    <wfs:Title>Raderberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Raderthal</wfs:Name>
+    <wfs:Title>Raderthal</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rath_Heumar</wfs:Name>
+    <wfs:Title>Rath_Heumar</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Riehl</wfs:Name>
+    <wfs:Title>Riehl</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rodenkirchen</wfs:Name>
+    <wfs:Title>Rodenkirchen</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Roggendorf_Thenhoven</wfs:Name>
+    <wfs:Title>Roggendorf_Thenhoven</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rondorf</wfs:Name>
+    <wfs:Title>Rondorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Seeberg</wfs:Name>
+    <wfs:Title>Seeberg</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Stammheim</wfs:Name>
+    <wfs:Title>Stammheim</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Sülz</wfs:Name>
+    <wfs:Title>Sülz</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Sürth</wfs:Name>
+    <wfs:Title>Sürth</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Urbach</wfs:Name>
+    <wfs:Title>Urbach</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Vingst</wfs:Name>
+    <wfs:Title>Vingst</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Vogelsang</wfs:Name>
+    <wfs:Title>Vogelsang</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Volkhoven_Weiler</wfs:Name>
+    <wfs:Title>Volkhoven_Weiler</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Wahn</wfs:Name>
+    <wfs:Title>Wahn</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Wahnheide</wfs:Name>
+    <wfs:Title>Wahnheide</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weiden</wfs:Name>
+    <wfs:Title>Weiden</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weidenpesch</wfs:Name>
+    <wfs:Title>Weidenpesch</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weiß</wfs:Name>
+    <wfs:Title>Weiß</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Westhoven</wfs:Name>
+    <wfs:Title>Westhoven</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Widdersdorf</wfs:Name>
+    <wfs:Title>Widdersdorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Worringen</wfs:Name>
+    <wfs:Title>Worringen</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Zollstock</wfs:Name>
+    <wfs:Title>Zollstock</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Zündorf</wfs:Name>
+    <wfs:Title>Zündorf</wfs:Title>
+    <wfs:DefaultSRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultSRS>
+    <wfs:OutputFormats>
+      <wfs:Format>GML3</wfs:Format>
+      <wfs:Format>text/xml; subtype=gml/3.1.1</wfs:Format>
+    </wfs:OutputFormats>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+</wfs:FeatureTypeList>
+<ogc:Filter_Capabilities>
+  <ogc:Spatial_Capabilities>
+    <ogc:GeometryOperands>
+      <ogc:GeometryOperand>gml:Envelope</ogc:GeometryOperand>
+      <ogc:GeometryOperand>gml:Point</ogc:GeometryOperand>
+      <ogc:GeometryOperand>gml:Polygon</ogc:GeometryOperand>
+      <ogc:GeometryOperand>gml:LineString</ogc:GeometryOperand>
+    </ogc:GeometryOperands>
+    <ogc:SpatialOperators>
+      <ogc:SpatialOperator name="BBOX"/>
+      <ogc:SpatialOperator name="Equals"/>
+      <ogc:SpatialOperator name="Disjoint"/>
+      <ogc:SpatialOperator name="Intersects"/>
+      <ogc:SpatialOperator name="Crosses"/>
+      <ogc:SpatialOperator name="Touches"/>
+      <ogc:SpatialOperator name="Within"/>
+      <ogc:SpatialOperator name="Contains"/>
+      <ogc:SpatialOperator name="Overlaps"/>
+    </ogc:SpatialOperators>
+  </ogc:Spatial_Capabilities>
+  <ogc:Scalar_Capabilities>
+    <ogc:LogicalOperators/>
+    <ogc:ComparisonOperators>
+      <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>NotEqualTo</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>LessThan</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>GreaterThan</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>LessThanEqualTo</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>GreaterThanEqualTo</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>Like</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
+      <ogc:ComparisonOperator>NullCheck</ogc:ComparisonOperator>
+    </ogc:ComparisonOperators>
+  </ogc:Scalar_Capabilities>
+  <ogc:Id_Capabilities>
+    <ogc:EID/>
+    <ogc:FID/>
+  </ogc:Id_Capabilities>
+</ogc:Filter_Capabilities>
+</wfs:WFS_Capabilities>

--- a/tests/resources/wfs_koeln_arcgis_getcapabilities_200.xml
+++ b/tests/resources/wfs_koeln_arcgis_getcapabilities_200.xml
@@ -1,0 +1,1022 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:WFS_Capabilities
+  xmlns="http://www.opengis.net/wfs/2.0"
+  xmlns:wfs="http://www.opengis.net/wfs/2.0"
+  xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:fes="http://www.opengis.net/fes/2.0"
+  xmlns:adressen_stadtteil="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="2.0.0"  xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?service=wfs%26version=2.0.0%26request=DescribeFeatureType"
+>
+  <ows:ServiceIdentification>
+    <ows:Title>WFS</ows:Title>
+    <ows:Abstract></ows:Abstract>
+    <ows:Keywords>
+      <ows:Keyword>ESRI(LongLat)</ows:Keyword>
+    </ows:Keywords>
+    <ows:ServiceType>WFS</ows:ServiceType>
+    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+    <ows:Fees></ows:Fees>
+    <ows:AccessConstraints></ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>Stadt Köln - Amt für Stadtentwicklung und Statistik</ows:ProviderName>
+    <ows:ServiceContact>
+      <ows:IndividualName>Raumbezugssystem</ows:IndividualName>
+      <ows:PositionName></ows:PositionName>
+      <ows:ContactInfo>
+        <ows:Phone>
+          <ows:Voice></ows:Voice>
+          <ows:Facsimile></ows:Facsimile>
+        </ows:Phone>
+        <ows:Address>
+          <ows:DeliveryPoint>Willy-Brandt-Platz 2</ows:DeliveryPoint>
+          <ows:City>Köln</ows:City>
+          <ows:AdministrativeArea></ows:AdministrativeArea>
+          <ows:PostalCode>50679</ows:PostalCode>
+          <ows:Country>Deutschland</ows:Country>
+          <ows:ElectronicMailAddress>statistik-rbs@stadt-koeln.de</ows:ElectronicMailAddress>
+        </ows:Address>
+        <ows:OnlineResource xlink:href="https://k00364:6443/arcgis/admin/services/adressen_stadtteil/MapServer/WFSServer"/>
+        <ows:HoursOfService></ows:HoursOfService>
+        <ows:ContactInstructions></ows:ContactInstructions>
+      </ows:ContactInfo>
+      <ows:Role></ows:Role>
+    </ows:ServiceContact>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="AcceptVersions">
+        <ows:AllowedValues>
+          <ows:Value>1.0.0</ows:Value>
+          <ows:Value>1.1.0</ows:Value>
+          <ows:Value>2.0.0</ows:Value>
+      </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="DescribeFeatureType">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+    <ows:Parameter name="outputFormat">
+      <ows:AllowedValues>
+        <ows:Value>text/xml; subtype=gml/3.2</ows:Value>
+      </ows:AllowedValues>
+    </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="GetPropertyValue">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="resolve">
+        <ows:AllowedValues>
+          <ows:Value>none</ows:Value>
+          <ows:Value>local</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="GetFeature">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="resultType">
+        <ows:AllowedValues>
+          <ows:Value>results</ows:Value>
+          <ows:Value>hits</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+      <ows:Parameter name="outputFormat">
+        <ows:AllowedValues>
+          <ows:Value>GML32</ows:Value>
+          <ows:Value>GML32+ZIP</ows:Value>
+          <ows:Value>GML32+GZIP</ows:Value>
+          <ows:Value>application/gml+xml; version=3.2</ows:Value>
+          <ows:Value>GML3</ows:Value>
+          <ows:Value>GML3+ZIP</ows:Value>
+          <ows:Value>GML3+GZIP</ows:Value>
+          <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+          <ows:Value>GML2</ows:Value>
+          <ows:Value>GML2+ZIP</ows:Value>
+          <ows:Value>GML2+GZIP</ows:Value>
+          <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+          <ows:Value>GEOJSON</ows:Value>
+          <ows:Value>GEOJSON+ZIP</ows:Value>
+          <ows:Value>GEOJSON+GZIP</ows:Value>
+          <ows:Value>ESRIGEOJSON</ows:Value>
+          <ows:Value>ESRIGEOJSON+ZIP</ows:Value>
+          <ows:Value>ESRIGEOJSON+GZIP</ows:Value>
+          <ows:Value>KML</ows:Value>
+          <ows:Value>application/vnd.google-earth.kml xml</ows:Value>
+          <ows:Value>application/vnd.google-earth.kml+xml</ows:Value>
+          <ows:Value>KMZ</ows:Value>
+          <ows:Value>application/vnd.google-earth.kmz</ows:Value>
+          <ows:Value>SHAPE+ZIP</ows:Value>
+          <ows:Value>CSV</ows:Value>
+          <ows:Value>CSV+ZIP</ows:Value>
+          <ows:Value>CSV+GZIP</ows:Value>
+          <ows:Value>Geopackage</ows:Value>
+          <ows:Value>Geopackage+ZIP</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+      <ows:Parameter name="resolve">
+        <ows:AllowedValues>
+          <ows:Value>none</ows:Value>
+          <ows:Value>local</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="GetGmlObject">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="ListStoredQueries">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="DescribeStoredQueries">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?"/>
+          <ows:Post xlink:href="https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer"/>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Constraint name="ImplementsBasicWFS"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsTransactionalWFS"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsLockingWFS"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="KVPEncoding"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="XMLEncoding"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="SOAPEncoding"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsInheritance"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsRemoteResolve"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsResultPaging"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsStandardJoins"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsSpatialJoins"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsTemporalJoins"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ImplementsFeatureVersioning"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+    <ows:Constraint name="ManageStoredQueries"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></ows:Constraint>
+  </ows:OperationsMetadata>
+  <wfs:FeatureTypeList>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Altstadt_Nord</wfs:Name>
+    <wfs:Title>Altstadt_Nord</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Altstadt_Süd</wfs:Name>
+    <wfs:Title>Altstadt_Süd</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bayenthal</wfs:Name>
+    <wfs:Title>Bayenthal</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bickendorf</wfs:Name>
+    <wfs:Title>Bickendorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bilderstöckchen</wfs:Name>
+    <wfs:Title>Bilderstöckchen</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Blumenberg</wfs:Name>
+    <wfs:Title>Blumenberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Bocklemünd_Mengenich</wfs:Name>
+    <wfs:Title>Bocklemünd_Mengenich</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Braunsfeld</wfs:Name>
+    <wfs:Title>Braunsfeld</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Brück</wfs:Name>
+    <wfs:Title>Brück</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Buchforst</wfs:Name>
+    <wfs:Title>Buchforst</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Buchheim</wfs:Name>
+    <wfs:Title>Buchheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Chorweiler</wfs:Name>
+    <wfs:Title>Chorweiler</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Dellbrück</wfs:Name>
+    <wfs:Title>Dellbrück</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Deutz</wfs:Name>
+    <wfs:Title>Deutz</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Dünnwald</wfs:Name>
+    <wfs:Title>Dünnwald</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ehrenfeld</wfs:Name>
+    <wfs:Title>Ehrenfeld</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Eil</wfs:Name>
+    <wfs:Title>Eil</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Elsdorf</wfs:Name>
+    <wfs:Title>Elsdorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ensen</wfs:Name>
+    <wfs:Title>Ensen</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Esch_Auweiler</wfs:Name>
+    <wfs:Title>Esch_Auweiler</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Finkenberg</wfs:Name>
+    <wfs:Title>Finkenberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Flittard</wfs:Name>
+    <wfs:Title>Flittard</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Fühlingen</wfs:Name>
+    <wfs:Title>Fühlingen</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Godorf</wfs:Name>
+    <wfs:Title>Godorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Gremberghoven</wfs:Name>
+    <wfs:Title>Gremberghoven</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Grengel</wfs:Name>
+    <wfs:Title>Grengel</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Hahnwald</wfs:Name>
+    <wfs:Title>Hahnwald</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Heimersdorf</wfs:Name>
+    <wfs:Title>Heimersdorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Höhenberg</wfs:Name>
+    <wfs:Title>Höhenberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Höhenhaus</wfs:Name>
+    <wfs:Title>Höhenhaus</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Holweide</wfs:Name>
+    <wfs:Title>Holweide</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Humboldt_Gremberg</wfs:Name>
+    <wfs:Title>Humboldt_Gremberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Immendorf</wfs:Name>
+    <wfs:Title>Immendorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Junkersdorf</wfs:Name>
+    <wfs:Title>Junkersdorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Kalk</wfs:Name>
+    <wfs:Title>Kalk</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Klettenberg</wfs:Name>
+    <wfs:Title>Klettenberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Langel</wfs:Name>
+    <wfs:Title>Langel</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Libur</wfs:Name>
+    <wfs:Title>Libur</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lind</wfs:Name>
+    <wfs:Title>Lind</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lindenthal</wfs:Name>
+    <wfs:Title>Lindenthal</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lindweiler</wfs:Name>
+    <wfs:Title>Lindweiler</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Longerich</wfs:Name>
+    <wfs:Title>Longerich</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Lövenich</wfs:Name>
+    <wfs:Title>Lövenich</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Marienburg</wfs:Name>
+    <wfs:Title>Marienburg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Mauenheim</wfs:Name>
+    <wfs:Title>Mauenheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Merheim</wfs:Name>
+    <wfs:Title>Merheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Merkenich</wfs:Name>
+    <wfs:Title>Merkenich</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Meschenich</wfs:Name>
+    <wfs:Title>Meschenich</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Mülheim</wfs:Name>
+    <wfs:Title>Mülheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Müngersdorf</wfs:Name>
+    <wfs:Title>Müngersdorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neubrück</wfs:Name>
+    <wfs:Title>Neubrück</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neuehrenfeld</wfs:Name>
+    <wfs:Title>Neuehrenfeld</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neustadt_Nord</wfs:Name>
+    <wfs:Title>Neustadt_Nord</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Neustadt_Süd</wfs:Name>
+    <wfs:Title>Neustadt_Süd</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Niehl</wfs:Name>
+    <wfs:Title>Niehl</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Nippes</wfs:Name>
+    <wfs:Title>Nippes</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ossendorf</wfs:Name>
+    <wfs:Title>Ossendorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Ostheim</wfs:Name>
+    <wfs:Title>Ostheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Pesch</wfs:Name>
+    <wfs:Title>Pesch</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Poll</wfs:Name>
+    <wfs:Title>Poll</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Porz</wfs:Name>
+    <wfs:Title>Porz</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Raderberg</wfs:Name>
+    <wfs:Title>Raderberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Raderthal</wfs:Name>
+    <wfs:Title>Raderthal</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rath_Heumar</wfs:Name>
+    <wfs:Title>Rath_Heumar</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Riehl</wfs:Name>
+    <wfs:Title>Riehl</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rodenkirchen</wfs:Name>
+    <wfs:Title>Rodenkirchen</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Roggendorf_Thenhoven</wfs:Name>
+    <wfs:Title>Roggendorf_Thenhoven</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Rondorf</wfs:Name>
+    <wfs:Title>Rondorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Seeberg</wfs:Name>
+    <wfs:Title>Seeberg</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Stammheim</wfs:Name>
+    <wfs:Title>Stammheim</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Sülz</wfs:Name>
+    <wfs:Title>Sülz</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Sürth</wfs:Name>
+    <wfs:Title>Sürth</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Urbach</wfs:Name>
+    <wfs:Title>Urbach</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Vingst</wfs:Name>
+    <wfs:Title>Vingst</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Vogelsang</wfs:Name>
+    <wfs:Title>Vogelsang</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Volkhoven_Weiler</wfs:Name>
+    <wfs:Title>Volkhoven_Weiler</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Wahn</wfs:Name>
+    <wfs:Title>Wahn</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Wahnheide</wfs:Name>
+    <wfs:Title>Wahnheide</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weiden</wfs:Name>
+    <wfs:Title>Weiden</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weidenpesch</wfs:Name>
+    <wfs:Title>Weidenpesch</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Weiß</wfs:Name>
+    <wfs:Title>Weiß</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Westhoven</wfs:Name>
+    <wfs:Title>Westhoven</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Widdersdorf</wfs:Name>
+    <wfs:Title>Widdersdorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Worringen</wfs:Name>
+    <wfs:Title>Worringen</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Zollstock</wfs:Name>
+    <wfs:Title>Zollstock</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  <wfs:FeatureType>
+    <wfs:Name>adressen_stadtteil:Zündorf</wfs:Name>
+    <wfs:Title>Zündorf</wfs:Title>
+    <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::25832</wfs:DefaultCRS>
+    <ows:WGS84BoundingBox>
+      <ows:LowerCorner>6.80534263 50.83164204</ows:LowerCorner>
+      <ows:UpperCorner>7.13337013 51.08846294</ows:UpperCorner>
+    </ows:WGS84BoundingBox>
+  </wfs:FeatureType>
+  </wfs:FeatureTypeList>
+  <fes:Filter_Capabilities>
+  <fes:Conformance>
+    <fes:Constraint name="ImplementsQuery"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsAdHocQuery"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsFunctions"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsResourceId"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsMinStandardFilter"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsStandardFilter"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsMinSpatialFilter"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsSpatialFilter"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsMinTemporalFilter"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsTemporalFilter"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsVersionNav"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsSorting"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsExtendedOperators"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsMinimumXPath"><ows:NoValues/><ows:DefaultValue>TRUE</ows:DefaultValue></fes:Constraint>
+    <fes:Constraint name="ImplementsSchemaElementFunc"><ows:NoValues/><ows:DefaultValue>FALSE</ows:DefaultValue></fes:Constraint>
+  </fes:Conformance>
+  <fes:Id_Capabilities>
+    <fes:ResourceIdentifier name="fes:ResourceId"/>
+  </fes:Id_Capabilities>
+  <fes:Scalar_Capabilities>
+    <fes:LogicalOperators/>
+    <fes:ComparisonOperators>
+      <fes:ComparisonOperator name="PropertyIsEqualTo"/>
+      <fes:ComparisonOperator name="PropertyIsNotEqualTo"/>
+      <fes:ComparisonOperator name="PropertyIsLessThan"/>
+      <fes:ComparisonOperator name="PropertyIsGreaterThan"/>
+      <fes:ComparisonOperator name="PropertyIsLessThanOrEqualTo"/>
+      <fes:ComparisonOperator name="PropertyIsGreaterThanOrEqualTo"/>
+      <fes:ComparisonOperator name="PropertyIsLike"/>
+      <fes:ComparisonOperator name="PropertyIsNull"/>
+      <fes:ComparisonOperator name="PropertyIsNil"/>
+      <fes:ComparisonOperator name="PropertyIsBetween"/>
+    </fes:ComparisonOperators>
+  </fes:Scalar_Capabilities>
+  <fes:Spatial_Capabilities>
+    <fes:GeometryOperands xmlns:gml="http://www.opengis.net/gml" xmlns:gml32="http://www.opengis.net/gml">
+      <fes:GeometryOperand name="gml:Box"/>
+      <fes:GeometryOperand name="gml:Envelope"/>
+      <fes:GeometryOperand name="gml:Point"/>
+      <fes:GeometryOperand name="gml:LineString"/>
+      <fes:GeometryOperand name="gml:LinearRing"/>
+      <fes:GeometryOperand name="gml:Polygon"/>
+      <fes:GeometryOperand name="gml:MultiPoint"/>
+      <fes:GeometryOperand name="gml:MultiCurve"/>
+      <fes:GeometryOperand name="gml:MultiSurface"/>
+    </fes:GeometryOperands>
+    <fes:SpatialOperators>
+      <fes:SpatialOperator name="BBOX"/>
+      <fes:SpatialOperator name="Equals"/>
+      <fes:SpatialOperator name="Disjoint"/>
+      <fes:SpatialOperator name="Intersects"/>
+      <fes:SpatialOperator name="Touches"/>
+      <fes:SpatialOperator name="Crosses"/>
+      <fes:SpatialOperator name="Within"/>
+      <fes:SpatialOperator name="Contains"/>
+      <fes:SpatialOperator name="Overlaps"/>
+      <fes:SpatialOperator name="Beyond"/>
+      <fes:SpatialOperator name="DWithin"/>
+    </fes:SpatialOperators>
+  </fes:Spatial_Capabilities>
+  </fes:Filter_Capabilities>
+</wfs:WFS_Capabilities>

--- a/tests/test_wfs_schema.py
+++ b/tests/test_wfs_schema.py
@@ -82,6 +82,9 @@ def mp_remote_describefeaturetype_typename_eq_attribute(monkeypatch):
                         __remote_describefeaturetype)
 
 
+
+
+
 class TestOnline(object):
     """Class grouping online tests for the WFS get_schema method."""
     @pytest.mark.xfail
@@ -174,8 +177,8 @@ class TestOffline(object):
         wfs110 = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
         schema = wfs110.get_schema('gw_varia:hhz')
 
-    def test_get_datatype(self):
-        """Test the _get_datatype helper function with different XML structures."""
+    def test_get_datatype_geometry(self):
+        """Test the _get_datatype helper function with geometry types."""
         from owslib.feature.schema import _get_datatype, XS_NAMESPACE
         from owslib.etree import etree
 
@@ -185,50 +188,165 @@ class TestOffline(object):
             'xsd': 'http://www.w3.org/2001/XMLSchema'
         }
 
-        # Case 1: Type defined as attribute
+        # Test geometry type
         # XML: <element name="field1" type="gml:PointPropertyType"/>
-        element1 = etree.Element('{%s}element' % XS_NAMESPACE,
-                               attrib={'name': 'field1', 'type': 'gml:PointPropertyType'},
-                               nsmap=ns)
-        assert _get_datatype(element1, "xsd", "gml") == "PointPropertyType"
+        element = etree.Element('{%s}element' % XS_NAMESPACE,
+                              attrib={'name': 'field1', 'type': 'gml:PointPropertyType'},
+                              nsmap=ns)
+        assert _get_datatype(element, "xsd", "gml") == "PointPropertyType"
 
-        # Case 2: Reference to another element
+    def test_get_datatype_reference(self):
+        """Test the _get_datatype helper function with element references."""
+        from owslib.feature.schema import _get_datatype, XS_NAMESPACE
+        from owslib.etree import etree
+
+        ns = {
+            'xs': XS_NAMESPACE,
+            'gml': 'http://www.opengis.net/gml',
+            'xsd': 'http://www.w3.org/2001/XMLSchema'
+        }
+
+        # Test element reference
         # XML: <element name="field2" ref="gml:polygonProperty"/>
-        element2 = etree.Element('{%s}element' % XS_NAMESPACE,
-                               attrib={'name': 'field2', 'ref': 'gml:polygonProperty'},
-                               nsmap=ns)
-        assert _get_datatype(element2, "xsd", "gml") == "polygonProperty"
+        element = etree.Element('{%s}element' % XS_NAMESPACE,
+                              attrib={'name': 'field2', 'ref': 'gml:polygonProperty'},
+                              nsmap=ns)
+        assert _get_datatype(element, "xsd", "gml") == "polygonProperty"
 
-        # Case 3: SimpleType with Restriction
+    @pytest.mark.parametrize("data_type", [
+        "xsd:boolean",
+        "xsd:date",
+        "xsd:dateTime",
+        "xsd:double",
+        "xsd:float",
+        "xsd:integer",
+        "xsd:int",
+        "xsd:string",
+    ])
+    def test_get_datatype_simple_types(self, data_type):
+        """Test the _get_datatype helper function with different simple types.
+
+        Parameters
+        ----------
+        data_type : str
+            The XML Schema data type to test
+        """
+        from owslib.feature.schema import _get_datatype, XS_NAMESPACE
+        from owslib.etree import etree
+
+        ns = {
+            'xs': XS_NAMESPACE,
+            'gml': 'http://www.opengis.net/gml',
+            'xsd': 'http://www.w3.org/2001/XMLSchema'
+        }
+
+        # Test simple type with restriction
         # XML:
         # <element name="field3">
         #     <simpleType>
-        #         <restriction base="xsd:string"/>
+        #         <restriction base="[data_type]"/>
         #     </simpleType>
         # </element>
-        element3 = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field3'}, nsmap=ns)
-        simple_type = etree.SubElement(element3, '{%s}simpleType' % XS_NAMESPACE)
+        element = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field3'}, nsmap=ns)
+        simple_type = etree.SubElement(element, '{%s}simpleType' % XS_NAMESPACE)
         restriction = etree.SubElement(simple_type, '{%s}restriction' % XS_NAMESPACE,
-                                     attrib={'base': 'xsd:string'})
-        assert _get_datatype(element3, "xsd", "gml") == "string"
+                                    attrib={'base': data_type})
+        expected_type = data_type.split(":")[-1]
+        assert _get_datatype(element, "xsd", "gml") == expected_type
 
-        # Case 4: Complex Type Definition
+    @pytest.mark.parametrize("data_type", [
+        "xsd:boolean",
+        "xsd:date",
+        "xsd:dateTime",
+        "xsd:double",
+        "xsd:float",
+        "xsd:integer",
+        "xsd:int",
+        "xsd:string",
+    ])
+    def test_get_datatype_direct_types(self, data_type):
+        """Test the _get_datatype helper function with direct type attributes.
+
+        Parameters
+        ----------
+        data_type : str
+            The XML Schema data type to test
+        """
+        from owslib.feature.schema import _get_datatype, XS_NAMESPACE
+        from owslib.etree import etree
+
+        ns = {
+            'xs': XS_NAMESPACE,
+            'gml': 'http://www.opengis.net/gml',
+            'xsd': 'http://www.w3.org/2001/XMLSchema'
+        }
+
+        # Test direct type attribute
+        # XML: <element name="field1" type="xsd:string"/>
+        element = etree.Element('{%s}element' % XS_NAMESPACE,
+                              attrib={'name': 'field1', 'type': data_type},
+                              nsmap=ns)
+        expected_type = data_type.split(":")[-1]
+        assert _get_datatype(element, "xsd", "gml") == expected_type
+
+    @pytest.mark.parametrize("data_type", [
+        "xsd:boolean",
+        "xsd:date",
+        "xsd:dateTime",
+        "xsd:double",
+        "xsd:float",
+        "xsd:integer",
+        "xsd:int",
+        "xsd:string",
+    ])
+    def test_get_datatype_complex_types(self, data_type):
+        """Test the _get_datatype helper function with complex type definitions.
+
+        Parameters
+        ----------
+        data_type : str
+            The XML Schema data type to test
+        """
+        from owslib.feature.schema import _get_datatype, XS_NAMESPACE
+        from owslib.etree import etree
+
+        ns = {
+            'xs': XS_NAMESPACE,
+            'gml': 'http://www.opengis.net/gml',
+            'xsd': 'http://www.w3.org/2001/XMLSchema'
+        }
+
+        # Test complex type
         # XML:
         # <element name="field4">
         #     <complexType>
         #         <sequence>
-        #             <element type="xsd:string"/>
+        #             <element type="xsd:type"/>
         #         </sequence>
         #     </complexType>
         # </element>
-        element4 = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field4'}, nsmap=ns)
-        complex_type = etree.SubElement(element4, '{%s}complexType' % XS_NAMESPACE)
+        element = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field4'}, nsmap=ns)
+        complex_type = etree.SubElement(element, '{%s}complexType' % XS_NAMESPACE)
         sequence = etree.SubElement(complex_type, '{%s}sequence' % XS_NAMESPACE)
         sub_element = etree.SubElement(sequence, '{%s}element' % XS_NAMESPACE,
-                                     attrib={'type': 'xsd:string'})
-        assert _get_datatype(element4, "xsd", "gml") == "string"
+                                    attrib={'type': data_type})
+        expected_type = data_type.split(":")[-1]
+        assert _get_datatype(element, "xsd", "gml") == expected_type
 
-        # Case 5: Unknown structure
+
+
+    def test_get_datatype_unknown(self):
+        """Test the _get_datatype helper function with unknown structure."""
+        from owslib.feature.schema import _get_datatype, XS_NAMESPACE
+        from owslib.etree import etree
+
+        ns = {
+            'xs': XS_NAMESPACE,
+            'gml': 'http://www.opengis.net/gml',
+            'xsd': 'http://www.w3.org/2001/XMLSchema'
+        }
+
+        # Test unknown structure
         # XML: <element name="field5"/>
-        element5 = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field5'}, nsmap=ns)
-        assert _get_datatype(element5, "xsd", "gml") is None
+        element = etree.Element('{%s}element' % XS_NAMESPACE, attrib={'name': 'field5'}, nsmap=ns)
+        assert _get_datatype(element, "xsd", "gml") is None

--- a/tests/test_wfs_schema_arcgis_server.py
+++ b/tests/test_wfs_schema_arcgis_server.py
@@ -1,0 +1,154 @@
+import pytest
+
+import owslib
+from owslib.etree import etree
+from owslib.wfs import WebFeatureService
+from tests.utils import service_ok
+
+WFS_SERVICE_URL = 'https://geoportal.stadt-koeln.de/arcgis/services/basiskarten/adressen_stadtteil/MapServer/WFSServer?SERVICE=WFS&request=GetCapabilities'
+
+
+@pytest.fixture
+def mp_wfs_110(monkeypatch):
+    """Monkeypatch the call to the remote GetCapabilities request of WFS
+    version 1.1.0.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+    """
+    def read(*args, **kwargs):
+        with open('tests/resources/wfs_koeln_arcgis_getcapabilities_110.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(
+        owslib.feature.common.WFSCapabilitiesReader, 'read', read)
+
+
+@pytest.fixture
+def mp_wfs_200(monkeypatch):
+    """Monkeypatch the call to the remote GetCapabilities request of WFS
+    version 2.0.0.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+    """
+    def read(*args, **kwargs):
+        with open('tests/resources/wfs_koeln_arcgis_getcapabilities_200.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(
+        owslib.feature.common.WFSCapabilitiesReader, 'read', read)
+
+
+@pytest.fixture()
+def mp_remote_describefeaturetype(monkeypatch):
+    """Monkeypatch the call to the remote DescribeFeatureType request.
+
+    Returns a standard DescribeFeatureType response.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.fixture
+        PyTest monkeypatch fixture.
+    """
+    def __remote_describefeaturetype(*args, **kwargs):
+        with open('tests/resources/wfs_koeln_arcgis_describefeaturetype_110.xml', 'r') as f:
+            data = f.read()
+            if type(data) is not bytes:
+                data = data.encode('utf-8')
+            data = etree.fromstring(data)
+        return data
+
+    monkeypatch.setattr(owslib.feature.schema,
+                        '_get_remote_describefeaturetype',
+                        __remote_describefeaturetype)
+
+
+class TestOnline(object):
+    """Class grouping online tests for the WFS get_schema method."""
+
+    @pytest.mark.xfail
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(WFS_SERVICE_URL),
+                       reason="WFS service is unreachable")
+    @pytest.mark.parametrize("wfs_version", ["1.1.0", "2.0.0"])
+    def test_get_schema(self, wfs_version):
+        """Test the get_schema method for a standard schema."""
+        wfs = WebFeatureService(WFS_SERVICE_URL, version=wfs_version)
+        schema = wfs.get_schema('adressen_stadtteil:Blumenberg')
+
+    @pytest.mark.xfail
+    @pytest.mark.online
+    @pytest.mark.skipif(not service_ok(WFS_SERVICE_URL),
+                       reason="WFS service is unreachable")
+    @pytest.mark.parametrize("wfs_version", ["1.1.0", "2.0.0"])
+    def test_schema_result(self, wfs_version):
+        """Test whether the output from get_schema is a wellformed dictionary."""
+        wfs = WebFeatureService(WFS_SERVICE_URL, version=wfs_version)
+        schema = wfs.get_schema('adressen_stadtteil:Blumenberg')
+        assert isinstance(schema, dict)
+
+        assert 'properties' in schema or 'geometry' in schema
+
+        if 'geometry' in schema:
+            assert 'geometry_column' in schema
+
+        if 'properties' in schema:
+            assert isinstance(schema['properties'], dict)
+
+        assert 'required' in schema
+        assert isinstance(schema['required'], list)
+
+
+class TestOffline(object):
+    """Class grouping offline tests for the WFS get_schema method."""
+
+    def test_get_schema(self, mp_wfs_110, mp_remote_describefeaturetype):
+        """Test the get_schema method for a standard schema.
+
+        Parameters
+        ----------
+        mp_wfs_110 : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to the remote DescribeFeatureType request.
+        """
+        wfs = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
+        schema = wfs.get_schema('adressen_stadtteil:Blumenberg')
+
+    def test_schema_result(self, mp_wfs_110, mp_remote_describefeaturetype):
+        """Test whether the output from get_schema is a wellformed dictionary.
+
+        Parameters
+        ----------
+        mp_wfs_110 : pytest.fixture
+            Monkeypatch the call to the remote GetCapabilities request.
+        mp_remote_describefeaturetype : pytest.fixture
+            Monkeypatch the call to the remote DescribeFeatureType request.
+        """
+        wfs = WebFeatureService(WFS_SERVICE_URL, version='1.1.0')
+        schema = wfs.get_schema('adressen_stadtteil:Blumenberg')
+        assert isinstance(schema, dict)
+
+        assert 'properties' in schema or 'geometry' in schema
+
+        if 'geometry' in schema:
+            assert 'geometry_column' in schema
+
+        if 'properties' in schema:
+            assert isinstance(schema['properties'], dict)
+
+        assert 'required' in schema
+        assert isinstance(schema['required'], list)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,12 +83,13 @@ def sorted_url_query(url):
 
 def service_ok(url, timeout=5):
     try:
-        resp = requests.head(url, allow_redirects=True, timeout=timeout)
+        resp = requests.get(url, allow_redirects=True, timeout=timeout, stream=True)
         if 'html' in resp.headers.get('content-type', '').lower():
+            resp.close()
             return False
-        if not resp.ok:  # if HEAD is not supported try GET with streaming
-            resp = requests.get(url, timeout=timeout, stream=True)
-        return resp.ok
+        ok = resp.ok
+        resp.close()
+        return ok
     except requests.exceptions.ReadTimeout:
         ok = False
     except requests.exceptions.ConnectTimeout:


### PR DESCRIPTION
This PR contains two enhancements.

1. The datatype determination for featuretype attributes is updated to support all possible variants of the GML spec. Currently only the simplest case (`<xsd:element minOccurs="0" maxOccurs="1" name="objectid" type="xsd:int"/>`) is supported.

2. The `service_ok` util now uses `requests.get` with `stream=True`. This adds support for a known bug in ArcGIS servers where the response header of the `HEAD` request response with the wrong `content-type`. `stream=True` should ensure, that there is no data fetched with the request. The traffic should be almost the same as with the `HEAD` request.