### PR TITLE
Add None guard for extract_xml_list

### DIFF
--- a/owslib/util.py
+++ b/owslib/util.py
@@ -692,9 +692,12 @@ Would be 2006-07-27T21:10:00Z, not 'now'
 
 def extract_xml_list(elements):
     """
-Some people don't have seperate tags for their keywords and seperate them with
+Some people don't have separate tags for their keywords and separate them with
 a newline. This will extract out all of the keywords correctly.
 """
+    if elements is None:
+        return []
+
     keywords = (re.split(r'[\n\r]+', f.text) for f in elements if f.text)
     flattened = (item.strip() for sublist in keywords for item in sublist)
     remove_blank = [_f for _f in flattened if _f]

--- a/tests/resources/wfs_mapserver_demo_getcapabilities_100.xml
+++ b/tests/resources/wfs_mapserver_demo_getcapabilities_100.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WFS_Capabilities version="1.0.0" updateSequence="0" xmlns="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
+<Service>
+  <Name>MapServer WFS</Name>
+  <Title>WFS Demo Server for MapServer</Title>
+  <Abstract>This demonstration server showcases MapServer (www.mapserver.org) and its OGC support</Abstract>
+  <OnlineResource>https://demo.mapserver.org/cgi-bin/wfs?</OnlineResource>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <DCPType>
+        <HTTP>
+          <Get onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+      <DCPType>
+        <HTTP>
+          <Post onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <DescribeFeatureType>
+      <SchemaDescriptionLanguage>
+        <XMLSCHEMA/>
+      </SchemaDescriptionLanguage>
+      <DCPType>
+        <HTTP>
+          <Get onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+      <DCPType>
+        <HTTP>
+          <Post onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+    </DescribeFeatureType>
+    <GetFeature>
+      <ResultFormat>
+        <GML2/>
+        <geojson/>
+      </ResultFormat>
+      <DCPType>
+        <HTTP>
+          <Get onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+      <DCPType>
+        <HTTP>
+          <Post onlineResource="https://demo.mapserver.org/cgi-bin/wfs?"/>
+        </HTTP>
+      </DCPType>
+    </GetFeature>
+  </Request>
+</Capability>
+
+<FeatureTypeList>
+  <Operations>
+    <Query/>
+  </Operations>
+    <FeatureType>
+        <Name>continents</Name>
+        <Title>World continents</Title>
+        <SRS>EPSG:4326</SRS>
+        <LatLongBoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="83.627419"/>
+        <MetadataURL type="TC211" format="text/xml">https://demo.mapserver.org/cgi-bin/wfs?request=GetMetadata&amp;layer=continents</MetadataURL>
+    </FeatureType>
+    <FeatureType>
+        <Name>cities</Name>
+        <Title>World cities</Title>
+        <SRS>EPSG:4326</SRS>
+        <LatLongBoundingBox minx="-178.166667" miny="-54.800000" maxx="179.383333" maxy="78.933333"/>
+        <MetadataURL type="TC211" format="text/xml">https://demo.mapserver.org/cgi-bin/wfs?request=GetMetadata&amp;layer=cities</MetadataURL>
+    </FeatureType>
+</FeatureTypeList>
+
+<ogc:Filter_Capabilities>
+  <ogc:Spatial_Capabilities>
+    <ogc:Spatial_Operators>
+      <ogc:Equals/>
+      <ogc:Disjoint/>
+      <ogc:Touches/>
+      <ogc:Within/>
+      <ogc:Overlaps/>
+      <ogc:Crosses/>
+      <ogc:Intersect/>
+      <ogc:Contains/>
+      <ogc:DWithin/>
+      <ogc:BBOX/>
+    </ogc:Spatial_Operators>
+  </ogc:Spatial_Capabilities>
+  <ogc:Scalar_Capabilities>
+    <ogc:Logical_Operators/>
+    <ogc:Comparison_Operators>
+      <ogc:Simple_Comparisons/>
+      <ogc:Like/>
+      <ogc:Between/>
+    </ogc:Comparison_Operators>
+  </ogc:Scalar_Capabilities>
+</ogc:Filter_Capabilities>
+
+</WFS_Capabilities>


### PR DESCRIPTION
Fix for #999. Similar to other extract functions in `util.py` this checks that the element is not None before trying to process it. 