### PR TITLE
Make smaller map request

### DIFF
--- a/tests/test_ogcapi_maps_cubewerx.py
+++ b/tests/test_ogcapi_maps_cubewerx.py
@@ -28,5 +28,5 @@ def test_ogcapi_maps_pygeoapi():
     assert erm['id'] == 'erm'
     assert erm['title'] == 'EuroRegionalMap'
 
-    data = w.map('erm', width=1200, height=800, transparent=False)
+    data = w.map('erm', width=600, height=400, transparent=False)
     assert isinstance(data, BytesIO)


### PR DESCRIPTION
Currently getting errors for test_ogcapi_maps_pygeoapi:

```html
RuntimeError: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>504 Gateway Timeout</title>
</head><body>
<h1>Gateway Timeout</h1>
<p>The gateway did not receive a timely response
from the upstream server or application.</p>
</body></html>
```