### PR TITLE
pygeoapi test fix

### DIFF
--- a/tests/test_ogcapi_edr_pygeoapi.py
+++ b/tests/test_ogcapi_edr_pygeoapi.py
@@ -39,5 +39,5 @@ def test_ogcapi_edr_pygeoapi():
     parameter_names = icoads['parameter_names'].keys()
     assert sorted(parameter_names) == ['AIRT', 'SST', 'UWND', 'VWND']
 
-    response = w.query_data('icoads-sst', 'position', coords='POINT(-75 45)')
+    response = w.query_data('icoads-sst', 'position', coords='POINT(0 0)')
     assert isinstance(response, dict)


### PR DESCRIPTION
The previous test example calls https://demo.pygeoapi.io/master/collections/icoads-sst/position?coords=POINT(-75%2045) which returns an `Internal Server Error`. Using `POINT(0 0)` returns a valid result. 

Possibly an issue with pygeoapi - as I presume an invalid or empty result shouldn't return a server error?

cc @tomkralidis 