### PR TITLE
Remove legacy setuptools.command.text

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@
 from pathlib import Path
 import re
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
 
 def read(filename, encoding='utf-8'):


### PR DESCRIPTION
As warned during the last release:

```
* Building wheel...
<string>:12: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
running bdist_wheel
```