### PR TITLE
Fix FutureWarning when truth-testing XML element

### DIFF
--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -859,7 +859,7 @@ class ContentMetadata:
             dimension['default'] = default_value.text
 
             current = dim.find(_DIMENSION_CURRENT_TAG)
-            if current and current.text == 'true':
+            if current is not None and current.text == 'true':
                 dimension['current'] = True
             else:
                 dimension['current'] = False


### PR DESCRIPTION
Instantiating a WebMapTileService currently raises a warning:

```
>>> from owslib.wmts import WebMapTileService
>>> wmts = WebMapTileService("https://wmts.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml")
/tmp/.venv/lib/python3.10/site-packages/owslib/wmts.py:862: FutureWarning: Truth-testing of elements was a source of confusion and will always return True in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if current and current.text == 'true':
```
  
see also https://github.com/geopython/OWSLib/pull/979

Thanks in advance for considering this PR :)