### PR TITLE
Update contents of wheel and sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,2 @@
-prune binder
-prune etc
+# this file controls the contents of sdist
 prune tests
-prune examples
-global-exclude *.py[cod\] __pycache__ *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,6 @@ ignore = ["F401", "E402"]
 max-line-length = 120
 exclude = [".git", "__pycache__", "docs/source/conf.py,", "build", "dist", "examples", "etc"]
 
-[tool.setuptools]
-packages = ["owslib"]
+# ensure all subpackages are found
+[tool.setuptools.packages.find]
+include = ["owslib*"]


### PR DESCRIPTION
@tomkralidis - these changes are what work for me when building #1031. 

Only `tests` needed to be excluded in MANIFEST.in as it is the only folder with a `__init__.py` file. 

`include = ["owslib*"]` was the only way I could get all the OWSLib files added to the wheel. I can't say I fully understand why `where = ["owslib"]` didn't work here. 

Maybe check what you get with a build of this PR and `python -m build`?

(note the PR is for your `pyproject` branch)