### PR TITLE
Remove setuptools constraint and test builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
         pip3 install ".[dev]"
         pip3 install ".[docs]"
         pip3 install ".[test]"
+    - name: run flake8 ⚙️
+      run: flake8 owslib/
     - name: run tests ⚙️
       run: pytest tests/
     - name: run tests in offline mode
@@ -42,7 +44,7 @@ jobs:
         COVERALLS_SERVICE_NAME: github
         COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
+    - name: test build
+      run: python -m build --wheel
     - name: build docs 🏗️
       run: cd docs && make html
-    - name: run flake8 ⚙️
-      run: flake8 owslib/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,3 +24,6 @@ jobs:
 
     - name: run tests ⚙️
       run: pytest tests/
+
+    - name: test build
+      run: python -m build --wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.37.dev0"
 description = "OGC Web Service utility library"
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 keywords = ["gis", "ogc", "ogcapi", "ows", "opensearch", "iso", "19115", "fgdc", "dif", "ows", "wfs", "wms", "sos", "csw", "wps", "wcs", "capabilities", "metadata", "wmts", "connectedsystems"]
 authors = [
     {name = "Sean Gillies", email = "sean.gillies@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<69", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
See comment from @landryb at https://github.com/geopython/OWSLib/pull/1031#issuecomment-4701033461

This PR removes the constraint and tests the wheel builds in the CI. 

@tomkralidis - is the setuptools constraint still valid?

Also fix:

```
Please use a simple string containing a SPDX expression for project.license. You can also use project.license-files. (Both options available on setuptools>=77.0.0).

 By 2027-Feb-18, you need to update your project and remove deprecated calls
 or your builds will no longer be supported.
```