### PR TITLE
Get version from TOML and update README with docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Service for the Web (CSW), Web Processing Service (WPS), and Web
 Map Tile Service (WMTS). Some of those are beta quality.
 
 
-Logging
--------
+## Logging
+
 OWSLib logs messages to module-based named Python loggers. You may
 configure your application to use the log messages like so:
 
@@ -142,8 +142,18 @@ configure your application to use the log messages like so:
     >>> LOGGER.setLevel(logging.DEBUG)
 ```
 
-Releasing
----------
+## Docs
+
+Requires Python 3.11+ and [PanDoc](https://pandoc.org/).
+
+```bash
+sudo apt-get -y install pandoc
+pip3 install -e ".[docs]"
+cd docs && make html
+python -m http.server --directory=../build/docs
+```
+
+## Releasing
 
 ```bash
   # update version
@@ -160,8 +170,7 @@ Releasing
   twine upload dist/*
 ```
 
-Support
--------
+## Support
 
 - https://lists.osgeo.org/mailman/listinfo/owslib-users
 - https://lists.osgeo.org/mailman/listinfo/owslib-devel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import re, sys, os
+import re, sys, os, tomllib
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -54,18 +54,9 @@ copyright = '2006-2023, ' + author + ' ' + license
 #
 # The full version, including alpha/beta/rc tags.
 
-file_ = '../owslib/__init__.py'
-filepath = os.path.join(os.path.abspath('..'), file_)
-
-with open(filepath) as fh:
-    contents = fh.read().strip()
-
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              contents, re.M)
-    if version_match:
-        version = version_match.group(1)
-    else:
-        version = 'UNKNOWN'
+toml_path = os.path.join(os.path.abspath('../../'), 'pyproject.toml')
+with open(toml_path, 'rb') as fh:
+    version = tomllib.load(fh)['project']['version']
 
 release = version
 


### PR DESCRIPTION
Fixes #1042. Note `tomllib` is only available in Python 3.11+ 

Also harmonise MD/RST title formatting, and add doc build steps to README.md